### PR TITLE
Prepare for release v0.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	kmodules.xyz/client-go v0.24.0
 	kmodules.xyz/custom-resources v0.24.0
 	kmodules.xyz/monitoring-agent-api v0.24.0
-	kmodules.xyz/resource-metadata v0.11.2-0.20220613095543-6ab623a873b2
+	kmodules.xyz/resource-metadata v0.11.2
 	kmodules.xyz/resource-metrics v0.10.1
 	kmodules.xyz/sets v0.24.0
 	kubepack.dev/kubepack v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1791,8 +1791,8 @@ kmodules.xyz/monitoring-agent-api v0.24.0 h1:CPFvzDppUKckMBLwaMnZbpYCuP7+NhcS4t7
 kmodules.xyz/monitoring-agent-api v0.24.0/go.mod h1:lu1TmXRMx9IcjMpY8s5nc4HNOhOix5/z9caEnbL8JxA=
 kmodules.xyz/offshoot-api v0.24.1 h1:8KCVNkLwdebzWmHcTdZPTQGxqI92bqA+vrmz65ueULY=
 kmodules.xyz/offshoot-api v0.24.1/go.mod h1:fYu0051hoJXXs70OjmIE+Q5smOgmzvYFhRJXCiFShaY=
-kmodules.xyz/resource-metadata v0.11.2-0.20220613095543-6ab623a873b2 h1:E96nui8HZMjGHluO2yrwsywiSrN6VEpfZL9EcXy6s5o=
-kmodules.xyz/resource-metadata v0.11.2-0.20220613095543-6ab623a873b2/go.mod h1:N3pgffPM+AOTBfswdZvCfFsB1IuZ8yzAceZAlnCm1eA=
+kmodules.xyz/resource-metadata v0.11.2 h1:uDc3YHMSA3H9H08SkjJzlpQb+c1zBUHUCBsIOQqoBWE=
+kmodules.xyz/resource-metadata v0.11.2/go.mod h1:N3pgffPM+AOTBfswdZvCfFsB1IuZ8yzAceZAlnCm1eA=
 kmodules.xyz/resource-metrics v0.10.1 h1:q1dhk0eYxkZqd1peRy9wHGd8tOktBBH3kzgeTVaNBiY=
 kmodules.xyz/resource-metrics v0.10.1/go.mod h1:YK0hjiLq6oBaGROmLSVcVDbmEgSxT1vpt8BCZZ+9teY=
 kmodules.xyz/sets v0.24.0 h1:GbltLEPVnURjcmWyf8eFstgJBpm9o151wsrABkByGrc=

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: acmecertmanagerio-challenge-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: acmecertmanagerio-order-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: admissionregistrationk8sio-mutatingwebhookconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: admissionregistrationk8sio-validatingwebhookconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apiextensionsk8sio-customresourcedefinition-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apiregistrationk8sio-apiservice-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
@@ -19,6 +19,6 @@ spec:
     editor:
       name: appk8sio-application-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: appcatalogappscodecom-appbinding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/daemonsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/daemonsets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apps-daemonset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/deployments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/deployments.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apps-deployment-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/replicasets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/replicasets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apps-replicaset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/statefulsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/statefulsets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apps-statefulset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditor.appscode.com/v1alpha1/siteinfos.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditor.appscode.com/v1alpha1/siteinfos.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: auditorappscodecom-siteinfo-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: auditregistrationk8sio-auditsink-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingk8sio-verticalpodautoscalercheckpoint-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingk8sio-verticalpodautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-elasticsearchautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-etcdautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-mariadbautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-memcachedautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-mongodbautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-mysqlautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-perconaxtradbautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-pgbouncerautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-postgresautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-proxysqlautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-redisautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: autoscaling-horizontalpodautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/cronjobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/cronjobs.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: batch-cronjob-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/jobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/jobs.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: batch-job-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: batch-cronjob-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-elasticsearchversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-etcdversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: catalogkubedbcom-mariadbversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-memcachedversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-mongodbversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-mysqlversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-perconaxtradbversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-pgbouncerversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-postgresversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-proxysqlversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-redisversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubevaultcom-vaultserverversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: certmanagerio-certificaterequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: certmanagerio-certificate-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: certmanagerio-clusterissuer-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: certmanagerio-issuer-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: certificatesk8sio-certificatesigningrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: certificatesk8sio-certificatesigningrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: clusterxk8sio-machine-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: clusterxk8sio-machineset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: coordinationk8sio-lease-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/bindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/bindings.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-binding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/componentstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/componentstatuses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-componentstatus-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/configmaps.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/configmaps.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-configmap-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/endpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/endpoints.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-endpoints-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-ephemeralcontainers-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/events.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-event-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/limitranges.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/limitranges.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-limitrange-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/namespaces.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/namespaces.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-namespace-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/nodes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/nodes.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-node-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-persistentvolumeclaim-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumes.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-persistentvolume-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/pods.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/pods.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-pod-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podstatusresults.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podstatusresults.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-podstatusresult-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podtemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podtemplates.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-podtemplate-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/rangeallocations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/rangeallocations.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-rangeallocation-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/replicationcontrollers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/replicationcontrollers.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-replicationcontroller-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequota.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequota.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-resourcequota-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequotas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequotas.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-resourcequota-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/secrets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/secrets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-secret-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/serviceaccounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/serviceaccounts.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-serviceaccount-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/services.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/services.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-service-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: discoveryk8sio-endpointslice-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: discoveryk8sio-endpointslice-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: discoveryk8sio-endpointslice-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-awsrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-azurerole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: enginekubevaultcom-elasticsearchrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-gcprole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-mongodbrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-mysqlrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-postgresrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: enginekubevaultcom-secretaccessrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-secretengine-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: enginekubevaultcom-secretrolebinding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1/events.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: eventsk8sio-event-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: eventsk8sio-event-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: extensions-daemonset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/deployments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/deployments.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: extensions-deployment-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: extensions-ingress-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: extensions-networkpolicy-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: extensions-podsecuritypolicy-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: extensions-replicaset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/scales.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/scales.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: extensions-scale-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: flowcontrolapiserverk8sio-flowschema-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: flowcontrolapiserverk8sio-prioritylevelconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: flowcontrolapiserverk8sio-flowschema-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: flowcontrolapiserverk8sio-prioritylevelconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: imagepolicyk8sio-imagereview-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: internalapiserverk8sio-storageversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-elasticsearch-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubedbcom-elasticsearch-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-etcd-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubedbcom-etcd-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-mariadb-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubedbcom-mariadb-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-memcached-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubedbcom-memcached-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-mongodb-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubedbcom-mongodb-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-mysql-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubedbcom-mysql-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-perconaxtradb-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubedbcom-perconaxtradb-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-pgbouncer-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubedbcom-pgbouncer-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-postgres-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubedbcom-postgres-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-proxysql-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubedbcom-proxysql-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-redis-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubedbcom-redis-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: kubedbcom-redissentinel-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubevault.com/v1alpha1/vaultservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubevault.com/v1alpha1/vaultservers.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubevaultcom-vaultserver-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     options:
       name: kubevaultcom-vaultserver-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: metaappscodecom-resourcedescriptor-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: metricsappscodecom-metricsconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: monitoringcoreoscom-alertmanager-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: monitoringcoreoscom-podmonitor-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: monitoringcoreoscom-probe-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: monitoringcoreoscom-prometheus-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: monitoringcoreoscom-prometheusrule-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
@@ -24,6 +24,6 @@ spec:
     editor:
       name: monitoringcoreoscom-servicemonitor-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: monitoringcoreoscom-thanosruler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: monitoringcoreoscom-alertmanagerconfig-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: networkingk8sio-ingressclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: networkingk8sio-ingress-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: networkingk8sio-networkpolicy-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: networkingk8sio-ingressclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: networkingk8sio-ingress-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: nodek8sio-runtimeclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: nodek8sio-runtimeclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-elasticsearchopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-etcdopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-mariadbopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-memcachedopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-mongodbopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-mysqlopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-perconaxtradbopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-pgbounceropsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-postgresopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-proxysqlopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-redisopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: policykubevaultcom-vaultpolicy-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: policykubevaultcom-vaultpolicybinding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/evictions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/evictions.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: policy-eviction-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: policy-poddisruptionbudget-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: policy-podsecuritypolicy-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: rbacauthorizationk8sio-clusterrolebinding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: rbacauthorizationk8sio-clusterrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: rbacauthorizationk8sio-rolebinding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: rbacauthorizationk8sio-role-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: repositoriesstashappscodecom-snapshot-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: schedulingk8sio-priorityclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: secretsstorecsixk8sio-secretproviderclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: secretsstorecsixk8sio-secretproviderclasspodstatus-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: settingsk8sio-podpreset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: snapshotstoragek8sio-volumesnapshotclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: snapshotstoragek8sio-volumesnapshotcontent-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: snapshotstoragek8sio-volumesnapshot-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-recovery-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-repository-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-restic-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-backupbatch-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-backupblueprint-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-backupconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-backupsession-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-function-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-restorebatch-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-restoresession-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-task-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: storagek8sio-csidriver-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: storagek8sio-csinode-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: storagek8sio-storageclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: storagek8sio-volumeattachment-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: storagek8sio-csistoragecapacity-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: voyagerappscodecom-ingress-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: voyagerappscodecom-ingress-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.6
+      version: v0.4.7

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1900,7 +1900,7 @@ kmodules.xyz/monitoring-agent-api/client
 # kmodules.xyz/offshoot-api v0.24.1
 ## explicit; go 1.18
 kmodules.xyz/offshoot-api/api/v1
-# kmodules.xyz/resource-metadata v0.11.2-0.20220613095543-6ab623a873b2
+# kmodules.xyz/resource-metadata v0.11.2
 ## explicit; go 1.18
 kmodules.xyz/resource-metadata/apis/core/install
 kmodules.xyz/resource-metadata/apis/core/v1alpha1


### PR DESCRIPTION
ProductLine: ByteBuilders
Release: v2022.06.14
Release-tracker: https://github.com/bytebuilders/CHANGELOG/pull/27
Signed-off-by: 1gtm <1gtm@appscode.com>