### PR TITLE
Prepare for release v0.0.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	kmodules.xyz/custom-resources v0.25.1
 	kmodules.xyz/go-containerregistry v0.0.11
 	kmodules.xyz/monitoring-agent-api v0.25.1
-	kmodules.xyz/resource-metadata v0.17.2
+	kmodules.xyz/resource-metadata v0.17.3
 	kmodules.xyz/resource-metrics v0.25.2
 	kmodules.xyz/sets v0.24.0
 	kubeops.dev/scanner v0.0.10

--- a/go.sum
+++ b/go.sum
@@ -2121,8 +2121,8 @@ kmodules.xyz/monitoring-agent-api v0.25.1 h1:E1H8U/vMfYQ8wevmJv6Lcj0Z4DF7cH3hZ2x
 kmodules.xyz/monitoring-agent-api v0.25.1/go.mod h1:IphGzRWbuV00B3TLalcBs6+IlchSZVTwKDty+J3LLz4=
 kmodules.xyz/offshoot-api v0.25.0 h1:Svq9da/+sg5afOjpgo9vx2J/Lu90Mo0aFxkdQmgKnGI=
 kmodules.xyz/offshoot-api v0.25.0/go.mod h1:ysEBn7LJuT3+s8ynAQA/OG0BSsJugXa6KGtDLMRjlKo=
-kmodules.xyz/resource-metadata v0.17.2 h1:J81LB78NswSi8F23RtxaKKDXyAML07Yupi3rs7+FAT0=
-kmodules.xyz/resource-metadata v0.17.2/go.mod h1:w1Mdovr5Jo0Tuyum2yAH4UAvmsz7d7w30WC5ED4IKOE=
+kmodules.xyz/resource-metadata v0.17.3 h1:AdJBaMmXT4l8YR91l3kKz3911f3RkAkrjQudbzRrE6g=
+kmodules.xyz/resource-metadata v0.17.3/go.mod h1:w1Mdovr5Jo0Tuyum2yAH4UAvmsz7d7w30WC5ED4IKOE=
 kmodules.xyz/resource-metrics v0.25.2 h1:BwCb6qyunvQBa0u8UUkw+wYG5/T4qtNtAKcHjSsk0JU=
 kmodules.xyz/resource-metrics v0.25.2/go.mod h1:ZK/52NLuwMk+Jt0bmUtGQHtSxPLYYpsFILG7SJhYPg0=
 kmodules.xyz/sets v0.24.0 h1:GbltLEPVnURjcmWyf8eFstgJBpm9o151wsrABkByGrc=

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesetbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesetbindings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
@@ -22,6 +22,6 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/daemonsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/daemonsets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/deployments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/deployments.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/replicasets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/replicasets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/statefulsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/statefulsets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditor.appscode.com/v1alpha1/siteinfos.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditor.appscode.com/v1alpha1/siteinfos.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redissentinelautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redissentinelautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/cronjobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/cronjobs.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/jobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/jobs.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigs.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigtemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigtemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaversions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/chartpresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/chartpresets.yaml
@@ -15,3 +15,11 @@ spec:
     name: chartpresets
     scope: Namespaced
     version: v1alpha1
+  ui:
+    editor:
+      name: chartsxhelmdev-chartpreset-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/clusterchartpresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/clusterchartpresets.yaml
@@ -15,3 +15,11 @@ spec:
     name: clusterchartpresets
     scope: Cluster
     version: v1alpha1
+  ui:
+    editor:
+      name: chartsxhelmdev-clusterchartpreset-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusterclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusterclasses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusters.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinedeployments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinedeployments.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinehealthchecks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinehealthchecks.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinepools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machines.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinesets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinesets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gatekeeper.sh/v1alpha1/configs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gatekeeper.sh/v1alpha1/configs.yaml
@@ -15,3 +15,11 @@ spec:
     name: configs
     scope: Namespaced
     version: v1alpha1
+  ui:
+    editor:
+      name: configgatekeepersh-config-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/awsmanagedcontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/awsmanagedcontrolplanes.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresources.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresources.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresourceservices.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresourceservices.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/podviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/podviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/resourcesummaries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/resourcesummaries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/bindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/bindings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/componentstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/componentstatuses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/configmaps.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/configmaps.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/endpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/endpoints.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/events.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/limitranges.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/limitranges.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/namespaces.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/namespaces.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/nodes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/nodes.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumes.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/pods.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/pods.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podstatusresults.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podstatusresults.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podtemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podtemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/rangeallocations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/rangeallocations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/replicationcontrollers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/replicationcontrollers.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequota.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequota.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequotas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequotas.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/secrets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/secrets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/serviceaccounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/serviceaccounts.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/services.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/services.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dashboard.kubedb.com/v1alpha1/elasticsearchdashboards.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dashboard.kubedb.com/v1alpha1/elasticsearchdashboards.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/drivers.x-helm.dev/v1alpha1/appreleases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/drivers.x-helm.dev/v1alpha1/appreleases.yaml
@@ -15,3 +15,11 @@ spec:
     name: appreleases
     scope: Namespaced
     version: v1alpha1
+  ui:
+    editor:
+      name: driversxhelmdev-apprelease-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mariadbroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mariadbroles.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/redisroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/redisroles.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1/events.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/expansion.gatekeeper.sh/v1alpha1/expansiontemplate.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/expansion.gatekeeper.sh/v1alpha1/expansiontemplate.yaml
@@ -15,3 +15,11 @@ spec:
     name: expansiontemplate
     scope: Cluster
     version: v1alpha1
+  ui:
+    editor:
+      name: expansiongatekeepersh-expansiontemplate-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/deployments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/deployments.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/scales.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/scales.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/external-dns.appscode.com/v1alpha1/externaldns.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/external-dns.appscode.com/v1alpha1/externaldns.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta1/helmreleases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta1/helmreleases.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagepolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagepolicies.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagerepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagerepositories.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imageupdateautomations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imageupdateautomations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureserviceprincipals.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureserviceprincipals.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azuresystemassignedidentites.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azuresystemassignedidentites.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureuserassignedidentites.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureuserassignedidentites.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusteridentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusteridentities.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusters.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclustertemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepoolmachines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepoolmachines.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachines.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinetemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclusters.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanes.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustercontrolleridentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustercontrolleridentities.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterroleidentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterroleidentities.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusters.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterstaticidentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterstaticidentities.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustertemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsfargateprofiles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsfargateprofiles.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinepools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachines.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinetemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedclusters.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedmachinepools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddressclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddressclaims.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddresses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -85,7 +85,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -98,7 +98,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -111,7 +111,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -128,7 +128,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -155,11 +155,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-elasticsearch-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-etcd-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/kafkas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/kafkas.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -43,11 +43,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-kafka-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -100,7 +100,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -113,7 +113,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -126,7 +126,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -154,7 +154,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -168,11 +168,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-mariadb-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-memcached-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -100,7 +100,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -113,7 +113,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -126,7 +126,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -154,7 +154,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -168,11 +168,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-mongodb-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -100,7 +100,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -113,7 +113,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -126,7 +126,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -154,7 +154,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -168,11 +168,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-mysql-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-perconaxtradb-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-pgbouncer-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -100,7 +100,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -113,7 +113,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -126,7 +126,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -154,7 +154,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -168,11 +168,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-postgres-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -55,7 +55,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -98,7 +98,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -111,7 +111,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -125,11 +125,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-proxysql-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -100,7 +100,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -113,7 +113,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -126,7 +126,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -154,7 +154,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -168,11 +168,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-redis-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubevault.com/v1alpha2/vaultservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubevault.com/v1alpha2/vaultservers.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubevaultcom-vaultserver-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1beta2/kustomizations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1beta2/kustomizations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/match.gatekeeper.sh/match/matchcrd.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/match.gatekeeper.sh/match/matchcrd.yaml
@@ -15,3 +15,11 @@ spec:
     name: matchcrd
     scope: Namespaced
     version: match
+  ui:
+    editor:
+      name: matchgatekeepersh-dummycrd-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menuoutlines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menuoutlines.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menus.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menus.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceblockdefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceblockdefinitions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcelayouts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcelayouts.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlines.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcetabledefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcetabledefinitions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
@@ -27,6 +27,6 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assign.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assign.yaml
@@ -15,3 +15,11 @@ spec:
     name: assign
     scope: Cluster
     version: v1
+  ui:
+    editor:
+      name: mutationsgatekeepersh-assign-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assignmetadata.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assignmetadata.yaml
@@ -15,3 +15,11 @@ spec:
     name: assignmetadata
     scope: Cluster
     version: v1
+  ui:
+    editor:
+      name: mutationsgatekeepersh-assignmetadata-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/modifyset.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/modifyset.yaml
@@ -15,3 +15,11 @@ spec:
     name: modifyset
     scope: Cluster
     version: v1
+  ui:
+    editor:
+      name: mutationsgatekeepersh-modifyset-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1alpha1/assignimage.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1alpha1/assignimage.yaml
@@ -15,3 +15,11 @@ spec:
     name: assignimage
     scope: Cluster
     version: v1alpha1
+  ui:
+    editor:
+      name: mutationsgatekeepersh-assignimage-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/alerts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/alerts.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/providers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/providers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/receivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/receivers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboards.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboards.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboardtemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboardtemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadatasources.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadatasources.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubevault.com/v1alpha1/vaultopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubevault.com/v1alpha1/vaultopsrequests.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/evictions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/evictions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/publishers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/publishers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/subscribers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/subscribers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/plans.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/plans.yaml
@@ -15,3 +15,11 @@ spec:
     name: plans
     scope: Cluster
     version: v1alpha1
+  ui:
+    editor:
+      name: productsxhelmdev-plan-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/products.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/products.yaml
@@ -15,3 +15,11 @@ spec:
     name: products
     scope: Cluster
     version: v1alpha1
+  ui:
+    editor:
+      name: productsxhelmdev-product-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/bundles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/bundles.yaml
@@ -15,3 +15,11 @@ spec:
     name: bundles
     scope: Cluster
     version: v1alpha1
+  ui:
+    editor:
+      name: releasesxhelmdev-bundle-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/orders.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/orders.yaml
@@ -15,3 +15,11 @@ spec:
     name: orders
     scope: Cluster
     version: v1alpha1
+  ui:
+    editor:
+      name: releasesxhelmdev-order-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/runtime.cluster.x-k8s.io/v1alpha1/extensionconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/runtime.cluster.x-k8s.io/v1alpha1/extensionconfigs.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mariadbdatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mariadbdatabases.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mongodbdatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mongodbdatabases.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mysqldatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mysqldatabases.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/postgresdatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/postgresdatabases.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/buckets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/buckets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/gitrepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/gitrepositories.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmcharts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmcharts.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmrepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmrepositories.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/ocirepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/ocirepositories.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: stashappscodecom-repository-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: stashappscodecom-restoresession-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constraintpodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constraintpodstatuses.yaml
@@ -15,3 +15,11 @@ spec:
     name: constraintpodstatuses
     scope: Namespaced
     version: v1beta1
+  ui:
+    editor:
+      name: statusgatekeepersh-constraintpodstatus-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constrainttemplatepodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constrainttemplatepodstatuses.yaml
@@ -15,3 +15,11 @@ spec:
     name: constrainttemplatepodstatuses
     scope: Namespaced
     version: v1beta1
+  ui:
+    editor:
+      name: statusgatekeepersh-constrainttemplatepodstatus-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/expansiontemplatepodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/expansiontemplatepodstatuses.yaml
@@ -15,3 +15,11 @@ spec:
     name: expansiontemplatepodstatuses
     scope: Namespaced
     version: v1beta1
+  ui:
+    editor:
+      name: statusgatekeepersh-expansiontemplatepodstatus-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/mutatorpodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/mutatorpodstatuses.yaml
@@ -15,3 +15,11 @@ spec:
     name: mutatorpodstatuses
     scope: Namespaced
     version: v1beta1
+  ui:
+    editor:
+      name: statusgatekeepersh-mutatorpodstatus-editor
+      sourceRef:
+        apiGroup: source.toolkit.fluxcd.io
+        kind: HelmRepository
+        name: bytebuilders-ui
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/approvalpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/approvalpolicies.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/clustermaintenancewindows.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/clustermaintenancewindows.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/maintenancewindows.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/maintenancewindows.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/recommendations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/recommendations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourcedashboards.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourcedashboards.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceeditors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceeditors.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchnodesstats.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchnodesstats.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpooloverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpooloverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerserveroverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerserveroverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncersettings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncersettings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgressettings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgressettings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlsettings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlsettings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.stash.appscode.com/v1alpha1/backupoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.stash.appscode.com/v1alpha1/backupoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1782,7 +1782,7 @@ kmodules.xyz/monitoring-agent-api/client
 # kmodules.xyz/offshoot-api v0.25.0
 ## explicit; go 1.18
 kmodules.xyz/offshoot-api/api/v1
-# kmodules.xyz/resource-metadata v0.17.2
+# kmodules.xyz/resource-metadata v0.17.3
 ## explicit; go 1.18
 kmodules.xyz/resource-metadata/apis/core/install
 kmodules.xyz/resource-metadata/apis/core/v1alpha1


### PR DESCRIPTION
ProductLine: ByteBuilders
Release: v2023.05.12
Release-tracker: https://github.com/bytebuilders/CHANGELOG/pull/39
Signed-off-by: 1gtm <1gtm@appscode.com>