### PR TITLE
Skip logging if some feature-resource not found

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	kmodules.xyz/custom-resources v0.30.0
 	kmodules.xyz/go-containerregistry v0.0.12
 	kmodules.xyz/monitoring-agent-api v0.29.0
-	kmodules.xyz/resource-metadata v0.18.13-0.20240823113925-d6c4a55d03cb
+	kmodules.xyz/resource-metadata v0.18.13-0.20240829025444-b72d620479e5
 	kmodules.xyz/resource-metrics v0.30.2
 	kmodules.xyz/resource-metrics/utils v0.30.1
 	kmodules.xyz/sets v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -920,8 +920,8 @@ kmodules.xyz/monitoring-agent-api v0.29.0 h1:gpFl6OZrlMLb/ySMHdREI9EwGtnJ91oZBn9
 kmodules.xyz/monitoring-agent-api v0.29.0/go.mod h1:iNbvaMTgVFOI5q2LJtGK91j4Dmjv4ZRiRdasGmWLKQI=
 kmodules.xyz/offshoot-api v0.29.4 h1:WQV2BIUIoVKKiqZNmZ4gAy367jEdwBhEl3dFCLZM1qA=
 kmodules.xyz/offshoot-api v0.29.4/go.mod h1:e+NQ0s4gW/YTPWBWEfdISZcmk+tlTq8IjvP5SLdqvko=
-kmodules.xyz/resource-metadata v0.18.13-0.20240823113925-d6c4a55d03cb h1:SNCaWXTAtb62gnyboHa69xjZj59FabzVvssX86YnCKE=
-kmodules.xyz/resource-metadata v0.18.13-0.20240823113925-d6c4a55d03cb/go.mod h1:VvUjfIzmM08SZ9ssZKhduzSrggKjY93ES2Bk+/m04hs=
+kmodules.xyz/resource-metadata v0.18.13-0.20240829025444-b72d620479e5 h1:ouRNFYD+gHWGJaY8JSJqbN7uMMRIYkLvUOhHb6RH/WQ=
+kmodules.xyz/resource-metadata v0.18.13-0.20240829025444-b72d620479e5/go.mod h1:VvUjfIzmM08SZ9ssZKhduzSrggKjY93ES2Bk+/m04hs=
 kmodules.xyz/resource-metrics v0.30.2 h1:EGJapJa7Sh2ePc/WyHziLVh9xtuh4vWPBoSGxVZ8uC8=
 kmodules.xyz/resource-metrics v0.30.2/go.mod h1:UYcQQLN+3o8rNPQJwJa2D9bt5ihJCeo5bCDuQ4O3MPY=
 kmodules.xyz/resource-metrics/utils v0.30.1 h1:iRnAKNMMdAi7QYjMQrK9W3vNMhSC21RWNx9yS3qlpTA=

--- a/pkg/controllers/feature/feature_controller.go
+++ b/pkg/controllers/feature/feature_controller.go
@@ -323,7 +323,7 @@ func (r *frReconciler) checkRequiredResourcesExistence(ctx context.Context) (boo
 		})
 		if err := r.apiReader.List(ctx, &objList, &client.ListOptions{Limit: 1}); err != nil {
 			if meta.IsNoMatchError(err) {
-				return false, fmt.Sprintf("Required resource %q is not registered.", gvk.String()), err
+				return false, err.Error(), nil
 			}
 			return false, "", err
 		}

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
@@ -35,7 +35,7 @@ spec:
     references:
     - '{.spec.appRef.name},{.spec.appRef.namespace},{.spec.appRef.kind},{.spec.appRef.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Postgres
     type: MatchRef
   - labels:
@@ -43,7 +43,7 @@ spec:
     references:
     - '{.spec.appRef.name},{.spec.appRef.namespace},{.spec.appRef.kind},{.spec.appRef.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Elasticsearch
     type: MatchRef
   - labels:
@@ -51,7 +51,7 @@ spec:
     references:
     - '{.spec.appRef.name},{.spec.appRef.namespace},{.spec.appRef.kind},{.spec.appRef.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MariaDB
     type: MatchRef
   - labels:
@@ -59,7 +59,7 @@ spec:
     references:
     - '{.spec.appRef.name},{.spec.appRef.namespace},{.spec.appRef.kind},{.spec.appRef.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MongoDB
     type: MatchRef
   - labels:
@@ -67,7 +67,7 @@ spec:
     references:
     - '{.spec.appRef.name},{.spec.appRef.namespace},{.spec.appRef.kind},{.spec.appRef.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MySQL
     type: MatchRef
   - labels:
@@ -75,7 +75,7 @@ spec:
     references:
     - '{.spec.appRef.name},{.spec.appRef.namespace},{.spec.appRef.kind},{.spec.appRef.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Redis
     type: MatchRef
   - labels:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/core.kubestash.com/v1alpha1/restoresessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/core.kubestash.com/v1alpha1/restoresessions.yaml
@@ -13,7 +13,7 @@ spec:
   - labels:
     - located_on
     references:
-    - '{.spec.dataSource.repository}{"\n"}{end}'
+    - '{.spec.dataSource.repository}'
     target:
       apiVersion: storage.kubestash.com/v1alpha1
       kind: Repository
@@ -21,7 +21,7 @@ spec:
   - labels:
     - storage
     references:
-    - '{.spec.dataSource.snapshot}{"\n"}{end}'
+    - '{.spec.dataSource.snapshot}'
     target:
       apiVersion: storage.kubestash.com/v1alpha1
       kind: Snapshot
@@ -29,7 +29,7 @@ spec:
   - labels:
     - auth_secret
     references:
-    - '{.spec.dataSource.encryptionSecret.name},{ .spec.dataSource.encryptionSecret.namespace}{"\n"}{end}'
+    - '{.spec.dataSource.encryptionSecret.name},{ .spec.dataSource.encryptionSecret.namespace}'
     target:
       apiVersion: v1
       kind: Secret

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/engine.kubevault.com/v1alpha1/secretengines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/engine.kubevault.com/v1alpha1/secretengines.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.postgres.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Postgres
     type: MatchRef
   - labels:
@@ -23,7 +23,7 @@ spec:
     references:
     - '{.spec.elasticsearch.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Elasticsearch
     type: MatchRef
   - labels:
@@ -31,7 +31,7 @@ spec:
     references:
     - '{.spec.mariadb.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MariaDB
     type: MatchRef
   - labels:
@@ -39,7 +39,7 @@ spec:
     references:
     - '{.spec.mongodb.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MongoDB
     type: MatchRef
   - labels:
@@ -47,7 +47,7 @@ spec:
     references:
     - '{.spec.mysql.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MySQL
     type: MatchRef
   - labels:
@@ -55,7 +55,7 @@ spec:
     references:
     - '{.spec.redis.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Redis
     type: MatchRef
   - labels:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/backends.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/backends.yaml
@@ -1,0 +1,163 @@
+apiVersion: meta.k8s.appscode.com/v1alpha1
+kind: ResourceDescriptor
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.envoyproxy.io
+    k8s.io/kind: Backend
+    k8s.io/resource: backends
+    k8s.io/version: v1alpha1
+  name: gateway.envoyproxy.io-v1alpha1-backends
+spec:
+  resource:
+    group: gateway.envoyproxy.io
+    kind: Backend
+    name: backends
+    scope: Namespaced
+    version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      description: |-
+        Backend allows the user to configure the endpoints of a backend and
+        the behavior of the connection from Envoy Proxy to the backend.
+      properties:
+        apiVersion:
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          type: string
+        kind:
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          properties:
+            name:
+              description: 'Name must be unique within a namespace. Is required when
+                creating resources, although some resources may allow a client to
+                request the generation of an appropriate name automatically. Name
+                is primarily intended for creation idempotence and configuration definition.
+                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: "Namespace defines the space within which each name must
+                be unique. An empty namespace is equivalent to the \"default\" namespace,
+                but \"default\" is the canonical representation. Not all objects are
+                required to be scoped to a namespace - the value of this field for
+                those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                More info: http://kubernetes.io/docs/user-guide/namespaces"
+              type: string
+            labels:
+              additionalProperties:
+                type: string
+              description: 'Map of string keys and values that can be used to organize
+                and categorize (scope and select) objects. May match selectors of
+                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            annotations:
+              additionalProperties:
+                type: string
+              description: 'Annotations is an unstructured key value map stored with
+                a resource that may be set by external tools to store and retrieve
+                arbitrary metadata. They are not queryable and should be preserved
+                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+          type: object
+        spec:
+          description: Spec defines the desired state of Backend.
+          properties:
+            appProtocols:
+              description: AppProtocols defines the application protocols to be supported
+                when connecting to the backend.
+              items:
+                description: AppProtocolType defines various backend applications
+                  protocols supported by Envoy Gateway
+                enum:
+                - gateway.envoyproxy.io/h2c
+                - gateway.envoyproxy.io/ws
+                - gateway.envoyproxy.io/wss
+                type: string
+              type: array
+            endpoints:
+              description: Endpoints defines the endpoints to be used when connecting
+                to the backend.
+              items:
+                description: |-
+                  BackendEndpoint describes a backend endpoint, which can be either a fully-qualified domain name, IP address or unix domain socket
+                  corresponding to Envoy's Address: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#config-core-v3-address
+                properties:
+                  fqdn:
+                    description: FQDN defines a FQDN endpoint
+                    properties:
+                      hostname:
+                        description: Hostname defines the FQDN hostname of the backend
+                          endpoint.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))*$
+                        type: string
+                      port:
+                        description: Port defines the port of the backend endpoint.
+                        format: int32
+                        maximum: 65535
+                        minimum: 0
+                        type: integer
+                    required:
+                    - hostname
+                    - port
+                    type: object
+                  ip:
+                    description: IP defines an IP endpoint. Currently, only IPv4 Addresses
+                      are supported.
+                    properties:
+                      address:
+                        description: Address defines the IP address of the backend
+                          endpoint.
+                        maxLength: 15
+                        minLength: 7
+                        pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$
+                        type: string
+                      port:
+                        description: Port defines the port of the backend endpoint.
+                        format: int32
+                        maximum: 65535
+                        minimum: 0
+                        type: integer
+                    required:
+                    - address
+                    - port
+                    type: object
+                  unix:
+                    description: Unix defines the unix domain socket endpoint
+                    properties:
+                      path:
+                        description: Path defines the unix domain socket path of the
+                          backend endpoint.
+                        type: string
+                    required:
+                    - path
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: one of fqdn, ip or unix must be specified
+                  rule: (has(self.fqdn) || has(self.ip) || has(self.unix))
+                - message: only one of fqdn, ip or unix can be specified
+                  rule: ((has(self.fqdn) && !(has(self.ip) || has(self.unix))) ||
+                    (has(self.ip) && !(has(self.fqdn) || has(self.unix))) || (has(self.unix)
+                    && !(has(self.ip) || has(self.fqdn))))
+              maxItems: 4
+              minItems: 1
+              type: array
+              x-kubernetes-validations:
+              - message: fqdn addresses cannot be mixed with other address types
+                rule: self.all(f, has(f.fqdn)) || !self.exists(f, has(f.fqdn))
+          type: object
+      required:
+      - spec
+      type: object

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/backendtrafficpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/backendtrafficpolicies.yaml
@@ -17,18 +17,24 @@ spec:
     version: v1alpha1
   validation:
     openAPIV3Schema:
-      description: BackendTrafficPolicy allows the user to configure the behavior
-        of the connection between the downstream client and Envoy Proxy listener.
+      description: |-
+        BackendTrafficPolicy allows the user to configure the behavior of the connection
+        between the Envoy Proxy listener and the backend service.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -66,27 +72,469 @@ spec:
         spec:
           description: spec defines the desired state of BackendTrafficPolicy.
           properties:
+            circuitBreaker:
+              description: |-
+                Circuit Breaker settings for the upstream connections and requests.
+                If not set, circuit breakers will be enabled with the default thresholds
+              properties:
+                maxConnections:
+                  default: 1024
+                  description: The maximum number of connections that Envoy will establish
+                    to the referenced backend defined within a xRoute rule.
+                  format: int64
+                  maximum: 4294967295
+                  minimum: 0
+                  type: integer
+                maxParallelRequests:
+                  default: 1024
+                  description: The maximum number of parallel requests that Envoy
+                    will make to the referenced backend defined within a xRoute rule.
+                  format: int64
+                  maximum: 4294967295
+                  minimum: 0
+                  type: integer
+                maxParallelRetries:
+                  default: 1024
+                  description: The maximum number of parallel retries that Envoy will
+                    make to the referenced backend defined within a xRoute rule.
+                  format: int64
+                  maximum: 4294967295
+                  minimum: 0
+                  type: integer
+                maxPendingRequests:
+                  default: 1024
+                  description: The maximum number of pending requests that Envoy will
+                    queue to the referenced backend defined within a xRoute rule.
+                  format: int64
+                  maximum: 4294967295
+                  minimum: 0
+                  type: integer
+                maxRequestsPerConnection:
+                  description: |-
+                    The maximum number of requests that Envoy will make over a single connection to the referenced backend defined within a xRoute rule.
+                    Default: unlimited.
+                  format: int64
+                  maximum: 4294967295
+                  minimum: 0
+                  type: integer
+              type: object
+            compression:
+              description: The compression config for the http streams.
+              items:
+                description: |-
+                  Compression defines the config of enabling compression.
+                  This can help reduce the bandwidth at the expense of higher CPU.
+                properties:
+                  gzip:
+                    description: The configuration for GZIP compressor.
+                    type: object
+                  type:
+                    description: CompressorType defines the compressor type to use
+                      for compression.
+                    enum:
+                    - Gzip
+                    type: string
+                required:
+                - type
+                type: object
+              type: array
+            connection:
+              description: Connection includes backend connection settings.
+              properties:
+                bufferLimit:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: |-
+                    BufferLimit Soft limit on size of the cluster’s connections read and write buffers.
+                    If unspecified, an implementation defined default is applied (32768 bytes).
+                    For example, 20Mi, 1Gi, 256Ki etc.
+                    Note: that when the suffix is not provided, the value is interpreted as bytes.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                  x-kubernetes-validations:
+                  - message: BufferLimit must be of the format "^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$"
+                    rule: 'type(self) == string ? self.matches(r"^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$")
+                      : type(self) == int'
+              type: object
+            faultInjection:
+              description: |-
+                FaultInjection defines the fault injection policy to be applied. This configuration can be used to
+                inject delays and abort requests to mimic failure scenarios such as service failures and overloads
+              properties:
+                abort:
+                  description: If specified, the request will be aborted if it meets
+                    the configuration criteria.
+                  properties:
+                    grpcStatus:
+                      description: GrpcStatus specifies the GRPC status code to be
+                        returned
+                      format: int32
+                      type: integer
+                    httpStatus:
+                      description: StatusCode specifies the HTTP status code to be
+                        returned
+                      format: int32
+                      maximum: 600
+                      minimum: 200
+                      type: integer
+                    percentage:
+                      default: 100
+                      description: Percentage specifies the percentage of requests
+                        to be aborted. Default 100%, if set 0, no requests will be
+                        aborted. Accuracy to 0.0001%.
+                      type: number
+                  type: object
+                  x-kubernetes-validations:
+                  - message: httpStatus and grpcStatus cannot be simultaneously defined.
+                    rule: ' !(has(self.httpStatus) && has(self.grpcStatus)) '
+                  - message: httpStatus and grpcStatus are set at least one.
+                    rule: ' has(self.httpStatus) || has(self.grpcStatus) '
+                delay:
+                  description: If specified, a delay will be injected into the request.
+                  properties:
+                    fixedDelay:
+                      description: FixedDelay specifies the fixed delay duration
+                      type: string
+                    percentage:
+                      default: 100
+                      description: Percentage specifies the percentage of requests
+                        to be delayed. Default 100%, if set 0, no requests will be
+                        delayed. Accuracy to 0.0001%.
+                      type: number
+                  required:
+                  - fixedDelay
+                  type: object
+              type: object
+              x-kubernetes-validations:
+              - message: Delay and abort faults are set at least one.
+                rule: ' has(self.delay) || has(self.abort) '
+            healthCheck:
+              description: HealthCheck allows gateway to perform active health checking
+                on backends.
+              properties:
+                active:
+                  description: Active health check configuration
+                  properties:
+                    healthyThreshold:
+                      default: 1
+                      description: HealthyThreshold defines the number of healthy
+                        health checks required before a backend host is marked healthy.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    http:
+                      description: |-
+                        HTTP defines the configuration of http health checker.
+                        It's required while the health checker type is HTTP.
+                      properties:
+                        expectedResponse:
+                          description: ExpectedResponse defines a list of HTTP expected
+                            responses to match.
+                          properties:
+                            binary:
+                              description: Binary payload base64 encoded.
+                              format: byte
+                              type: string
+                            text:
+                              description: Text payload in plain text.
+                              type: string
+                            type:
+                              allOf:
+                              - enum:
+                                - Text
+                                - Binary
+                              - enum:
+                                - Text
+                                - Binary
+                              description: Type defines the type of the payload.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                          x-kubernetes-validations:
+                          - message: If payload type is Text, text field needs to
+                              be set.
+                            rule: 'self.type == ''Text'' ? has(self.text) : !has(self.text)'
+                          - message: If payload type is Binary, binary field needs
+                              to be set.
+                            rule: 'self.type == ''Binary'' ? has(self.binary) : !has(self.binary)'
+                        expectedStatuses:
+                          description: |-
+                            ExpectedStatuses defines a list of HTTP response statuses considered healthy.
+                            Defaults to 200 only
+                          items:
+                            description: HTTPStatus defines the http status code.
+                            exclusiveMaximum: true
+                            maximum: 600
+                            minimum: 100
+                            type: integer
+                          type: array
+                        method:
+                          description: |-
+                            Method defines the HTTP method used for health checking.
+                            Defaults to GET
+                          type: string
+                        path:
+                          description: Path defines the HTTP path that will be requested
+                            during health checking.
+                          maxLength: 1024
+                          minLength: 1
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    interval:
+                      default: 3s
+                      description: Interval defines the time between active health
+                        checks.
+                      format: duration
+                      type: string
+                    tcp:
+                      description: |-
+                        TCP defines the configuration of tcp health checker.
+                        It's required while the health checker type is TCP.
+                      properties:
+                        receive:
+                          description: Receive defines the expected response payload.
+                          properties:
+                            binary:
+                              description: Binary payload base64 encoded.
+                              format: byte
+                              type: string
+                            text:
+                              description: Text payload in plain text.
+                              type: string
+                            type:
+                              allOf:
+                              - enum:
+                                - Text
+                                - Binary
+                              - enum:
+                                - Text
+                                - Binary
+                              description: Type defines the type of the payload.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                          x-kubernetes-validations:
+                          - message: If payload type is Text, text field needs to
+                              be set.
+                            rule: 'self.type == ''Text'' ? has(self.text) : !has(self.text)'
+                          - message: If payload type is Binary, binary field needs
+                              to be set.
+                            rule: 'self.type == ''Binary'' ? has(self.binary) : !has(self.binary)'
+                        send:
+                          description: Send defines the request payload.
+                          properties:
+                            binary:
+                              description: Binary payload base64 encoded.
+                              format: byte
+                              type: string
+                            text:
+                              description: Text payload in plain text.
+                              type: string
+                            type:
+                              allOf:
+                              - enum:
+                                - Text
+                                - Binary
+                              - enum:
+                                - Text
+                                - Binary
+                              description: Type defines the type of the payload.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                          x-kubernetes-validations:
+                          - message: If payload type is Text, text field needs to
+                              be set.
+                            rule: 'self.type == ''Text'' ? has(self.text) : !has(self.text)'
+                          - message: If payload type is Binary, binary field needs
+                              to be set.
+                            rule: 'self.type == ''Binary'' ? has(self.binary) : !has(self.binary)'
+                      type: object
+                    timeout:
+                      default: 1s
+                      description: Timeout defines the time to wait for a health check
+                        response.
+                      format: duration
+                      type: string
+                    type:
+                      allOf:
+                      - enum:
+                        - HTTP
+                        - TCP
+                      - enum:
+                        - HTTP
+                        - TCP
+                      description: Type defines the type of health checker.
+                      type: string
+                    unhealthyThreshold:
+                      default: 3
+                      description: UnhealthyThreshold defines the number of unhealthy
+                        health checks required before a backend host is marked unhealthy.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                  required:
+                  - type
+                  type: object
+                  x-kubernetes-validations:
+                  - message: If Health Checker type is HTTP, http field needs to be
+                      set.
+                    rule: 'self.type == ''HTTP'' ? has(self.http) : !has(self.http)'
+                  - message: If Health Checker type is TCP, tcp field needs to be
+                      set.
+                    rule: 'self.type == ''TCP'' ? has(self.tcp) : !has(self.tcp)'
+                passive:
+                  description: Passive passive check configuration
+                  properties:
+                    baseEjectionTime:
+                      default: 30s
+                      description: BaseEjectionTime defines the base duration for
+                        which a host will be ejected on consecutive failures.
+                      format: duration
+                      type: string
+                    consecutive5XxErrors:
+                      default: 5
+                      description: Consecutive5xxErrors sets the number of consecutive
+                        5xx errors triggering ejection.
+                      format: int32
+                      type: integer
+                    consecutiveGatewayErrors:
+                      default: 0
+                      description: ConsecutiveGatewayErrors sets the number of consecutive
+                        gateway errors triggering ejection.
+                      format: int32
+                      type: integer
+                    consecutiveLocalOriginFailures:
+                      default: 5
+                      description: |-
+                        ConsecutiveLocalOriginFailures sets the number of consecutive local origin failures triggering ejection.
+                        Parameter takes effect only when split_external_local_origin_errors is set to true.
+                      format: int32
+                      type: integer
+                    interval:
+                      default: 3s
+                      description: Interval defines the time between passive health
+                        checks.
+                      format: duration
+                      type: string
+                    maxEjectionPercent:
+                      default: 10
+                      description: MaxEjectionPercent sets the maximum percentage
+                        of hosts in a cluster that can be ejected.
+                      format: int32
+                      type: integer
+                    splitExternalLocalOriginErrors:
+                      default: false
+                      description: SplitExternalLocalOriginErrors enables splitting
+                        of errors between external and local origin.
+                      type: boolean
+                  type: object
+              type: object
             loadBalancer:
-              description: LoadBalancer policy to apply when routing traffic from
-                the gateway to the backend endpoints
+              description: |-
+                LoadBalancer policy to apply when routing traffic from the gateway to
+                the backend endpoints
               properties:
                 consistentHash:
-                  description: ConsistentHash defines the configuration when the load
-                    balancer type is set to ConsistentHash
+                  description: |-
+                    ConsistentHash defines the configuration when the load balancer type is
+                    set to ConsistentHash
                   properties:
+                    cookie:
+                      description: Cookie configures the cookie hash policy when the
+                        consistent hash type is set to Cookie.
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          description: Additional Attributes to set for the generated
+                            cookie.
+                          type: object
+                        name:
+                          description: |-
+                            Name of the cookie to hash.
+                            If this cookie does not exist in the request, Envoy will generate a cookie and set
+                            the TTL on the response back to the client based on Layer 4
+                            attributes of the backend endpoint, to ensure that these future requests
+                            go to the same backend endpoint. Make sure to set the TTL field for this case.
+                          type: string
+                        ttl:
+                          description: |-
+                            TTL of the generated cookie if the cookie is not present. This value sets the
+                            Max-Age attribute value.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    header:
+                      description: Header configures the header hash policy when the
+                        consistent hash type is set to Header.
+                      properties:
+                        name:
+                          description: Name of the header to hash.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    tableSize:
+                      default: 65537
+                      description: The table size for consistent hashing, must be
+                        prime number limited to 5000011.
+                      format: int64
+                      maximum: 5000011
+                      minimum: 2
+                      type: integer
                     type:
-                      description: ConsistentHashType defines the type of input to
-                        hash on.
+                      description: |-
+                        ConsistentHashType defines the type of input to hash on. Valid Type values are
+                        "SourceIP",
+                        "Header",
+                        "Cookie".
                       enum:
                       - SourceIP
+                      - Header
+                      - Cookie
                       type: string
                   required:
                   - type
                   type: object
+                  x-kubernetes-validations:
+                  - message: If consistent hash type is header, the header field must
+                      be set.
+                    rule: 'self.type == ''Header'' ? has(self.header) : !has(self.header)'
+                  - message: If consistent hash type is cookie, the cookie field must
+                      be set.
+                    rule: 'self.type == ''Cookie'' ? has(self.cookie) : !has(self.cookie)'
+                slowStart:
+                  description: |-
+                    SlowStart defines the configuration related to the slow start load balancer policy.
+                    If set, during slow start window, traffic sent to the newly added hosts will gradually increase.
+                    Currently this is only supported for RoundRobin and LeastRequest load balancers
+                  properties:
+                    window:
+                      description: |-
+                        Window defines the duration of the warm up period for newly added host.
+                        During slow start window, traffic sent to the newly added hosts will gradually increase.
+                        Currently only supports linear growth of traffic. For additional details,
+                        see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-slowstartconfig
+                      type: string
+                  required:
+                  - window
+                  type: object
                 type:
-                  description: Type decides the type of Load Balancer policy. Valid
-                    LoadBalancerType values are "ConsistentHash", "LeastRequest",
-                    "Random", "RoundRobin",
+                  description: |-
+                    Type decides the type of Load Balancer policy.
+                    Valid LoadBalancerType values are
+                    "ConsistentHash",
+                    "LeastRequest",
+                    "Random",
+                    "RoundRobin".
                   enum:
                   - ConsistentHash
                   - LeastRequest
@@ -101,45 +549,77 @@ spec:
                   needs to be set.
                 rule: 'self.type == ''ConsistentHash'' ? has(self.consistentHash)
                   : !has(self.consistentHash)'
+              - message: Currently SlowStart is only supported for RoundRobin and
+                  LeastRequest load balancers.
+                rule: 'self.type in [''Random'', ''ConsistentHash''] ? !has(self.slowStart)
+                  : true '
+            proxyProtocol:
+              description: ProxyProtocol enables the Proxy Protocol when communicating
+                with the backend.
+              properties:
+                version:
+                  description: |-
+                    Version of ProxyProtol
+                    Valid ProxyProtocolVersion values are
+                    "V1"
+                    "V2"
+                  enum:
+                  - V1
+                  - V2
+                  type: string
+              required:
+              - version
+              type: object
             rateLimit:
-              description: RateLimit allows the user to limit the number of incoming
-                requests to a predefined value based on attributes within the traffic
-                flow.
+              description: |-
+                RateLimit allows the user to limit the number of incoming requests
+                to a predefined value based on attributes within the traffic flow.
               properties:
                 global:
                   description: Global defines global rate limit configuration.
                   properties:
                     rules:
-                      description: Rules are a list of RateLimit selectors and limits.
-                        Each rule and its associated limit is applied in a mutually
-                        exclusive way i.e. if multiple rules get selected, each of
-                        their associated limits get applied, so a single traffic request
-                        might increase the rate limit counters for multiple rules
-                        if selected.
+                      description: |-
+                        Rules are a list of RateLimit selectors and limits. Each rule and its
+                        associated limit is applied in a mutually exclusive way. If a request
+                        matches multiple rules, each of their associated limits get applied, so a
+                        single request might increase the rate limit counters for multiple rules
+                        if selected. The rate limit service will return a logical OR of the individual
+                        rate limit decisions of all matching rules. For example, if a request
+                        matches two rules, one rate limited and one not, the final decision will be
+                        to rate limit the request.
                       items:
-                        description: RateLimitRule defines the semantics for matching
-                          attributes from the incoming requests, and setting limits
-                          for them.
+                        description: |-
+                          RateLimitRule defines the semantics for matching attributes
+                          from the incoming requests, and setting limits for them.
                         properties:
                           clientSelectors:
-                            description: ClientSelectors holds the list of select
-                              conditions to select specific clients using attributes
-                              from the traffic flow. All individual select conditions
-                              must hold True for this rule and its limit to be applied.
-                              If this field is empty, it is equivalent to True, and
-                              the limit is applied.
+                            description: |-
+                              ClientSelectors holds the list of select conditions to select
+                              specific clients using attributes from the traffic flow.
+                              All individual select conditions must hold True for this rule
+                              and its limit to be applied.
+
+
+                              If no client selectors are specified, the rule applies to all traffic of
+                              the targeted Route.
+
+
+                              If the policy targets a Gateway, the rule applies to each Route of the Gateway.
+                              Please note that each Route has its own rate limit counters. For example,
+                              if a Gateway has two Routes, and the policy has a rule with limit 10rps,
+                              each Route will have its own 10rps limit.
                             items:
-                              description: RateLimitSelectCondition specifies the
-                                attributes within the traffic flow that can be used
-                                to select a subset of clients to be ratelimited. All
-                                the individual conditions must hold True for the overall
-                                condition to hold True.
+                              description: |-
+                                RateLimitSelectCondition specifies the attributes within the traffic flow that can
+                                be used to select a subset of clients to be ratelimited.
+                                All the individual conditions must hold True for the overall condition to hold True.
                               properties:
                                 headers:
-                                  description: Headers is a list of request headers
-                                    to match. Multiple header values are ANDed together,
-                                    meaning, a request MUST match all the specified
-                                    headers.
+                                  description: |-
+                                    Headers is a list of request headers to match. Multiple header values are ANDed together,
+                                    meaning, a request MUST match all the specified headers.
+                                    At least one of headers or sourceCIDR condition must be specified.
                                   items:
                                     description: HeaderMatch defines the match attributes
                                       within the HTTP Headers of the request.
@@ -159,12 +639,11 @@ spec:
                                         - Distinct
                                         type: string
                                       value:
-                                        description: Value within the HTTP header.
-                                          Due to the case-insensitivity of header
-                                          names, "foo" and "Foo" are considered equivalent.
-                                          Do not set this field when Type="Distinct",
-                                          implying matching on any/all unique values
-                                          within the header.
+                                        description: |-
+                                          Value within the HTTP header. Due to the
+                                          case-insensitivity of header names, "foo" and "Foo" are considered equivalent.
+                                          Do not set this field when Type="Distinct", implying matching on any/all unique
+                                          values within the header.
                                         maxLength: 1024
                                         type: string
                                     required:
@@ -176,20 +655,21 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 sourceCIDR:
-                                  description: SourceCIDR is the client IP Address
-                                    range to match on.
+                                  description: |-
+                                    SourceCIDR is the client IP Address range to match on.
+                                    At least one of headers or sourceCIDR condition must be specified.
                                   properties:
                                     type:
                                       default: Exact
+                                      enum:
+                                      - Exact
+                                      - Distinct
                                       type: string
                                     value:
-                                      description: Value is the IP CIDR that represents
-                                        the range of Source IP Addresses of the client.
-                                        These could also be the intermediate addresses
-                                        through which the request has flown through
-                                        and is part of the  `X-Forwarded-For` header.
-                                        For example, `192.168.0.1/32`, `192.168.0.0/24`,
-                                        `001:db8::/64`.
+                                      description: |-
+                                        Value is the IP CIDR that represents the range of Source IP Addresses of the client.
+                                        These could also be the intermediate addresses through which the request has flown through and is part of the  `X-Forwarded-For` header.
+                                        For example, `192.168.0.1/32`, `192.168.0.0/24`, `001:db8::/64`.
                                       maxLength: 256
                                       minLength: 1
                                       type: string
@@ -200,20 +680,153 @@ spec:
                             maxItems: 8
                             type: array
                           limit:
-                            description: Limit holds the rate limit values. This limit
-                              is applied for traffic flows when the selectors compute
-                              to True, causing the request to be counted towards the
-                              limit. The limit is enforced and the request is ratelimited,
-                              i.e. a response with 429 HTTP status code is sent back
-                              to the client when the selected requests have reached
-                              the limit.
+                            description: |-
+                              Limit holds the rate limit values.
+                              This limit is applied for traffic flows when the selectors
+                              compute to True, causing the request to be counted towards the limit.
+                              The limit is enforced and the request is ratelimited, i.e. a response with
+                              429 HTTP status code is sent back to the client when
+                              the selected requests have reached the limit.
                             properties:
                               requests:
                                 type: integer
                               unit:
-                                description: RateLimitUnit specifies the intervals
-                                  for setting rate limits. Valid RateLimitUnit values
-                                  are "Second", "Minute", "Hour", and "Day".
+                                description: |-
+                                  RateLimitUnit specifies the intervals for setting rate limits.
+                                  Valid RateLimitUnit values are "Second", "Minute", "Hour", and "Day".
+                                enum:
+                                - Second
+                                - Minute
+                                - Hour
+                                - Day
+                                type: string
+                            required:
+                            - requests
+                            - unit
+                            type: object
+                        required:
+                        - limit
+                        type: object
+                      maxItems: 64
+                      type: array
+                  required:
+                  - rules
+                  type: object
+                local:
+                  description: Local defines local rate limit configuration.
+                  properties:
+                    rules:
+                      description: |-
+                        Rules are a list of RateLimit selectors and limits. If a request matches
+                        multiple rules, the strictest limit is applied. For example, if a request
+                        matches two rules, one with 10rps and one with 20rps, the final limit will
+                        be based on the rule with 10rps.
+                      items:
+                        description: |-
+                          RateLimitRule defines the semantics for matching attributes
+                          from the incoming requests, and setting limits for them.
+                        properties:
+                          clientSelectors:
+                            description: |-
+                              ClientSelectors holds the list of select conditions to select
+                              specific clients using attributes from the traffic flow.
+                              All individual select conditions must hold True for this rule
+                              and its limit to be applied.
+
+
+                              If no client selectors are specified, the rule applies to all traffic of
+                              the targeted Route.
+
+
+                              If the policy targets a Gateway, the rule applies to each Route of the Gateway.
+                              Please note that each Route has its own rate limit counters. For example,
+                              if a Gateway has two Routes, and the policy has a rule with limit 10rps,
+                              each Route will have its own 10rps limit.
+                            items:
+                              description: |-
+                                RateLimitSelectCondition specifies the attributes within the traffic flow that can
+                                be used to select a subset of clients to be ratelimited.
+                                All the individual conditions must hold True for the overall condition to hold True.
+                              properties:
+                                headers:
+                                  description: |-
+                                    Headers is a list of request headers to match. Multiple header values are ANDed together,
+                                    meaning, a request MUST match all the specified headers.
+                                    At least one of headers or sourceCIDR condition must be specified.
+                                  items:
+                                    description: HeaderMatch defines the match attributes
+                                      within the HTTP Headers of the request.
+                                    properties:
+                                      name:
+                                        description: Name of the HTTP header.
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                      type:
+                                        default: Exact
+                                        description: Type specifies how to match against
+                                          the value of the header.
+                                        enum:
+                                        - Exact
+                                        - RegularExpression
+                                        - Distinct
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Value within the HTTP header. Due to the
+                                          case-insensitivity of header names, "foo" and "Foo" are considered equivalent.
+                                          Do not set this field when Type="Distinct", implying matching on any/all unique
+                                          values within the header.
+                                        maxLength: 1024
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  maxItems: 16
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                sourceCIDR:
+                                  description: |-
+                                    SourceCIDR is the client IP Address range to match on.
+                                    At least one of headers or sourceCIDR condition must be specified.
+                                  properties:
+                                    type:
+                                      default: Exact
+                                      enum:
+                                      - Exact
+                                      - Distinct
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Value is the IP CIDR that represents the range of Source IP Addresses of the client.
+                                        These could also be the intermediate addresses through which the request has flown through and is part of the  `X-Forwarded-For` header.
+                                        For example, `192.168.0.1/32`, `192.168.0.0/24`, `001:db8::/64`.
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - value
+                                  type: object
+                              type: object
+                            maxItems: 8
+                            type: array
+                          limit:
+                            description: |-
+                              Limit holds the rate limit values.
+                              This limit is applied for traffic flows when the selectors
+                              compute to True, causing the request to be counted towards the limit.
+                              The limit is enforced and the request is ratelimited, i.e. a response with
+                              429 HTTP status code is sent back to the client when
+                              the selected requests have reached the limit.
+                            properties:
+                              requests:
+                                type: integer
+                              unit:
+                                description: |-
+                                  RateLimitUnit specifies the intervals for setting rate limits.
+                                  Valid RateLimitUnit values are "Second", "Minute", "Hour", and "Day".
                                 enum:
                                 - Second
                                 - Minute
@@ -229,22 +842,104 @@ spec:
                         type: object
                       maxItems: 16
                       type: array
-                  required:
-                  - rules
                   type: object
                 type:
-                  description: Type decides the scope for the RateLimits. Valid RateLimitType
-                    values are "Global".
+                  description: |-
+                    Type decides the scope for the RateLimits.
+                    Valid RateLimitType values are "Global" or "Local".
                   enum:
                   - Global
+                  - Local
                   type: string
               required:
               - type
               type: object
+            retry:
+              description: |-
+                Retry provides more advanced usage, allowing users to customize the number of retries, retry fallback strategy, and retry triggering conditions.
+                If not set, retry will be disabled.
+              properties:
+                numRetries:
+                  default: 2
+                  description: NumRetries is the number of retries to be attempted.
+                    Defaults to 2.
+                  format: int32
+                  minimum: 0
+                  type: integer
+                perRetry:
+                  description: PerRetry is the retry policy to be applied per retry
+                    attempt.
+                  properties:
+                    backOff:
+                      description: |-
+                        Backoff is the backoff policy to be applied per retry attempt. gateway uses a fully jittered exponential
+                        back-off algorithm for retries. For additional details,
+                        see https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#config-http-filters-router-x-envoy-max-retries
+                      properties:
+                        baseInterval:
+                          description: BaseInterval is the base interval between retries.
+                          format: duration
+                          type: string
+                        maxInterval:
+                          description: |-
+                            MaxInterval is the maximum interval between retries. This parameter is optional, but must be greater than or equal to the base_interval if set.
+                            The default is 10 times the base_interval
+                          format: duration
+                          type: string
+                      type: object
+                    timeout:
+                      description: Timeout is the timeout per retry attempt.
+                      format: duration
+                      type: string
+                  type: object
+                retryOn:
+                  description: |-
+                    RetryOn specifies the retry trigger condition.
+
+
+                    If not specified, the default is to retry on connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes(503).
+                  properties:
+                    httpStatusCodes:
+                      description: |-
+                        HttpStatusCodes specifies the http status codes to be retried.
+                        The retriable-status-codes trigger must also be configured for these status codes to trigger a retry.
+                      items:
+                        description: HTTPStatus defines the http status code.
+                        exclusiveMaximum: true
+                        maximum: 600
+                        minimum: 100
+                        type: integer
+                      type: array
+                    triggers:
+                      description: Triggers specifies the retry trigger condition(Http/Grpc).
+                      items:
+                        description: TriggerEnum specifies the conditions that trigger
+                          retries.
+                        enum:
+                        - 5xx
+                        - gateway-error
+                        - reset
+                        - connect-failure
+                        - retriable-4xx
+                        - refused-stream
+                        - retriable-status-codes
+                        - cancelled
+                        - deadline-exceeded
+                        - internal
+                        - resource-exhausted
+                        - unavailable
+                        type: string
+                      type: array
+                  type: object
+              type: object
             targetRef:
-              description: targetRef is the name of the resource this policy is being
-                attached to. This Policy and the TargetRef MUST be in the same namespace
-                for this Policy to have effect and be applied to the Gateway.
+              description: |-
+                TargetRef is the name of the resource this policy is being attached to.
+                This policy and the TargetRef MUST be in the same namespace for this
+                Policy to have effect
+
+
+                Deprecated: use targetRefs/targetSelectors instead
               properties:
                 group:
                   description: Group is the group of the target resource.
@@ -262,24 +957,21 @@ spec:
                   maxLength: 253
                   minLength: 1
                   type: string
-                namespace:
-                  description: Namespace is the namespace of the referent. When unspecified,
-                    the local namespace is inferred. Even when policy targets a resource
-                    in a different namespace, it MUST only apply to traffic originating
-                    from the same namespace as the policy.
-                  maxLength: 63
-                  minLength: 1
-                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                  type: string
                 sectionName:
-                  description: "SectionName is the name of a section within the target
-                    resource. When unspecified, this targetRef targets the entire
-                    resource. In the following resources, SectionName is interpreted
-                    as the following: \n * Gateway: Listener Name * Service: Port
-                    Name \n If a SectionName is specified, but does not exist on the
-                    targeted object, the Policy must fail to attach, and the policy
-                    implementation should record a `ResolvedRefs` or similar Condition
-                    in the Policy's status."
+                  description: |-
+                    SectionName is the name of a section within the target resource. When
+                    unspecified, this targetRef targets the entire resource. In the following
+                    resources, SectionName is interpreted as the following:
+
+
+                    * Gateway: Listener name
+                    * HTTPRoute: HTTPRouteRule name
+                    * Service: Port name
+
+
+                    If a SectionName is specified, but does not exist on the targeted object,
+                    the Policy must fail to attach, and the policy implementation should record
+                    a `ResolvedRefs` or similar Condition in the Policy's status.
                   maxLength: 253
                   minLength: 1
                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -289,17 +981,184 @@ spec:
               - kind
               - name
               type: object
-              x-kubernetes-validations:
-              - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
-                rule: self.group == 'gateway.networking.k8s.io'
-              - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
-                rule: self.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'UDPRoute',
-                  'TCPRoute', 'TLSRoute']
-              - message: this policy does not yet support the sectionName field
-                rule: '!has(self.sectionName)'
-          required:
-          - targetRef
+            targetRefs:
+              description: |-
+                TargetRefs are the names of the Gateway resources this policy
+                is being attached to.
+              items:
+                description: |-
+                  LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                  direct policy to. This should be used as part of Policy resources that can
+                  target single resources. For more information on how this policy attachment
+                  mode works, and a sample Policy resource, refer to the policy attachment
+                  documentation for Gateway API.
+
+
+                  Note: This should only be used for direct policy attachment when references
+                  to SectionName are actually needed. In all other cases,
+                  LocalPolicyTargetReference should be used.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              type: array
+            targetSelectors:
+              description: TargetSelectors allow targeting resources for this policy
+                based on labels
+              items:
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: Group is the group that this selector targets. Defaults
+                      to gateway.networking.k8s.io
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is the resource kind that this selector targets.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: MatchLabels are the set of label selectors for identifying
+                      the targeted resource
+                    type: object
+                required:
+                - kind
+                - matchLabels
+                type: object
+                x-kubernetes-validations:
+                - message: group must be gateway.networking.k8s.io
+                  rule: 'has(self.group) ? self.group == ''gateway.networking.k8s.io''
+                    : true '
+              type: array
+            tcpKeepalive:
+              description: |-
+                TcpKeepalive settings associated with the upstream client connection.
+                Disabled by default.
+              properties:
+                idleTime:
+                  description: |-
+                    The duration a connection needs to be idle before keep-alive
+                    probes start being sent.
+                    The duration format is
+                    Defaults to `7200s`.
+                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                  type: string
+                interval:
+                  description: |-
+                    The duration between keep-alive probes.
+                    Defaults to `75s`.
+                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                  type: string
+                probes:
+                  description: |-
+                    The total number of unacknowledged probes to send before deciding
+                    the connection is dead.
+                    Defaults to 9.
+                  format: int32
+                  type: integer
+              type: object
+            timeout:
+              description: Timeout settings for the backend connections.
+              properties:
+                http:
+                  description: Timeout settings for HTTP.
+                  properties:
+                    connectionIdleTimeout:
+                      description: |-
+                        The idle timeout for an HTTP connection. Idle time is defined as a period in which there are no active requests in the connection.
+                        Default: 1 hour.
+                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                      type: string
+                    maxConnectionDuration:
+                      description: |-
+                        The maximum duration of an HTTP connection.
+                        Default: unlimited.
+                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                      type: string
+                  type: object
+                tcp:
+                  description: Timeout settings for TCP.
+                  properties:
+                    connectTimeout:
+                      description: |-
+                        The timeout for network connection establishment, including TCP and TLS handshakes.
+                        Default: 10 seconds.
+                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                      type: string
+                  type: object
+              type: object
+            useClientProtocol:
+              description: |-
+                UseClientProtocol configures Envoy to prefer sending requests to backends using
+                the same HTTP protocol that the incoming request used. Defaults to false, which means
+                that Envoy will use the protocol indicated by the attached BackendRef.
+              type: boolean
           type: object
+          x-kubernetes-validations:
+          - message: either targetRef or targetRefs must be used
+            rule: '(has(self.targetRef) && !has(self.targetRefs)) || (!has(self.targetRef)
+              && has(self.targetRefs)) || (has(self.targetSelectors) && self.targetSelectors.size()
+              > 0) '
+          - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
+            rule: 'has(self.targetRef) ? self.targetRef.group == ''gateway.networking.k8s.io''
+              : true '
+          - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
+            rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''HTTPRoute'',
+              ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''] : true'
+          - message: this policy does not yet support the sectionName field
+            rule: 'has(self.targetRef) ? !has(self.targetRef.sectionName) : true'
+          - message: this policy can only have a targetRefs[*].group of gateway.networking.k8s.io
+            rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.group == ''gateway.networking.k8s.io'')
+              : true '
+          - message: this policy can only have a targetRefs[*].kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
+            rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind in [''Gateway'',
+              ''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''])
+              : true '
+          - message: this policy does not yet support the sectionName field
+            rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, !has(ref.sectionName))
+              : true'
       required:
       - spec
       type: object

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/clienttrafficpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/clienttrafficpolicies.yaml
@@ -17,18 +17,24 @@ spec:
     version: v1alpha1
   validation:
     openAPIV3Schema:
-      description: ClientTrafficPolicy allows the user to configure the behavior of
-        the connection between the downstream client and Envoy Proxy listener.
+      description: |-
+        ClientTrafficPolicy allows the user to configure the behavior of the connection
+        between the downstream client and Envoy Proxy listener.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -66,11 +72,289 @@ spec:
         spec:
           description: Spec defines the desired state of ClientTrafficPolicy.
           properties:
+            clientIPDetection:
+              description: ClientIPDetectionSettings provides configuration for determining
+                the original client IP address for requests.
+              properties:
+                customHeader:
+                  description: |-
+                    CustomHeader provides configuration for determining the client IP address for a request based on
+                    a trusted custom HTTP header. This uses the custom_header original IP detection extension.
+                    Refer to https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/http/original_ip_detection/custom_header/v3/custom_header.proto
+                    for more details.
+                  properties:
+                    failClosed:
+                      description: |-
+                        FailClosed is a switch used to control the flow of traffic when client IP detection
+                        fails. If set to true, the listener will respond with 403 Forbidden when the client
+                        IP address cannot be determined.
+                      type: boolean
+                    name:
+                      description: Name of the header containing the original downstream
+                        remote address, if present.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[A-Za-z0-9-]+$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                xForwardedFor:
+                  description: XForwardedForSettings provides configuration for using
+                    X-Forwarded-For headers for determining the client IP address.
+                  properties:
+                    numTrustedHops:
+                      description: |-
+                        NumTrustedHops controls the number of additional ingress proxy hops from the right side of XFF HTTP
+                        headers to trust when determining the origin client's IP address.
+                        Refer to https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for
+                        for more details.
+                      format: int32
+                      type: integer
+                  type: object
+              type: object
+              x-kubernetes-validations:
+              - message: customHeader cannot be used in conjunction with xForwardedFor
+                rule: '!(has(self.xForwardedFor) && has(self.customHeader))'
+            connection:
+              description: Connection includes client connection settings.
+              properties:
+                bufferLimit:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: |-
+                    BufferLimit provides configuration for the maximum buffer size in bytes for each incoming connection.
+                    For example, 20Mi, 1Gi, 256Ki etc.
+                    Note that when the suffix is not provided, the value is interpreted as bytes.
+                    Default: 32768 bytes.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                  x-kubernetes-validations:
+                  - message: bufferLimit must be of the format "^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$"
+                    rule: 'type(self) == string ? self.matches(r"^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$")
+                      : type(self) == int'
+                connectionLimit:
+                  description: ConnectionLimit defines limits related to connections
+                  properties:
+                    closeDelay:
+                      description: |-
+                        CloseDelay defines the delay to use before closing connections that are rejected
+                        once the limit value is reached.
+                        Default: none.
+                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                      type: string
+                    value:
+                      description: |-
+                        Value of the maximum concurrent connections limit.
+                        When the limit is reached, incoming connections will be closed after the CloseDelay duration.
+                        Default: unlimited.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                  type: object
+              type: object
+            enableProxyProtocol:
+              description: |-
+                EnableProxyProtocol interprets the ProxyProtocol header and adds the
+                Client Address into the X-Forwarded-For header.
+                Note Proxy Protocol must be present when this field is set, else the connection
+                is closed.
+              type: boolean
+            headers:
+              description: HeaderSettings provides configuration for header management.
+              properties:
+                disableRateLimitHeaders:
+                  description: |-
+                    DisableRateLimitHeaders configures Envoy Proxy to omit the "X-RateLimit-" response headers
+                    when rate limiting is enabled.
+                  type: boolean
+                enableEnvoyHeaders:
+                  description: |-
+                    EnableEnvoyHeaders configures Envoy Proxy to add the "X-Envoy-" headers to requests
+                    and responses.
+                  type: boolean
+                preserveXRequestID:
+                  description: |-
+                    PreserveXRequestID configures Envoy to keep the X-Request-ID header if passed for a request that is edge
+                    (Edge request is the request from external clients to front Envoy) and not reset it, which is the current Envoy behaviour.
+                    It defaults to false.
+                  type: boolean
+                withUnderscoresAction:
+                  description: |-
+                    WithUnderscoresAction configures the action to take when an HTTP header with underscores
+                    is encountered. The default action is to reject the request.
+                  enum:
+                  - Allow
+                  - RejectRequest
+                  - DropHeader
+                  type: string
+                xForwardedClientCert:
+                  description: |-
+                    XForwardedClientCert configures how Envoy Proxy handle the x-forwarded-client-cert (XFCC) HTTP header.
+
+
+                    x-forwarded-client-cert (XFCC) is an HTTP header used to forward the certificate
+                    information of part or all of the clients or proxies that a request has flowed through,
+                    on its way from the client to the server.
+
+
+                    Envoy proxy may choose to sanitize/append/forward the XFCC header before proxying the request.
+
+
+                    If not set, the default behavior is sanitizing the XFCC header.
+                  properties:
+                    certDetailsToAdd:
+                      description: |-
+                        CertDetailsToAdd specifies the fields in the client certificate to be forwarded in the XFCC header.
+
+
+                        Hash(the SHA 256 digest of the current client certificate) and By(the Subject Alternative Name)
+                        are always included if the client certificate is forwarded.
+
+
+                        This field is only applicable when the mode is set to `AppendForward` or
+                        `SanitizeSet` and the client connection is mTLS.
+                      items:
+                        description: XFCCCertData specifies the fields in the client
+                          certificate to be forwarded in the XFCC header.
+                        enum:
+                        - Subject
+                        - Cert
+                        - Chain
+                        - DNS
+                        - URI
+                        type: string
+                      maxItems: 5
+                      type: array
+                    mode:
+                      description: |-
+                        Mode defines how XFCC header is handled by Envoy Proxy.
+                        If not set, the default mode is `Sanitize`.
+                      enum:
+                      - Sanitize
+                      - ForwardOnly
+                      - AppendForward
+                      - SanitizeSet
+                      - AlwaysForwardOnly
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                  - message: certDetailsToAdd can only be set when mode is AppendForward
+                      or SanitizeSet
+                    rule: '(has(self.certDetailsToAdd) && self.certDetailsToAdd.size()
+                      > 0) ? (self.mode == ''AppendForward'' || self.mode == ''SanitizeSet'')
+                      : true'
+              type: object
+            healthCheck:
+              description: HealthCheck provides configuration for determining whether
+                the HTTP/HTTPS listener is healthy.
+              properties:
+                path:
+                  description: Path specifies the HTTP path to match on for health
+                    check requests.
+                  maxLength: 1024
+                  minLength: 1
+                  type: string
+              required:
+              - path
+              type: object
+            http1:
+              description: HTTP1 provides HTTP/1 configuration on the listener.
+              properties:
+                enableTrailers:
+                  description: EnableTrailers defines if HTTP/1 trailers should be
+                    proxied by Envoy.
+                  type: boolean
+                http10:
+                  description: HTTP10 turns on support for HTTP/1.0 and HTTP/0.9 requests.
+                  properties:
+                    useDefaultHost:
+                      description: |-
+                        UseDefaultHost defines if the HTTP/1.0 request is missing the Host header,
+                        then the hostname associated with the listener should be injected into the
+                        request.
+                        If this is not set and an HTTP/1.0 request arrives without a host, then
+                        it will be rejected.
+                      type: boolean
+                  type: object
+                preserveHeaderCase:
+                  description: |-
+                    PreserveHeaderCase defines if Envoy should preserve the letter case of headers.
+                    By default, Envoy will lowercase all the headers.
+                  type: boolean
+              type: object
+            http2:
+              description: HTTP2 provides HTTP/2 configuration on the listener.
+              properties:
+                initialConnectionWindowSize:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: |-
+                    InitialConnectionWindowSize sets the initial window size for HTTP/2 connections.
+                    If not set, the default value is 1 MiB.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                  x-kubernetes-validations:
+                  - message: initialConnectionWindowSize must be of the format "^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$"
+                    rule: 'type(self) == string ? self.matches(r"^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$")
+                      : type(self) == int'
+                initialStreamWindowSize:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: |-
+                    InitialStreamWindowSize sets the initial window size for HTTP/2 streams.
+                    If not set, the default value is 64 KiB(64*1024).
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                  x-kubernetes-validations:
+                  - message: initialStreamWindowSize must be of the format "^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$"
+                    rule: 'type(self) == string ? self.matches(r"^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$")
+                      : type(self) == int'
+                maxConcurrentStreams:
+                  description: |-
+                    MaxConcurrentStreams sets the maximum number of concurrent streams allowed per connection.
+                    If not set, the default value is 100.
+                  format: int32
+                  maximum: 2147483647
+                  minimum: 1
+                  type: integer
+              type: object
+            http3:
+              description: HTTP3 provides HTTP/3 configuration on the listener.
+              type: object
+            path:
+              description: Path enables managing how the incoming path set by clients
+                can be normalized.
+              properties:
+                disableMergeSlashes:
+                  description: |-
+                    DisableMergeSlashes allows disabling the default configuration of merging adjacent
+                    slashes in the path.
+                    Note that slash merging is not part of the HTTP spec and is provided for convenience.
+                  type: boolean
+                escapedSlashesAction:
+                  description: |-
+                    EscapedSlashesAction determines how %2f, %2F, %5c, or %5C sequences in the path URI
+                    should be handled.
+                    The default is UnescapeAndRedirect.
+                  enum:
+                  - KeepUnchanged
+                  - RejectRequest
+                  - UnescapeAndForward
+                  - UnescapeAndRedirect
+                  type: string
+              type: object
             targetRef:
-              description: TargetRef is the name of the Gateway resource this policy
-                is being attached to. This Policy and the TargetRef MUST be in the
-                same namespace for this Policy to have effect and be applied to the
-                Gateway. TargetRef
+              description: |-
+                TargetRef is the name of the resource this policy is being attached to.
+                This policy and the TargetRef MUST be in the same namespace for this
+                Policy to have effect
+
+
+                Deprecated: use targetRefs/targetSelectors instead
               properties:
                 group:
                   description: Group is the group of the target resource.
@@ -88,24 +372,21 @@ spec:
                   maxLength: 253
                   minLength: 1
                   type: string
-                namespace:
-                  description: Namespace is the namespace of the referent. When unspecified,
-                    the local namespace is inferred. Even when policy targets a resource
-                    in a different namespace, it MUST only apply to traffic originating
-                    from the same namespace as the policy.
-                  maxLength: 63
-                  minLength: 1
-                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                  type: string
                 sectionName:
-                  description: "SectionName is the name of a section within the target
-                    resource. When unspecified, this targetRef targets the entire
-                    resource. In the following resources, SectionName is interpreted
-                    as the following: \n * Gateway: Listener Name * Service: Port
-                    Name \n If a SectionName is specified, but does not exist on the
-                    targeted object, the Policy must fail to attach, and the policy
-                    implementation should record a `ResolvedRefs` or similar Condition
-                    in the Policy's status."
+                  description: |-
+                    SectionName is the name of a section within the target resource. When
+                    unspecified, this targetRef targets the entire resource. In the following
+                    resources, SectionName is interpreted as the following:
+
+
+                    * Gateway: Listener name
+                    * HTTPRoute: HTTPRouteRule name
+                    * Service: Port name
+
+
+                    If a SectionName is specified, but does not exist on the targeted object,
+                    the Policy must fail to attach, and the policy implementation should record
+                    a `ResolvedRefs` or similar Condition in the Policy's status.
                   maxLength: 253
                   minLength: 1
                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -115,37 +396,345 @@ spec:
               - kind
               - name
               type: object
-              x-kubernetes-validations:
-              - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
-                rule: self.group == 'gateway.networking.k8s.io'
-              - message: this policy can only have a targetRef.kind of Gateway
-                rule: self.kind == 'Gateway'
-              - message: this policy does not yet support the sectionName field
-                rule: '!has(self.sectionName)'
+            targetRefs:
+              description: |-
+                TargetRefs are the names of the Gateway resources this policy
+                is being attached to.
+              items:
+                description: |-
+                  LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                  direct policy to. This should be used as part of Policy resources that can
+                  target single resources. For more information on how this policy attachment
+                  mode works, and a sample Policy resource, refer to the policy attachment
+                  documentation for Gateway API.
+
+
+                  Note: This should only be used for direct policy attachment when references
+                  to SectionName are actually needed. In all other cases,
+                  LocalPolicyTargetReference should be used.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              type: array
+            targetSelectors:
+              description: TargetSelectors allow targeting resources for this policy
+                based on labels
+              items:
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: Group is the group that this selector targets. Defaults
+                      to gateway.networking.k8s.io
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is the resource kind that this selector targets.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: MatchLabels are the set of label selectors for identifying
+                      the targeted resource
+                    type: object
+                required:
+                - kind
+                - matchLabels
+                type: object
+                x-kubernetes-validations:
+                - message: group must be gateway.networking.k8s.io
+                  rule: 'has(self.group) ? self.group == ''gateway.networking.k8s.io''
+                    : true '
+              type: array
             tcpKeepalive:
-              description: TcpKeepalive settings associated with the downstream client
-                connection. If defined, sets SO_KEEPALIVE on the listener socket to
-                enable TCP Keepalives. Disabled by default.
+              description: |-
+                TcpKeepalive settings associated with the downstream client connection.
+                If defined, sets SO_KEEPALIVE on the listener socket to enable TCP Keepalives.
+                Disabled by default.
               properties:
                 idleTime:
-                  description: The duration a connection needs to be idle before keep-alive
-                    probes start being sent. The duration format is Defaults to `7200s`.
+                  description: |-
+                    The duration a connection needs to be idle before keep-alive
+                    probes start being sent.
+                    The duration format is
+                    Defaults to `7200s`.
                   pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                   type: string
                 interval:
-                  description: The duration between keep-alive probes. Defaults to
-                    `75s`.
+                  description: |-
+                    The duration between keep-alive probes.
+                    Defaults to `75s`.
                   pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                   type: string
                 probes:
-                  description: The total number of unacknowledged probes to send before
-                    deciding the connection is dead. Defaults to 9.
+                  description: |-
+                    The total number of unacknowledged probes to send before deciding
+                    the connection is dead.
+                    Defaults to 9.
                   format: int32
                   type: integer
               type: object
-          required:
-          - targetRef
+            timeout:
+              description: Timeout settings for the client connections.
+              properties:
+                http:
+                  description: Timeout settings for HTTP.
+                  properties:
+                    idleTimeout:
+                      description: |-
+                        IdleTimeout for an HTTP connection. Idle time is defined as a period in which there are no active requests in the connection.
+                        Default: 1 hour.
+                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                      type: string
+                    requestReceivedTimeout:
+                      description: |-
+                        RequestReceivedTimeout is the duration envoy waits for the complete request reception. This timer starts upon request
+                        initiation and stops when either the last byte of the request is sent upstream or when the response begins.
+                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                      type: string
+                  type: object
+                tcp:
+                  description: Timeout settings for TCP.
+                  properties:
+                    idleTimeout:
+                      description: |-
+                        IdleTimeout for a TCP connection. Idle time is defined as a period in which there are no
+                        bytes sent or received on either the upstream or downstream connection.
+                        Default: 1 hour.
+                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                      type: string
+                  type: object
+              type: object
+            tls:
+              description: TLS settings configure TLS termination settings with the
+                downstream client.
+              properties:
+                alpnProtocols:
+                  description: |-
+                    ALPNProtocols supplies the list of ALPN protocols that should be
+                    exposed by the listener. By default h2 and http/1.1 are enabled.
+                    Supported values are:
+                    - http/1.0
+                    - http/1.1
+                    - h2
+                  items:
+                    description: ALPNProtocol specifies the protocol to be negotiated
+                      using ALPN
+                    enum:
+                    - http/1.0
+                    - http/1.1
+                    - h2
+                    type: string
+                  type: array
+                ciphers:
+                  description: |-
+                    Ciphers specifies the set of cipher suites supported when
+                    negotiating TLS 1.0 - 1.2. This setting has no effect for TLS 1.3.
+                    In non-FIPS Envoy Proxy builds the default cipher list is:
+                    - [ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]
+                    - [ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]
+                    - ECDHE-ECDSA-AES256-GCM-SHA384
+                    - ECDHE-RSA-AES256-GCM-SHA384
+                    In builds using BoringSSL FIPS the default cipher list is:
+                    - ECDHE-ECDSA-AES128-GCM-SHA256
+                    - ECDHE-RSA-AES128-GCM-SHA256
+                    - ECDHE-ECDSA-AES256-GCM-SHA384
+                    - ECDHE-RSA-AES256-GCM-SHA384
+                  items:
+                    type: string
+                  type: array
+                clientValidation:
+                  description: |-
+                    ClientValidation specifies the configuration to validate the client
+                    initiating the TLS connection to the Gateway listener.
+                  properties:
+                    caCertificateRefs:
+                      description: |-
+                        CACertificateRefs contains one or more references to
+                        Kubernetes objects that contain TLS certificates of
+                        the Certificate Authorities that can be used
+                        as a trust anchor to validate the certificates presented by the client.
+
+
+                        A single reference to a Kubernetes ConfigMap or a Kubernetes Secret,
+                        with the CA certificate in a key named `ca.crt` is currently supported.
+
+
+                        References to a resource in different namespace are invalid UNLESS there
+                        is a ReferenceGrant in the target namespace that allows the certificate
+                        to be attached.
+                      items:
+                        description: |-
+                          SecretObjectReference identifies an API object including its namespace,
+                          defaulting to Secret.
+
+
+                          The API object must be valid in the cluster; the Group and Kind must
+                          be registered in the cluster for this reference to be valid.
+
+
+                          References to objects with invalid Group and Kind are not valid, and must
+                          be rejected by the implementation, with appropriate Conditions set
+                          on the containing object.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Secret
+                            description: Kind is kind of the referent. For example
+                              "Secret".
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the referenced object. When unspecified, the local
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      maxItems: 8
+                      type: array
+                    optional:
+                      description: |-
+                        Optional set to true accepts connections even when a client doesn't present a certificate.
+                        Defaults to false, which rejects connections without a valid client certificate.
+                      type: boolean
+                  type: object
+                ecdhCurves:
+                  description: |-
+                    ECDHCurves specifies the set of supported ECDH curves.
+                    In non-FIPS Envoy Proxy builds the default curves are:
+                    - X25519
+                    - P-256
+                    In builds using BoringSSL FIPS the default curve is:
+                    - P-256
+                  items:
+                    type: string
+                  type: array
+                maxVersion:
+                  description: |-
+                    Max specifies the maximal TLS protocol version to allow
+                    The default is TLS 1.3 if this is not specified.
+                  enum:
+                  - Auto
+                  - "1.0"
+                  - "1.1"
+                  - "1.2"
+                  - "1.3"
+                  type: string
+                minVersion:
+                  description: |-
+                    Min specifies the minimal TLS protocol version to allow.
+                    The default is TLS 1.2 if this is not specified.
+                  enum:
+                  - Auto
+                  - "1.0"
+                  - "1.1"
+                  - "1.2"
+                  - "1.3"
+                  type: string
+                signatureAlgorithms:
+                  description: |-
+                    SignatureAlgorithms specifies which signature algorithms the listener should
+                    support.
+                  items:
+                    type: string
+                  type: array
+              type: object
+              x-kubernetes-validations:
+              - message: setting ciphers has no effect if the minimum possible TLS
+                  version is 1.3
+                rule: 'has(self.minVersion) && self.minVersion == ''1.3'' ? !has(self.ciphers)
+                  : true'
+              - message: minVersion must be smaller or equal to maxVersion
+                rule: 'has(self.minVersion) && has(self.maxVersion) ? {"Auto":0,"1.0":1,"1.1":2,"1.2":3,"1.3":4}[self.minVersion]
+                  <= {"1.0":1,"1.1":2,"1.2":3,"1.3":4,"Auto":5}[self.maxVersion] :
+                  !has(self.minVersion) && has(self.maxVersion) ? 3 <= {"1.0":1,"1.1":2,"1.2":3,"1.3":4,"Auto":5}[self.maxVersion]
+                  : true'
           type: object
+          x-kubernetes-validations:
+          - message: either targetRef or targetRefs must be used
+            rule: '(has(self.targetRef) && !has(self.targetRefs)) || (!has(self.targetRef)
+              && has(self.targetRefs)) || (has(self.targetSelectors) && self.targetSelectors.size()
+              > 0) '
+          - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
+            rule: 'has(self.targetRef) ? self.targetRef.group == ''gateway.networking.k8s.io''
+              : true'
+          - message: this policy can only have a targetRef.kind of Gateway
+            rule: 'has(self.targetRef) ? self.targetRef.kind == ''Gateway'' : true'
+          - message: this policy can only have a targetRefs[*].group of gateway.networking.k8s.io
+            rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.group == ''gateway.networking.k8s.io'')
+              : true'
+          - message: this policy can only have a targetRefs[*].kind of Gateway
+            rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind == ''Gateway'')
+              : true'
       required:
       - spec
       type: object

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
@@ -1,0 +1,572 @@
+apiVersion: meta.k8s.appscode.com/v1alpha1
+kind: ResourceDescriptor
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.envoyproxy.io
+    k8s.io/kind: EnvoyExtensionPolicy
+    k8s.io/resource: envoyextensionpolicies
+    k8s.io/version: v1alpha1
+  name: gateway.envoyproxy.io-v1alpha1-envoyextensionpolicies
+spec:
+  resource:
+    group: gateway.envoyproxy.io
+    kind: EnvoyExtensionPolicy
+    name: envoyextensionpolicies
+    scope: Namespaced
+    version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      description: EnvoyExtensionPolicy allows the user to configure various envoy
+        extensibility options for the Gateway.
+      properties:
+        apiVersion:
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          type: string
+        kind:
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          properties:
+            name:
+              description: 'Name must be unique within a namespace. Is required when
+                creating resources, although some resources may allow a client to
+                request the generation of an appropriate name automatically. Name
+                is primarily intended for creation idempotence and configuration definition.
+                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: "Namespace defines the space within which each name must
+                be unique. An empty namespace is equivalent to the \"default\" namespace,
+                but \"default\" is the canonical representation. Not all objects are
+                required to be scoped to a namespace - the value of this field for
+                those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                More info: http://kubernetes.io/docs/user-guide/namespaces"
+              type: string
+            labels:
+              additionalProperties:
+                type: string
+              description: 'Map of string keys and values that can be used to organize
+                and categorize (scope and select) objects. May match selectors of
+                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            annotations:
+              additionalProperties:
+                type: string
+              description: 'Annotations is an unstructured key value map stored with
+                a resource that may be set by external tools to store and retrieve
+                arbitrary metadata. They are not queryable and should be preserved
+                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+          type: object
+        spec:
+          description: Spec defines the desired state of EnvoyExtensionPolicy.
+          properties:
+            extProc:
+              description: |-
+                ExtProc is an ordered list of external processing filters
+                that should added to the envoy filter chain
+              items:
+                description: ExtProc defines the configuration for External Processing
+                  filter.
+                properties:
+                  backendRefs:
+                    description: BackendRefs defines the configuration of the external
+                      processing service
+                    items:
+                      description: BackendRef defines how an ObjectReference that
+                        is specific to BackendRef.
+                      properties:
+                        group:
+                          default: ""
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Service
+                          description: |-
+                            Kind is the Kubernetes resource kind of the referent. For example
+                            "Service".
+
+
+                            Defaults to "Service" when not specified.
+
+
+                            ExternalName services can refer to CNAME DNS records that may live
+                            outside of the cluster and as such are difficult to reason about in
+                            terms of conformance. They also may not be safe to forward to (see
+                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                            support ExternalName Services.
+
+
+                            Support: Core (Services with a type other than ExternalName)
+
+
+                            Support: Implementation-specific (Services with type ExternalName)
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the backend. When unspecified, the local
+                            namespace is inferred.
+
+
+                            Note that when a namespace different than the local namespace is specified,
+                            a ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port specifies the destination port number to use for this resource.
+                            Port is required when the referent is a Kubernetes Service. In this
+                            case, the port number is the service port number, not the target port.
+                            For other resources, destination port might be derived from the referent
+                            resource or this field.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                      x-kubernetes-validations:
+                      - message: Must have port for Service reference
+                        rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                          ? has(self.port) : true'
+                    maxItems: 1
+                    minItems: 1
+                    type: array
+                    x-kubernetes-validations:
+                    - message: BackendRefs only supports Service and Backend kind.
+                      rule: self.all(f, f.kind == 'Service' || f.kind == 'Backend')
+                    - message: BackendRefs only supports Core and gateway.envoyproxy.io
+                        group.
+                      rule: self.all(f, f.group == '' || f.group == 'gateway.envoyproxy.io')
+                  failOpen:
+                    description: |-
+                      FailOpen defines if requests or responses that cannot be processed due to connectivity to the
+                      external processor are terminated or passed-through.
+                      Default: false
+                    type: boolean
+                  messageTimeout:
+                    description: |-
+                      MessageTimeout is the timeout for a response to be returned from the external processor
+                      Default: 200ms
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
+                  processingMode:
+                    description: |-
+                      ProcessingMode defines how request and response body is processed
+                      Default: header and body are not sent to the external processor
+                    properties:
+                      request:
+                        description: |-
+                          Defines processing mode for requests. If present, request headers are sent. Request body is processed according
+                          to the specified mode.
+                        properties:
+                          body:
+                            description: Defines body processing mode
+                            enum:
+                            - Streamed
+                            - Buffered
+                            - BufferedPartial
+                            type: string
+                        type: object
+                      response:
+                        description: |-
+                          Defines processing mode for responses. If present, response headers are sent. Response body is processed according
+                          to the specified mode.
+                        properties:
+                          body:
+                            description: Defines body processing mode
+                            enum:
+                            - Streamed
+                            - Buffered
+                            - BufferedPartial
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - backendRefs
+                type: object
+              maxItems: 16
+              type: array
+            targetRef:
+              description: |-
+                TargetRef is the name of the resource this policy is being attached to.
+                This policy and the TargetRef MUST be in the same namespace for this
+                Policy to have effect
+
+
+                Deprecated: use targetRefs/targetSelectors instead
+              properties:
+                group:
+                  description: Group is the group of the target resource.
+                  maxLength: 253
+                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                kind:
+                  description: Kind is kind of the target resource.
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                  type: string
+                name:
+                  description: Name is the name of the target resource.
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is the name of a section within the target resource. When
+                    unspecified, this targetRef targets the entire resource. In the following
+                    resources, SectionName is interpreted as the following:
+
+
+                    * Gateway: Listener name
+                    * HTTPRoute: HTTPRouteRule name
+                    * Service: Port name
+
+
+                    If a SectionName is specified, but does not exist on the targeted object,
+                    the Policy must fail to attach, and the policy implementation should record
+                    a `ResolvedRefs` or similar Condition in the Policy's status.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+              required:
+              - group
+              - kind
+              - name
+              type: object
+            targetRefs:
+              description: |-
+                TargetRefs are the names of the Gateway resources this policy
+                is being attached to.
+              items:
+                description: |-
+                  LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                  direct policy to. This should be used as part of Policy resources that can
+                  target single resources. For more information on how this policy attachment
+                  mode works, and a sample Policy resource, refer to the policy attachment
+                  documentation for Gateway API.
+
+
+                  Note: This should only be used for direct policy attachment when references
+                  to SectionName are actually needed. In all other cases,
+                  LocalPolicyTargetReference should be used.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              type: array
+            targetSelectors:
+              description: TargetSelectors allow targeting resources for this policy
+                based on labels
+              items:
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: Group is the group that this selector targets. Defaults
+                      to gateway.networking.k8s.io
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is the resource kind that this selector targets.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: MatchLabels are the set of label selectors for identifying
+                      the targeted resource
+                    type: object
+                required:
+                - kind
+                - matchLabels
+                type: object
+                x-kubernetes-validations:
+                - message: group must be gateway.networking.k8s.io
+                  rule: 'has(self.group) ? self.group == ''gateway.networking.k8s.io''
+                    : true '
+              type: array
+            wasm:
+              description: |-
+                Wasm is a list of Wasm extensions to be loaded by the Gateway.
+                Order matters, as the extensions will be loaded in the order they are
+                defined in this list.
+              items:
+                description: |-
+                  Wasm defines a Wasm extension.
+
+
+                  Note: at the moment, Envoy Gateway does not support configuring Wasm runtime.
+                  v8 is used as the VM runtime for the Wasm extensions.
+                properties:
+                  code:
+                    description: Code is the Wasm code for the extension.
+                    properties:
+                      http:
+                        description: |-
+                          HTTP is the HTTP URL containing the Wasm code.
+
+
+                          Note that the HTTP server must be accessible from the Envoy proxy.
+                        properties:
+                          sha256:
+                            description: |-
+                              SHA256 checksum that will be used to verify the Wasm code.
+
+
+                              If not specified, Envoy Gateway will not verify the downloaded Wasm code.
+                              kubebuilder:validation:Pattern=`^[a-f0-9]{64}$`
+                            type: string
+                          url:
+                            description: URL is the URL containing the Wasm code.
+                            pattern: ^((https?:)(\/\/\/?)([\w]*(?::[\w]*)?@)?([\d\w\.-]+)(?::(\d+))?)?([\/\\\w\.()-]*)?(?:([?][^#]*)?(#.*)?)*
+                            type: string
+                        required:
+                        - url
+                        type: object
+                      image:
+                        description: |-
+                          Image is the OCI image containing the Wasm code.
+
+
+                          Note that the image must be accessible from the Envoy Gateway.
+                        properties:
+                          pullSecretRef:
+                            description: |-
+                              PullSecretRef is a reference to the secret containing the credentials to pull the image.
+                              Only support Kubernetes Secret resource from the same namespace.
+                            properties:
+                              group:
+                                default: ""
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "Secret".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace is the namespace of the referenced object. When unspecified, the local
+                                  namespace is inferred.
+
+
+                                  Note that when a namespace different than the local namespace is specified,
+                                  a ReferenceGrant object is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the ReferenceGrant
+                                  documentation for details.
+
+
+                                  Support: Core
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-validations:
+                            - message: only support Secret kind.
+                              rule: self.kind == 'Secret'
+                          sha256:
+                            description: |-
+                              SHA256 checksum that will be used to verify the OCI image.
+
+
+                              It must match the digest of the OCI image.
+
+
+                              If not specified, Envoy Gateway will not verify the downloaded OCI image.
+                              kubebuilder:validation:Pattern=`^[a-f0-9]{64}$`
+                            type: string
+                          url:
+                            description: |-
+                              URL is the URL of the OCI image.
+                              URL can be in the format of `registry/image:tag` or `registry/image@sha256:digest`.
+                            type: string
+                        required:
+                        - url
+                        type: object
+                      pullPolicy:
+                        description: |-
+                          PullPolicy is the policy to use when pulling the Wasm module by either the HTTP or Image source.
+                          This field is only applicable when the SHA256 field is not set.
+
+
+                          If not specified, the default policy is IfNotPresent except for OCI images whose tag is latest.
+
+
+                          Note: EG does not update the Wasm module every time an Envoy proxy requests
+                          the Wasm module even if the pull policy is set to Always.
+                          It only updates the Wasm module when the EnvoyExtension resource version changes.
+                        enum:
+                        - IfNotPresent
+                        - Always
+                        type: string
+                      type:
+                        allOf:
+                        - enum:
+                          - HTTP
+                          - Image
+                        - enum:
+                          - HTTP
+                          - Image
+                          - ConfigMap
+                        description: |-
+                          Type is the type of the source of the Wasm code.
+                          Valid WasmCodeSourceType values are "HTTP" or "Image".
+                        type: string
+                    required:
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: If type is HTTP, http field needs to be set.
+                      rule: 'self.type == ''HTTP'' ? has(self.http) : !has(self.http)'
+                    - message: If type is Image, image field needs to be set.
+                      rule: 'self.type == ''Image'' ? has(self.image) : !has(self.image)'
+                  config:
+                    description: |-
+                      Config is the configuration for the Wasm extension.
+                      This configuration will be passed as a JSON string to the Wasm extension.
+                    x-kubernetes-preserve-unknown-fields: true
+                  failOpen:
+                    default: false
+                    description: |-
+                      FailOpen is a switch used to control the behavior when a fatal error occurs
+                      during the initialization or the execution of the Wasm extension.
+                      If FailOpen is set to true, the system bypasses the Wasm extension and
+                      allows the traffic to pass through. Otherwise, if it is set to false or
+                      not set (defaulting to false), the system blocks the traffic and returns
+                      an HTTP 5xx error.
+                    type: boolean
+                  name:
+                    description: |-
+                      Name is a unique name for this Wasm extension. It is used to identify the
+                      Wasm extension if multiple extensions are handled by the same vm_id and root_id.
+                      It's also used for logging/debugging.
+                      If not specified, EG will generate a unique name for the Wasm extension.
+                    type: string
+                  rootID:
+                    description: |-
+                      RootID is a unique ID for a set of extensions in a VM which will share a
+                      RootContext and Contexts if applicable (e.g., an Wasm HttpFilter and an Wasm AccessLog).
+                      If left blank, all extensions with a blank root_id with the same vm_id will share Context(s).
+
+
+                      Note: RootID must match the root_id parameter used to register the Context in the Wasm code.
+                    type: string
+                required:
+                - code
+                type: object
+              maxItems: 16
+              type: array
+          type: object
+          x-kubernetes-validations:
+          - message: either targetRef or targetRefs must be used
+            rule: '(has(self.targetRef) && !has(self.targetRefs)) || (!has(self.targetRef)
+              && has(self.targetRefs)) || (has(self.targetSelectors) && self.targetSelectors.size()
+              > 0) '
+          - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
+            rule: 'has(self.targetRef) ? self.targetRef.group == ''gateway.networking.k8s.io''
+              : true'
+          - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
+            rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''HTTPRoute'',
+              ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''] : true'
+          - message: this policy does not yet support the sectionName field
+            rule: 'has(self.targetRef) ? !has(self.targetRef.sectionName) : true'
+          - message: this policy can only have a targetRefs[*].group of gateway.networking.k8s.io
+            rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.group == ''gateway.networking.k8s.io'')
+              : true '
+          - message: this policy can only have a targetRefs[*].kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
+            rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind in [''Gateway'',
+              ''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''])
+              : true '
+          - message: this policy does not yet support the sectionName field
+            rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, !has(ref.sectionName))
+              : true'
+      required:
+      - spec
+      type: object

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/envoypatchpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/envoypatchpolicies.yaml
@@ -17,18 +17,24 @@ spec:
     version: v1alpha1
   validation:
     openAPIV3Schema:
-      description: EnvoyPatchPolicy allows the user to modify the generated Envoy
-        xDS resources by Envoy Gateway using this patch API
+      description: |-
+        EnvoyPatchPolicy allows the user to modify the generated Envoy xDS
+        resources by Envoy Gateway using this patch API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -69,8 +75,9 @@ spec:
             jsonPatches:
               description: JSONPatch defines the JSONPatch configuration.
               items:
-                description: EnvoyJSONPatchConfig defines the configuration for patching
-                  a Envoy xDS Resource using JSONPatch semantic
+                description: |-
+                  EnvoyJSONPatchConfig defines the configuration for patching a Envoy xDS Resource
+                  using JSONPatch semantic
                 properties:
                   name:
                     description: Name is the name of the resource
@@ -78,6 +85,12 @@ spec:
                   operation:
                     description: Patch defines the JSON Patch Operation
                     properties:
+                      from:
+                        description: |-
+                          From is the source location of the value to be copied or moved. Only valid
+                          for move or copy operations
+                          Refer to https://datatracker.ietf.org/doc/html/rfc6901 for more details.
+                        type: string
                       op:
                         description: Op is the type of operation to perform
                         enum:
@@ -89,17 +102,18 @@ spec:
                         - test
                         type: string
                       path:
-                        description: Path is the location of the target document/field
-                          where the operation will be performed Refer to https://datatracker.ietf.org/doc/html/rfc6901
-                          for more details.
+                        description: |-
+                          Path is the location of the target document/field where the operation will be performed
+                          Refer to https://datatracker.ietf.org/doc/html/rfc6901 for more details.
                         type: string
                       value:
-                        description: Value is the new value of the path location.
+                        description: |-
+                          Value is the new value of the path location. The value is only used by
+                          the `add` and `replace` operations.
                         x-kubernetes-preserve-unknown-fields: true
                     required:
                     - op
                     - path
-                    - value
                     type: object
                   type:
                     description: Type is the typed URL of the Envoy xDS Resource
@@ -108,6 +122,7 @@ spec:
                     - type.googleapis.com/envoy.config.route.v3.RouteConfiguration
                     - type.googleapis.com/envoy.config.cluster.v3.Cluster
                     - type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+                    - type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
                     type: string
                 required:
                 - name
@@ -116,17 +131,24 @@ spec:
                 type: object
               type: array
             priority:
-              description: Priority of the EnvoyPatchPolicy. If multiple EnvoyPatchPolicies
-                are applied to the same TargetRef, they will be applied in the ascending
-                order of the priority i.e. int32.min has the highest priority and
-                int32.max has the lowest priority. Defaults to 0.
+              description: |-
+                Priority of the EnvoyPatchPolicy.
+                If multiple EnvoyPatchPolicies are applied to the same
+                TargetRef, they will be applied in the ascending order of
+                the priority i.e. int32.min has the highest priority and
+                int32.max has the lowest priority.
+                Defaults to 0.
               format: int32
               type: integer
             targetRef:
-              description: TargetRef is the name of the Gateway API resource this
-                policy is being attached to. Currently only attaching to Gateway is
-                supported This Policy and the TargetRef MUST be in the same namespace
-                for this Policy to have effect and be applied to the Gateway TargetRef
+              description: |-
+                TargetRef is the name of the Gateway API resource this policy
+                is being attached to.
+                By default, attaching to Gateway is supported and
+                when mergeGateways is enabled it should attach to GatewayClass.
+                This Policy and the TargetRef MUST be in the same namespace
+                for this Policy to have effect and be applied to the Gateway
+                TargetRef
               properties:
                 group:
                   description: Group is the group of the target resource.
@@ -144,23 +166,15 @@ spec:
                   maxLength: 253
                   minLength: 1
                   type: string
-                namespace:
-                  description: Namespace is the namespace of the referent. When unspecified,
-                    the local namespace is inferred. Even when policy targets a resource
-                    in a different namespace, it MUST only apply to traffic originating
-                    from the same namespace as the policy.
-                  maxLength: 63
-                  minLength: 1
-                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                  type: string
               required:
               - group
               - kind
               - name
               type: object
             type:
-              description: Type decides the type of patch. Valid EnvoyPatchType values
-                are "JSONPatch".
+              description: |-
+                Type decides the type of patch.
+                Valid EnvoyPatchType values are "JSONPatch".
               enum:
               - JSONPatch
               type: string

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
@@ -20,14 +20,19 @@ spec:
       description: EnvoyProxy is the schema for the envoyproxies API.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -65,26 +70,161 @@ spec:
         spec:
           description: EnvoyProxySpec defines the desired state of EnvoyProxy.
           properties:
+            backendTLS:
+              description: |-
+                BackendTLS is the TLS configuration for the Envoy proxy to use when connecting to backends.
+                These settings are applied on backends for which TLS policies are specified.
+              properties:
+                alpnProtocols:
+                  description: |-
+                    ALPNProtocols supplies the list of ALPN protocols that should be
+                    exposed by the listener. By default h2 and http/1.1 are enabled.
+                    Supported values are:
+                    - http/1.0
+                    - http/1.1
+                    - h2
+                  items:
+                    description: ALPNProtocol specifies the protocol to be negotiated
+                      using ALPN
+                    enum:
+                    - http/1.0
+                    - http/1.1
+                    - h2
+                    type: string
+                  type: array
+                ciphers:
+                  description: |-
+                    Ciphers specifies the set of cipher suites supported when
+                    negotiating TLS 1.0 - 1.2. This setting has no effect for TLS 1.3.
+                    In non-FIPS Envoy Proxy builds the default cipher list is:
+                    - [ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]
+                    - [ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]
+                    - ECDHE-ECDSA-AES256-GCM-SHA384
+                    - ECDHE-RSA-AES256-GCM-SHA384
+                    In builds using BoringSSL FIPS the default cipher list is:
+                    - ECDHE-ECDSA-AES128-GCM-SHA256
+                    - ECDHE-RSA-AES128-GCM-SHA256
+                    - ECDHE-ECDSA-AES256-GCM-SHA384
+                    - ECDHE-RSA-AES256-GCM-SHA384
+                  items:
+                    type: string
+                  type: array
+                clientCertificateRef:
+                  description: |-
+                    ClientCertificateRef defines the reference to a Kubernetes Secret that contains
+                    the client certificate and private key for Envoy to use when connecting to
+                    backend services and external services, such as ExtAuth, ALS, OpenTelemetry, etc.
+                    This secret should be located within the same namespace as the Envoy proxy resource that references it.
+                  properties:
+                    group:
+                      default: ""
+                      description: |-
+                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                        When unspecified or empty string, core API group is inferred.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Secret
+                      description: Kind is kind of the referent. For example "Secret".
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referenced object. When unspecified, the local
+                        namespace is inferred.
+
+
+                        Note that when a namespace different than the local namespace is specified,
+                        a ReferenceGrant object is required in the referent namespace to allow that
+                        namespace's owner to accept the reference. See the ReferenceGrant
+                        documentation for details.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                ecdhCurves:
+                  description: |-
+                    ECDHCurves specifies the set of supported ECDH curves.
+                    In non-FIPS Envoy Proxy builds the default curves are:
+                    - X25519
+                    - P-256
+                    In builds using BoringSSL FIPS the default curve is:
+                    - P-256
+                  items:
+                    type: string
+                  type: array
+                maxVersion:
+                  description: |-
+                    Max specifies the maximal TLS protocol version to allow
+                    The default is TLS 1.3 if this is not specified.
+                  enum:
+                  - Auto
+                  - "1.0"
+                  - "1.1"
+                  - "1.2"
+                  - "1.3"
+                  type: string
+                minVersion:
+                  description: |-
+                    Min specifies the minimal TLS protocol version to allow.
+                    The default is TLS 1.2 if this is not specified.
+                  enum:
+                  - Auto
+                  - "1.0"
+                  - "1.1"
+                  - "1.2"
+                  - "1.3"
+                  type: string
+                signatureAlgorithms:
+                  description: |-
+                    SignatureAlgorithms specifies which signature algorithms the listener should
+                    support.
+                  items:
+                    type: string
+                  type: array
+              type: object
+              x-kubernetes-validations:
+              - message: setting ciphers has no effect if the minimum possible TLS
+                  version is 1.3
+                rule: 'has(self.minVersion) && self.minVersion == ''1.3'' ? !has(self.ciphers)
+                  : true'
+              - message: minVersion must be smaller or equal to maxVersion
+                rule: 'has(self.minVersion) && has(self.maxVersion) ? {"Auto":0,"1.0":1,"1.1":2,"1.2":3,"1.3":4}[self.minVersion]
+                  <= {"1.0":1,"1.1":2,"1.2":3,"1.3":4,"Auto":5}[self.maxVersion] :
+                  !has(self.minVersion) && has(self.maxVersion) ? 3 <= {"1.0":1,"1.1":2,"1.2":3,"1.3":4,"Auto":5}[self.maxVersion]
+                  : true'
             bootstrap:
-              description: Bootstrap defines the Envoy Bootstrap as a YAML string.
+              description: |-
+                Bootstrap defines the Envoy Bootstrap as a YAML string.
                 Visit https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/bootstrap/v3/bootstrap.proto#envoy-v3-api-msg-config-bootstrap-v3-bootstrap
-                to learn more about the syntax. If set, this is the Bootstrap configuration
-                used for the managed Envoy Proxy fleet instead of the default Bootstrap
-                configuration set by Envoy Gateway. Some fields within the Bootstrap
-                that are required to communicate with the xDS Server (Envoy Gateway)
-                and receive xDS resources from it are not configurable and will result
-                in the `EnvoyProxy` resource being rejected. Backward compatibility
-                across minor versions is not guaranteed. We strongly recommend using
-                `egctl x translate` to generate a `EnvoyProxy` resource with the `Bootstrap`
-                field set to the default Bootstrap configuration used. You can edit
-                this configuration, and rerun `egctl x translate` to ensure there
-                are no validation errors.
+                to learn more about the syntax.
+                If set, this is the Bootstrap configuration used for the managed Envoy Proxy fleet instead of the default Bootstrap configuration
+                set by Envoy Gateway.
+                Some fields within the Bootstrap that are required to communicate with the xDS Server (Envoy Gateway) and receive xDS resources
+                from it are not configurable and will result in the `EnvoyProxy` resource being rejected.
+                Backward compatibility across minor versions is not guaranteed.
+                We strongly recommend using `egctl x translate` to generate a `EnvoyProxy` resource with the `Bootstrap` field set to the default
+                Bootstrap configuration used. You can edit this configuration, and rerun `egctl x translate` to ensure there are no validation errors.
               properties:
                 type:
                   default: Replace
-                  description: Type is the type of the bootstrap configuration, it
-                    should be either Replace or Merge. If unspecified, it defaults
-                    to Replace.
+                  description: |-
+                    Type is the type of the bootstrap configuration, it should be either Replace or Merge.
+                    If unspecified, it defaults to Replace.
                   enum:
                   - Merge
                   - Replace
@@ -96,10 +236,124 @@ spec:
               - value
               type: object
             concurrency:
-              description: Concurrency defines the number of worker threads to run.
-                If unset, it defaults to the number of cpuset threads on the platform.
+              description: |-
+                Concurrency defines the number of worker threads to run. If unset, it defaults to
+                the number of cpuset threads on the platform.
               format: int32
               type: integer
+            extraArgs:
+              description: |-
+                ExtraArgs defines additional command line options that are provided to Envoy.
+                More info: https://www.envoyproxy.io/docs/envoy/latest/operations/cli#command-line-options
+                Note: some command line options are used internally(e.g. --log-level) so they cannot be provided here.
+              items:
+                type: string
+              type: array
+            filterOrder:
+              description: |-
+                FilterOrder defines the order of filters in the Envoy proxy's HTTP filter chain.
+                The FilterPosition in the list will be applied in the order they are defined.
+                If unspecified, the default filter order is applied.
+                Default filter order is:
+
+
+                - envoy.filters.http.fault
+
+
+                - envoy.filters.http.cors
+
+
+                - envoy.filters.http.ext_authz
+
+
+                - envoy.filters.http.basic_authn
+
+
+                - envoy.filters.http.oauth2
+
+
+                - envoy.filters.http.jwt_authn
+
+
+                - envoy.filters.http.ext_proc
+
+
+                - envoy.filters.http.wasm
+
+
+                - envoy.filters.http.rbac
+
+
+                - envoy.filters.http.local_ratelimit
+
+
+                - envoy.filters.http.ratelimit
+
+
+                - envoy.filters.http.router
+              items:
+                description: FilterPosition defines the position of an Envoy HTTP
+                  filter in the filter chain.
+                properties:
+                  after:
+                    description: |-
+                      After defines the filter that should come after the filter.
+                      Only one of Before or After must be set.
+                    enum:
+                    - envoy.filters.http.cors
+                    - envoy.filters.http.ext_authz
+                    - envoy.filters.http.basic_authn
+                    - envoy.filters.http.oauth2
+                    - envoy.filters.http.jwt_authn
+                    - envoy.filters.http.fault
+                    - envoy.filters.http.local_ratelimit
+                    - envoy.filters.http.ratelimit
+                    - envoy.filters.http.wasm
+                    - envoy.filters.http.ext_proc
+                    - envoy.filters.http.rbac
+                    type: string
+                  before:
+                    description: |-
+                      Before defines the filter that should come before the filter.
+                      Only one of Before or After must be set.
+                    enum:
+                    - envoy.filters.http.cors
+                    - envoy.filters.http.ext_authz
+                    - envoy.filters.http.basic_authn
+                    - envoy.filters.http.oauth2
+                    - envoy.filters.http.jwt_authn
+                    - envoy.filters.http.fault
+                    - envoy.filters.http.local_ratelimit
+                    - envoy.filters.http.ratelimit
+                    - envoy.filters.http.wasm
+                    - envoy.filters.http.ext_proc
+                    - envoy.filters.http.rbac
+                    type: string
+                  name:
+                    description: Name of the filter.
+                    enum:
+                    - envoy.filters.http.cors
+                    - envoy.filters.http.ext_authz
+                    - envoy.filters.http.basic_authn
+                    - envoy.filters.http.oauth2
+                    - envoy.filters.http.jwt_authn
+                    - envoy.filters.http.fault
+                    - envoy.filters.http.local_ratelimit
+                    - envoy.filters.http.ratelimit
+                    - envoy.filters.http.wasm
+                    - envoy.filters.http.ext_proc
+                    - envoy.filters.http.rbac
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: one of before or after must be specified
+                  rule: (has(self.before) || has(self.after))
+                - message: only one of before or after can be specified
+                  rule: (has(self.before) && !has(self.after)) || (!has(self.before)
+                    && has(self.after))
+              type: array
             logging:
               default:
                 level:
@@ -118,36 +372,35 @@ spec:
                     type: string
                   default:
                     default: warn
-                  description: 'Level is a map of logging level per component, where
-                    the component is the key and the log level is the value. If unspecified,
-                    defaults to "default: warn".'
+                  description: |-
+                    Level is a map of logging level per component, where the component is the key
+                    and the log level is the value. If unspecified, defaults to "default: warn".
                   type: object
               type: object
             mergeGateways:
-              description: MergeGateways defines if Gateway resources should be merged
-                onto the same Envoy Proxy Infrastructure. Setting this field to true
-                would merge all Gateway Listeners under the parent Gateway Class.
-                This means that the port, protocol and hostname tuple must be unique
-                for every listener. If a duplicate listener is detected, the newer
-                listener (based on timestamp) will be rejected and its status will
-                be updated with a "Accepted=False" condition.
+              description: |-
+                MergeGateways defines if Gateway resources should be merged onto the same Envoy Proxy Infrastructure.
+                Setting this field to true would merge all Gateway Listeners under the parent Gateway Class.
+                This means that the port, protocol and hostname tuple must be unique for every listener.
+                If a duplicate listener is detected, the newer listener (based on timestamp) will be rejected and its status will be updated with a "Accepted=False" condition.
               type: boolean
             provider:
-              description: Provider defines the desired resource provider and provider-specific
-                configuration. If unspecified, the "Kubernetes" resource provider
-                is used with default configuration parameters.
+              description: |-
+                Provider defines the desired resource provider and provider-specific configuration.
+                If unspecified, the "Kubernetes" resource provider is used with default configuration
+                parameters.
               properties:
                 kubernetes:
-                  description: Kubernetes defines the desired state of the Kubernetes
-                    resource provider. Kubernetes provides infrastructure resources
-                    for running the data plane, e.g. Envoy proxy. If unspecified and
-                    type is "Kubernetes", default settings for managed Kubernetes
-                    resources are applied.
+                  description: |-
+                    Kubernetes defines the desired state of the Kubernetes resource provider.
+                    Kubernetes provides infrastructure resources for running the data plane,
+                    e.g. Envoy proxy. If unspecified and type is "Kubernetes", default settings
+                    for managed Kubernetes resources are applied.
                   properties:
-                    envoyDeployment:
-                      description: EnvoyDeployment defines the desired state of the
-                        Envoy deployment resource. If unspecified, default settings
-                        for the managed Envoy deployment resource are applied.
+                    envoyDaemonSet:
+                      description: |-
+                        EnvoyDaemonSet defines the desired state of the Envoy daemonset resource.
+                        Disabled by default, a deployment resource is used instead to provision the Envoy Proxy fleet
                       properties:
                         container:
                           description: Container defines the desired specification
@@ -165,17 +418,16 @@ spec:
                                       Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previously defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Defaults
-                                      to "".'
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -188,10 +440,15 @@ spec:
                                             description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -202,11 +459,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
-                                        description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                         properties:
                                           apiVersion:
                                             description: Version of the schema the
@@ -222,11 +477,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -258,10 +511,15 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -281,25 +539,30 @@ spec:
                                 image to be used, instead of the default image.
                               type: string
                             resources:
-                              description: 'Resources required by this container.
-                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Resources required by this container.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources,
-                                    defined in spec.resourceClaims, that are used
-                                    by this container. \n This is an alpha field and
-                                    requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable. It can
-                                    only be set for containers."
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one
-                                          entry in pod.spec.resourceClaims of the
-                                          Pod where this field is used. It makes that
-                                          resource available inside a container.
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                     required:
                                     - name
@@ -315,8 +578,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -325,35 +589,58 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. Requests cannot
-                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             securityContext:
-                              description: 'SecurityContext defines the security options
-                                the container should be run with. If set, the fields
-                                of SecurityContext override the equivalent fields
-                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls
-                                    whether a process can gain more privileges than
-                                    its parent process. This bool directly controls
-                                    if the no_new_privs flag will be set on the container
-                                    process. AllowPrivilegeEscalation is true always
-                                    when the container is: 1) run as Privileged 2)
-                                    has CAP_SYS_ADMIN Note that this field cannot
-                                    be set when spec.os.name is windows.'
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
-                                  description: The capabilities to add/drop when running
-                                    containers. Defaults to the default set of capabilities
-                                    granted by the container runtime. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
                                       description: Added capabilities
@@ -362,6 +649,7 @@ spec:
                                           type
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       description: Removed capabilities
                                       items:
@@ -369,68 +657,63 @@ spec:
                                           type
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes
-                                    in privileged containers are essentially equivalent
-                                    to root on the host. Defaults to false. Note that
-                                    this field cannot be set when spec.os.name is
-                                    windows.
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc
-                                    mount to use for the containers. The default is
-                                    DefaultProcMount which uses the container runtime
-                                    defaults for readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to
-                                    be enabled. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only
-                                    root filesystem. Default is false. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    the container. If unspecified, the container runtime
-                                    will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -450,112 +733,3905 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by this
-                                    container. If seccomp options are provided at
-                                    both the pod & container level, the container
-                                    options override the pod options. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    from the PodSecurityContext will be used. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             volumeMounts:
-                              description: VolumeMounts are volumes to mount into
-                                the container's filesystem. Cannot be updated.
+                              description: |-
+                                VolumeMounts are volumes to mount into the container's filesystem.
+                                Cannot be updated.
                               items:
                                 description: VolumeMount describes a mounting of a
                                   Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which
-                                      the volume should be mounted.  Must not contain
-                                      ':'.
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts
-                                      are propagated from the host to container and
-                                      the other way around. When not set, MountPropagationNone
-                                      is used. This field is beta in 1.10.
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write
-                                      otherwise (false or unspecified). Defaults to
-                                      false.
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
                                   subPath:
-                                    description: Path within the volume from which
-                                      the container's volume should be mounted. Defaults
-                                      to "" (volume's root).
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from
-                                      which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment
-                                      variable references $(VAR_NAME) are expanded
-                                      using the container's environment. Defaults
-                                      to "" (volume's root). SubPathExpr and SubPath
-                                      are mutually exclusive.
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                          type: object
+                        name:
+                          description: |-
+                            Name of the daemonSet.
+                            When unset, this defaults to an autogenerated name.
+                          type: string
+                        patch:
+                          description: Patch defines how to perform the patch operation
+                            to daemonset
+                          properties:
+                            type:
+                              description: |-
+                                Type is the type of merge operation to perform
+
+
+                                By default, StrategicMerge is used as the patch type.
+                              type: string
+                            value:
+                              description: Object contains the raw configuration for
+                                merged object
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - value
+                          type: object
+                        pod:
+                          description: Pod defines the desired specification of pod.
+                          properties:
+                            affinity:
+                              description: If specified, the pod's scheduling constraints.
+                              properties:
+                                nodeAffinity:
+                                  description: Describes node affinity scheduling
+                                    rules for the pod.
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.),
+                                        compute a sum by iterating through the elements of this field and adding
+                                        "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                        node(s) with the highest sum are the most preferred.
+                                      items:
+                                        description: |-
+                                          An empty preferred scheduling term matches all objects with implicit weight 0
+                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                        properties:
+                                          preference:
+                                            description: A node selector term, associated
+                                              with the corresponding weight.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          weight:
+                                            description: Weight associated with matching
+                                              the corresponding nodeSelectorTerm,
+                                              in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - preference
+                                        - weight
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to an update), the system
+                                        may or may not try to eventually evict the pod from its node.
+                                      properties:
+                                        nodeSelectorTerms:
+                                          description: Required. A list of node selector
+                                            terms. The terms are ORed.
+                                          items:
+                                            description: |-
+                                              A null or empty node selector term matches no objects. The requirements of
+                                              them are ANDed.
+                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - nodeSelectorTerms
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                podAffinity:
+                                  description: Describes pod affinity scheduling rules
+                                    (e.g. co-locate this pod in the same node, zone,
+                                    etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.),
+                                        compute a sum by iterating through the elements of this field and adding
+                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                        node(s) with the highest sum are the most preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
+                                        When there are multiple elements, the lists of nodes corresponding to each
+                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                      items:
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          namespaceSelector:
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          topologyKey:
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                podAntiAffinity:
+                                  description: Describes pod anti-affinity scheduling
+                                    rules (e.g. avoid putting this pod in the same
+                                    node, zone, etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the anti-affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                        compute a sum by iterating through the elements of this field and adding
+                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                        node(s) with the highest sum are the most preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        If the anti-affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the anti-affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
+                                        When there are multiple elements, the lists of nodes corresponding to each
+                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                      items:
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          namespaceSelector:
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          topologyKey:
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                              type: object
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Annotations are the annotations that should be appended to the pods.
+                                By default, no pod annotations are appended.
+                              type: object
+                            imagePullSecrets:
+                              description: |-
+                                ImagePullSecrets is an optional list of references to secrets
+                                in the same namespace to use for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual puller implementations for them to use.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                              items:
+                                description: |-
+                                  LocalObjectReference contains enough information to let you locate the
+                                  referenced object inside the same namespace.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Labels are the additional labels that should be tagged to the pods.
+                                By default, no additional pod labels are tagged.
+                              type: object
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                NodeSelector is a selector which must be true for the pod to fit on a node.
+                                Selector which must match a node's labels for the pod to be scheduled on that node.
+                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                              type: object
+                            securityContext:
+                              description: |-
+                                SecurityContext holds pod-level security attributes and common container settings.
+                                Optional: Defaults to empty.  See type description for default values of each field.
+                              properties:
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                fsGroup:
+                                  description: |-
+                                    A special supplemental group that applies to all containers in a pod.
+                                    Some volume types allow the Kubelet to change the ownership of that volume
+                                    to be owned by the pod:
+
+
+                                    1. The owning GID will be the FSGroup
+                                    2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                    3. The permission bits are OR'd with rw-rw----
+
+
+                                    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                fsGroupChangePolicy:
+                                  description: |-
+                                    fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will only apply to
+                                    volume types which support fsGroup based ownership(and permissions).
+                                    It will have no effect on ephemeral volume types such as: secret, configmaps
+                                    and emptydir.
+                                    Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: string
+                                runAsGroup:
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: |-
+                                    The SELinux context to be applied to all containers.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                    takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: |-
+                                    The seccomp options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                supplementalGroups:
+                                  description: |-
+                                    A list of groups applied to the first process run in each container, in addition
+                                    to the container's primary GID, the fsGroup (if specified), and group memberships
+                                    defined in the container image for the uid of the container process. If unspecified,
+                                    no additional groups are added to any container. Note that group memberships
+                                    defined in the container image for the uid of the container process are still effective,
+                                    even if they are not included in this list.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  items:
+                                    format: int64
+                                    type: integer
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                sysctls:
+                                  description: |-
+                                    Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                    sysctls (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  items:
+                                    description: Sysctl defines a kernel parameter
+                                      to be set
+                                    properties:
+                                      name:
+                                        description: Name of a property to set
+                                        type: string
+                                      value:
+                                        description: Value of a property to set
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                windowsOptions:
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            tolerations:
+                              description: If specified, the pod's tolerations.
+                              items:
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                            topologySpreadConstraints:
+                              description: |-
+                                TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                All topologySpreadConstraints are ANDed.
+                              items:
+                                description: TopologySpreadConstraint specifies how
+                                  to spread matching pods among the given topology.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is used to find matching pods.
+                                      Pods that match this label selector are counted to determine the number of pods
+                                      in their corresponding topology domain.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select the pods over which
+                                      spreading will be calculated. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are ANDed with labelSelector
+                                      to select the group of existing pods over which spreading will be calculated
+                                      for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                      MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      Keys that don't exist in the incoming pod labels will
+                                      be ignored. A null or empty list means only match against labelSelector.
+
+
+                                      This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  maxSkew:
+                                    description: |-
+                                      MaxSkew describes the degree to which pods may be unevenly distributed.
+                                      When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                      between the number of matching pods in the target topology and the global minimum.
+                                      The global minimum is the minimum number of matching pods in an eligible domain
+                                      or zero if the number of eligible domains is less than MinDomains.
+                                      For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                      labelSelector spread as 2/2/1:
+                                      In this case, the global minimum is 1.
+                                      | zone1 | zone2 | zone3 |
+                                      |  P P  |  P P  |   P   |
+                                      - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                      scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                      violate MaxSkew(1).
+                                      - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                      When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                      to topologies that satisfy it.
+                                      It's a required field. Default value is 1 and 0 is not allowed.
+                                    format: int32
+                                    type: integer
+                                  minDomains:
+                                    description: |-
+                                      MinDomains indicates a minimum number of eligible domains.
+                                      When the number of eligible domains with matching topology keys is less than minDomains,
+                                      Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                      And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                      this value has no effect on scheduling.
+                                      As a result, when the number of eligible domains is less than minDomains,
+                                      scheduler won't schedule more than maxSkew Pods to those domains.
+                                      If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                      Valid values are integers greater than 0.
+                                      When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                                      For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                      labelSelector spread as 2/2/2:
+                                      | zone1 | zone2 | zone3 |
+                                      |  P P  |  P P  |  P P  |
+                                      The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                      In this situation, new pod with the same labelSelector cannot be scheduled,
+                                      because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                      it will violate MaxSkew.
+                                    format: int32
+                                    type: integer
+                                  nodeAffinityPolicy:
+                                    description: |-
+                                      NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options are:
+                                      - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                      - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                      If this value is nil, the behavior is equivalent to the Honor policy.
+                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    description: |-
+                                      NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                      pod topology spread skew. Options are:
+                                      - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                      has a toleration, are included.
+                                      - Ignore: node taints are ignored. All nodes are included.
+
+
+                                      If this value is nil, the behavior is equivalent to the Ignore policy.
+                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                    type: string
+                                  topologyKey:
+                                    description: |-
+                                      TopologyKey is the key of node labels. Nodes that have a label with this key
+                                      and identical values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket", and try to put balanced number
+                                      of pods into each bucket.
+                                      We define a domain as a particular instance of a topology.
+                                      Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                      nodeAffinityPolicy and nodeTaintsPolicy.
+                                      e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                      And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                      It's a required field.
+                                    type: string
+                                  whenUnsatisfiable:
+                                    description: |-
+                                      WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                      the spread constraint.
+                                      - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                      - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                        but giving higher precedence to topologies that would help reduce the
+                                        skew.
+                                      A constraint is considered "Unsatisfiable" for an incoming pod
+                                      if and only if every possible node assignment for that pod would violate
+                                      "MaxSkew" on some topology.
+                                      For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                      labelSelector spread as 3/1/1:
+                                      | zone1 | zone2 | zone3 |
+                                      | P P P |   P   |   P   |
+                                      If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                      to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                      MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                      won't make it *more* imbalanced.
+                                      It's a required field.
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
+                                type: object
+                              type: array
+                            volumes:
+                              description: |-
+                                Volumes that can be mounted by containers belonging to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes
+                              items:
+                                description: Volume represents a named volume in a
+                                  pod that may be accessed by any container in the
+                                  pod.
+                                properties:
+                                  awsElasticBlockStore:
+                                    description: |-
+                                      awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
+                                        type: string
+                                      partition:
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        description: |-
+                                          readOnly value true will force the readOnly setting in VolumeMounts.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                        type: boolean
+                                      volumeID:
+                                        description: |-
+                                          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  azureDisk:
+                                    description: azureDisk represents an Azure Data
+                                      Disk mount on the host and bind mount to the
+                                      pod.
+                                    properties:
+                                      cachingMode:
+                                        description: 'cachingMode is the Host Caching
+                                          mode: None, Read Only, Read Write.'
+                                        type: string
+                                      diskName:
+                                        description: diskName is the Name of the data
+                                          disk in the blob storage
+                                        type: string
+                                      diskURI:
+                                        description: diskURI is the URI of data disk
+                                          in the blob storage
+                                        type: string
+                                      fsType:
+                                        description: |-
+                                          fsType is Filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      kind:
+                                        description: 'kind expected values are Shared:
+                                          multiple blob disks per storage account  Dedicated:
+                                          single blob disk per storage account  Managed:
+                                          azure managed data disk (only in managed
+                                          availability set). defaults to shared'
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                    required:
+                                    - diskName
+                                    - diskURI
+                                    type: object
+                                  azureFile:
+                                    description: azureFile represents an Azure File
+                                      Service mount on the host and bind mount to
+                                      the pod.
+                                    properties:
+                                      readOnly:
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      secretName:
+                                        description: secretName is the  name of secret
+                                          that contains Azure Storage Account Name
+                                          and Key
+                                        type: string
+                                      shareName:
+                                        description: shareName is the azure share
+                                          Name
+                                        type: string
+                                    required:
+                                    - secretName
+                                    - shareName
+                                    type: object
+                                  cephfs:
+                                    description: cephFS represents a Ceph FS mount
+                                      on the host that shares a pod's lifetime
+                                    properties:
+                                      monitors:
+                                        description: |-
+                                          monitors is Required: Monitors is a collection of Ceph monitors
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: 'path is Optional: Used as the
+                                          mounted root, rather than the full Ceph
+                                          tree, default is /'
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                        type: boolean
+                                      secretFile:
+                                        description: |-
+                                          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                        type: string
+                                      secretRef:
+                                        description: |-
+                                          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      user:
+                                        description: |-
+                                          user is optional: User is the rados user name, default is admin
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                        type: string
+                                    required:
+                                    - monitors
+                                    type: object
+                                  cinder:
+                                    description: |-
+                                      cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                        type: boolean
+                                      secretRef:
+                                        description: |-
+                                          secretRef is optional: points to a secret object containing parameters used to connect
+                                          to OpenStack.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      volumeID:
+                                        description: |-
+                                          volumeID used to identify the volume in cinder.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  configMap:
+                                    description: configMap represents a configMap
+                                      that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: |-
+                                          defaultMode is optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the ConfigMap,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  csi:
+                                    description: csi (Container Storage Interface)
+                                      represents ephemeral storage that is handled
+                                      by certain external CSI drivers (Beta feature).
+                                    properties:
+                                      driver:
+                                        description: |-
+                                          driver is the name of the CSI driver that handles this volume.
+                                          Consult with your admin for the correct name as registered in the cluster.
+                                        type: string
+                                      fsType:
+                                        description: |-
+                                          fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                          If not provided, the empty value is passed to the associated CSI driver
+                                          which will determine the default filesystem to apply.
+                                        type: string
+                                      nodePublishSecretRef:
+                                        description: |-
+                                          nodePublishSecretRef is a reference to the secret object containing
+                                          sensitive information to pass to the CSI driver to complete the CSI
+                                          NodePublishVolume and NodeUnpublishVolume calls.
+                                          This field is optional, and  may be empty if no secret is required. If the
+                                          secret object contains more than one secret, all secret references are passed.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      readOnly:
+                                        description: |-
+                                          readOnly specifies a read-only configuration for the volume.
+                                          Defaults to false (read/write).
+                                        type: boolean
+                                      volumeAttributes:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          volumeAttributes stores driver-specific properties that are passed to the CSI
+                                          driver. Consult your driver's documentation for supported values.
+                                        type: object
+                                    required:
+                                    - driver
+                                    type: object
+                                  downwardAPI:
+                                    description: downwardAPI represents downward API
+                                      about the pod that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: |-
+                                          Optional: mode bits to use on created files by default. Must be a
+                                          Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: Items is a list of downward API
+                                          volume file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name, namespace and uid are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            mode:
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  emptyDir:
+                                    description: |-
+                                      emptyDir represents a temporary directory that shares a pod's lifetime.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                    properties:
+                                      medium:
+                                        description: |-
+                                          medium represents what type of storage medium should back this directory.
+                                          The default is "" which means to use the node's default medium.
+                                          Must be an empty string (default) or Memory.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                        type: string
+                                      sizeLimit:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                          The size limit is also applicable for memory medium.
+                                          The maximum usage on memory medium EmptyDir would be the minimum value between
+                                          the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                          The default is nil which means that the limit is undefined.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  ephemeral:
+                                    description: |-
+                                      ephemeral represents a volume that is handled by a cluster storage driver.
+                                      The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                      and deleted when the pod is removed.
+
+
+                                      Use this if:
+                                      a) the volume is only needed while the pod runs,
+                                      b) features of normal volumes like restoring from snapshot or capacity
+                                         tracking are needed,
+                                      c) the storage driver is specified through a storage class, and
+                                      d) the storage driver supports dynamic volume provisioning through
+                                         a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                         information on the connection between this volume type
+                                         and PersistentVolumeClaim).
+
+
+                                      Use PersistentVolumeClaim or one of the vendor-specific
+                                      APIs for volumes that persist for longer than the lifecycle
+                                      of an individual pod.
+
+
+                                      Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                      be used that way - see the documentation of the driver for
+                                      more information.
+
+
+                                      A pod can use both types of ephemeral volumes and
+                                      persistent volumes at the same time.
+                                    properties:
+                                      volumeClaimTemplate:
+                                        description: |-
+                                          Will be used to create a stand-alone PVC to provision the volume.
+                                          The pod in which this EphemeralVolumeSource is embedded will be the
+                                          owner of the PVC, i.e. the PVC will be deleted together with the
+                                          pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                          `<volume name>` is the name from the `PodSpec.Volumes` array
+                                          entry. Pod validation will reject the pod if the concatenated name
+                                          is not valid for a PVC (for example, too long).
+
+
+                                          An existing PVC with that name that is not owned by the pod
+                                          will *not* be used for the pod to avoid using an unrelated
+                                          volume by mistake. Starting the pod is then blocked until
+                                          the unrelated PVC is removed. If such a pre-created PVC is
+                                          meant to be used by the pod, the PVC has to updated with an
+                                          owner reference to the pod once the pod exists. Normally
+                                          this should not be necessary, but it may be useful when
+                                          manually reconstructing a broken cluster.
+
+
+                                          This field is read-only and no changes will be made by Kubernetes
+                                          to the PVC after it has been created.
+
+
+                                          Required, must not be nil.
+                                        properties:
+                                          metadata:
+                                            description: |-
+                                              May contain labels and annotations that will be copied into the PVC
+                                              when creating it. No other fields are allowed and will be rejected during
+                                              validation.
+                                            type: object
+                                          spec:
+                                            description: |-
+                                              The specification for the PersistentVolumeClaim. The entire content is
+                                              copied unchanged into the PVC that gets created from this
+                                              template. The same fields as in a PersistentVolumeClaim
+                                              are also valid here.
+                                            properties:
+                                              accessModes:
+                                                description: |-
+                                                  accessModes contains the desired access modes the volume should have.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              dataSource:
+                                                description: |-
+                                                  dataSource field can be used to specify either:
+                                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external controller can support the specified data source,
+                                                  it will create a new volume based on the contents of the specified data source.
+                                                  When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                                  and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                                  If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                                properties:
+                                                  apiGroup:
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              dataSourceRef:
+                                                description: |-
+                                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                  volume is desired. This may be any object from a non-empty API group (non
+                                                  core object) or a PersistentVolumeClaim object.
+                                                  When this field is specified, volume binding will only succeed if the type of
+                                                  the specified object matches some installed volume populator or dynamic
+                                                  provisioner.
+                                                  This field will replace the functionality of the dataSource field and as such
+                                                  if both fields are non-empty, they must have the same value. For backwards
+                                                  compatibility, when namespace isn't specified in dataSourceRef,
+                                                  both fields (dataSource and dataSourceRef) will be set to the same
+                                                  value automatically if one of them is empty and the other is non-empty.
+                                                  When namespace is specified in dataSourceRef,
+                                                  dataSource isn't set to the same value and must be empty.
+                                                  There are three important differences between dataSource and dataSourceRef:
+                                                  * While dataSource only allows two specific types of objects, dataSourceRef
+                                                    allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                  * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                    preserves all values, and generates an error if a disallowed value is
+                                                    specified.
+                                                  * While dataSource only allows local objects, dataSourceRef allows objects
+                                                    in any namespaces.
+                                                  (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                  (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                properties:
+                                                  apiGroup:
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                  namespace:
+                                                    description: |-
+                                                      Namespace is the namespace of resource being referenced
+                                                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              resources:
+                                                description: |-
+                                                  resources represents the minimum resources the volume should have.
+                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  that are lower than previous value but must still be higher than capacity recorded in the
+                                                  status field of the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                                properties:
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    description: |-
+                                                      Limits describes the maximum amount of compute resources allowed.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    description: |-
+                                                      Requests describes the minimum amount of compute resources required.
+                                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                    type: object
+                                                type: object
+                                              selector:
+                                                description: selector is a label query
+                                                  over volumes to consider for binding.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              storageClassName:
+                                                description: |-
+                                                  storageClassName is the name of the StorageClass required by the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                                type: string
+                                              volumeAttributesClassName:
+                                                description: |-
+                                                  volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                                  If specified, the CSI driver will create or update the volume with the attributes defined
+                                                  in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                                  it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                                  will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                                  If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                                  will be set by the persistentvolume controller if it exists.
+                                                  If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                                  set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                                  exists.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                                  (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                                type: string
+                                              volumeMode:
+                                                description: |-
+                                                  volumeMode defines what type of volume is required by the claim.
+                                                  Value of Filesystem is implied when not included in claim spec.
+                                                type: string
+                                              volumeName:
+                                                description: volumeName is the binding
+                                                  reference to the PersistentVolume
+                                                  backing this claim.
+                                                type: string
+                                            type: object
+                                        required:
+                                        - spec
+                                        type: object
+                                    type: object
+                                  fc:
+                                    description: fc represents a Fibre Channel resource
+                                      that is attached to a kubelet's host machine
+                                      and then exposed to the pod.
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
+                                        type: string
+                                      lun:
+                                        description: 'lun is Optional: FC target lun
+                                          number'
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      targetWWNs:
+                                        description: 'targetWWNs is Optional: FC target
+                                          worldwide names (WWNs)'
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      wwids:
+                                        description: |-
+                                          wwids Optional: FC volume world wide identifiers (wwids)
+                                          Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  flexVolume:
+                                    description: |-
+                                      flexVolume represents a generic volume resource that is
+                                      provisioned/attached using an exec based plugin.
+                                    properties:
+                                      driver:
+                                        description: driver is the name of the driver
+                                          to use for this volume.
+                                        type: string
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                        type: string
+                                      options:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'options is Optional: this field
+                                          holds extra command options if any.'
+                                        type: object
+                                      readOnly:
+                                        description: |-
+                                          readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: |-
+                                          secretRef is Optional: secretRef is reference to the secret object containing
+                                          sensitive information to pass to the plugin scripts. This may be
+                                          empty if no secret object is specified. If the secret object
+                                          contains more than one secret, all secrets are passed to the plugin
+                                          scripts.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                    - driver
+                                    type: object
+                                  flocker:
+                                    description: flocker represents a Flocker volume
+                                      attached to a kubelet's host machine. This depends
+                                      on the Flocker control service being running
+                                    properties:
+                                      datasetName:
+                                        description: |-
+                                          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                          should be considered as deprecated
+                                        type: string
+                                      datasetUUID:
+                                        description: datasetUUID is the UUID of the
+                                          dataset. This is unique identifier of a
+                                          Flocker dataset
+                                        type: string
+                                    type: object
+                                  gcePersistentDisk:
+                                    description: |-
+                                      gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
+                                        type: string
+                                      partition:
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        format: int32
+                                        type: integer
+                                      pdName:
+                                        description: |-
+                                          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        type: boolean
+                                    required:
+                                    - pdName
+                                    type: object
+                                  gitRepo:
+                                    description: |-
+                                      gitRepo represents a git repository at a particular revision.
+                                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                      EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                      into the Pod's container.
+                                    properties:
+                                      directory:
+                                        description: |-
+                                          directory is the target directory name.
+                                          Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                          git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                          the subdirectory with the given name.
+                                        type: string
+                                      repository:
+                                        description: repository is the URL
+                                        type: string
+                                      revision:
+                                        description: revision is the commit hash for
+                                          the specified revision.
+                                        type: string
+                                    required:
+                                    - repository
+                                    type: object
+                                  glusterfs:
+                                    description: |-
+                                      glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                                    properties:
+                                      endpoints:
+                                        description: |-
+                                          endpoints is the endpoint name that details Glusterfs topology.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                        type: string
+                                      path:
+                                        description: |-
+                                          path is the Glusterfs volume path.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                        type: boolean
+                                    required:
+                                    - endpoints
+                                    - path
+                                    type: object
+                                  hostPath:
+                                    description: |-
+                                      hostPath represents a pre-existing file or directory on the host
+                                      machine that is directly exposed to the container. This is generally
+                                      used for system agents or other privileged things that are allowed
+                                      to see the host machine. Most containers will NOT need this.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                      ---
+                                      TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                      mount host directories as read/write.
+                                    properties:
+                                      path:
+                                        description: |-
+                                          path of the directory on the host.
+                                          If the path is a symlink, it will follow the link to the real path.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type for HostPath Volume
+                                          Defaults to ""
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  iscsi:
+                                    description: |-
+                                      iscsi represents an ISCSI Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                    properties:
+                                      chapAuthDiscovery:
+                                        description: chapAuthDiscovery defines whether
+                                          support iSCSI Discovery CHAP authentication
+                                        type: boolean
+                                      chapAuthSession:
+                                        description: chapAuthSession defines whether
+                                          support iSCSI Session CHAP authentication
+                                        type: boolean
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
+                                        type: string
+                                      initiatorName:
+                                        description: |-
+                                          initiatorName is the custom iSCSI Initiator Name.
+                                          If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                          <target portal>:<volume name> will be created for the connection.
+                                        type: string
+                                      iqn:
+                                        description: iqn is the target iSCSI Qualified
+                                          Name.
+                                        type: string
+                                      iscsiInterface:
+                                        description: |-
+                                          iscsiInterface is the interface Name that uses an iSCSI transport.
+                                          Defaults to 'default' (tcp).
+                                        type: string
+                                      lun:
+                                        description: lun represents iSCSI Target Lun
+                                          number.
+                                        format: int32
+                                        type: integer
+                                      portals:
+                                        description: |-
+                                          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                        type: boolean
+                                      secretRef:
+                                        description: secretRef is the CHAP Secret
+                                          for iSCSI target and initiator authentication
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      targetPortal:
+                                        description: |-
+                                          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
+                                        type: string
+                                    required:
+                                    - iqn
+                                    - lun
+                                    - targetPortal
+                                    type: object
+                                  name:
+                                    description: |-
+                                      name of the volume.
+                                      Must be a DNS_LABEL and unique within the pod.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  nfs:
+                                    description: |-
+                                      nfs represents an NFS mount on the host that shares a pod's lifetime
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    properties:
+                                      path:
+                                        description: |-
+                                          path that is exported by the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the NFS export to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                        type: boolean
+                                      server:
+                                        description: |-
+                                          server is the hostname or IP address of the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                        type: string
+                                    required:
+                                    - path
+                                    - server
+                                    type: object
+                                  persistentVolumeClaim:
+                                    description: |-
+                                      persistentVolumeClaimVolumeSource represents a reference to a
+                                      PersistentVolumeClaim in the same namespace.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                    properties:
+                                      claimName:
+                                        description: |-
+                                          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly Will force the ReadOnly setting in VolumeMounts.
+                                          Default false.
+                                        type: boolean
+                                    required:
+                                    - claimName
+                                    type: object
+                                  photonPersistentDisk:
+                                    description: photonPersistentDisk represents a
+                                      PhotonController persistent disk attached and
+                                      mounted on kubelets host machine
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      pdID:
+                                        description: pdID is the ID that identifies
+                                          Photon Controller persistent disk
+                                        type: string
+                                    required:
+                                    - pdID
+                                    type: object
+                                  portworxVolume:
+                                    description: portworxVolume represents a portworx
+                                      volume attached and mounted on kubelets host
+                                      machine
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fSType represents the filesystem type to mount
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      volumeID:
+                                        description: volumeID uniquely identifies
+                                          a Portworx volume
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  projected:
+                                    description: projected items for all in one resources
+                                      secrets, configmaps, and downward API
+                                    properties:
+                                      defaultMode:
+                                        description: |-
+                                          defaultMode are the mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      sources:
+                                        description: sources is the list of volume
+                                          projections
+                                        items:
+                                          description: Projection that may be projected
+                                            along with other supported volume types
+                                          properties:
+                                            clusterTrustBundle:
+                                              description: |-
+                                                ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                                of ClusterTrustBundle objects in an auto-updating file.
+
+
+                                                Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+
+                                                ClusterTrustBundle objects can either be selected by name, or by the
+                                                combination of signer name and a label selector.
+
+
+                                                Kubelet performs aggressive normalization of the PEM contents written
+                                                into the pod filesystem.  Esoteric PEM features such as inter-block
+                                                comments and block headers are stripped.  Certificates are deduplicated.
+                                                The ordering of certificates within the file is arbitrary, and Kubelet
+                                                may change the order over time.
+                                              properties:
+                                                labelSelector:
+                                                  description: |-
+                                                    Select all ClusterTrustBundles that match this label selector.  Only has
+                                                    effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                    interpreted as "match nothing".  If set but empty, interpreted as "match
+                                                    everything".
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                name:
+                                                  description: |-
+                                                    Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                                    with signerName and labelSelector.
+                                                  type: string
+                                                optional:
+                                                  description: |-
+                                                    If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                    aren't available.  If using name, then the named ClusterTrustBundle is
+                                                    allowed not to exist.  If using signerName, then the combination of
+                                                    signerName and labelSelector is allowed to match zero
+                                                    ClusterTrustBundles.
+                                                  type: boolean
+                                                path:
+                                                  description: Relative path from
+                                                    the volume root to write the bundle.
+                                                  type: string
+                                                signerName:
+                                                  description: |-
+                                                    Select all ClusterTrustBundles that match this signer name.
+                                                    Mutually-exclusive with name.  The contents of all selected
+                                                    ClusterTrustBundles will be unified and deduplicated.
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                            configMap:
+                                              description: configMap information about
+                                                the configMap data to project
+                                              properties:
+                                                items:
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    ConfigMap will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present. If a key is specified which is not present in the ConfigMap,
+                                                    the volume setup will error unless it is marked optional. Paths must be
+                                                    relative and may not contain the '..' path or start with '..'.
+                                                  items:
+                                                    description: Maps a string key
+                                                      to a path within a volume.
+                                                    properties:
+                                                      key:
+                                                        description: key is the key
+                                                          to project.
+                                                        type: string
+                                                      mode:
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
+                                                          This might be in conflict with other options that affect the file
+                                                          mode, like fsGroup, and the result can be other mode bits set.
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: optional specify whether
+                                                    the ConfigMap or its keys must
+                                                    be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            downwardAPI:
+                                              description: downwardAPI information
+                                                about the downwardAPI data to project
+                                              properties:
+                                                items:
+                                                  description: Items is a list of
+                                                    DownwardAPIVolume file
+                                                  items:
+                                                    description: DownwardAPIVolumeFile
+                                                      represents information to create
+                                                      the file containing the pod
+                                                      field
+                                                    properties:
+                                                      fieldRef:
+                                                        description: 'Required: Selects
+                                                          a field of the pod: only
+                                                          annotations, labels, name,
+                                                          namespace and uid are supported.'
+                                                        properties:
+                                                          apiVersion:
+                                                            description: Version of
+                                                              the schema the FieldPath
+                                                              is written in terms
+                                                              of, defaults to "v1".
+                                                            type: string
+                                                          fieldPath:
+                                                            description: Path of the
+                                                              field to select in the
+                                                              specified API version.
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      mode:
+                                                        description: |-
+                                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
+                                                          This might be in conflict with other options that affect the file
+                                                          mode, like fsGroup, and the result can be other mode bits set.
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: 'Required: Path
+                                                          is  the relative path name
+                                                          of the file to be created.
+                                                          Must not be absolute or
+                                                          contain the ''..'' path.
+                                                          Must be utf-8 encoded. The
+                                                          first item of the relative
+                                                          path must not start with
+                                                          ''..'''
+                                                        type: string
+                                                      resourceFieldRef:
+                                                        description: |-
+                                                          Selects a resource of the container: only resources limits and requests
+                                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                        properties:
+                                                          containerName:
+                                                            description: 'Container
+                                                              name: required for volumes,
+                                                              optional for env vars'
+                                                            type: string
+                                                          divisor:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            description: Specifies
+                                                              the output format of
+                                                              the exposed resources,
+                                                              defaults to "1"
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          resource:
+                                                            description: 'Required:
+                                                              resource to select'
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            secret:
+                                              description: secret information about
+                                                the secret data to project
+                                              properties:
+                                                items:
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    Secret will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present. If a key is specified which is not present in the Secret,
+                                                    the volume setup will error unless it is marked optional. Paths must be
+                                                    relative and may not contain the '..' path or start with '..'.
+                                                  items:
+                                                    description: Maps a string key
+                                                      to a path within a volume.
+                                                    properties:
+                                                      key:
+                                                        description: key is the key
+                                                          to project.
+                                                        type: string
+                                                      mode:
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
+                                                          This might be in conflict with other options that affect the file
+                                                          mode, like fsGroup, and the result can be other mode bits set.
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: optional field specify
+                                                    whether the Secret or its key
+                                                    must be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            serviceAccountToken:
+                                              description: serviceAccountToken is
+                                                information about the serviceAccountToken
+                                                data to project
+                                              properties:
+                                                audience:
+                                                  description: |-
+                                                    audience is the intended audience of the token. A recipient of a token
+                                                    must identify itself with an identifier specified in the audience of the
+                                                    token, and otherwise should reject the token. The audience defaults to the
+                                                    identifier of the apiserver.
+                                                  type: string
+                                                expirationSeconds:
+                                                  description: |-
+                                                    expirationSeconds is the requested duration of validity of the service
+                                                    account token. As the token approaches expiration, the kubelet volume
+                                                    plugin will proactively rotate the service account token. The kubelet will
+                                                    start trying to rotate the token if the token is older than 80 percent of
+                                                    its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                    and must be at least 10 minutes.
+                                                  format: int64
+                                                  type: integer
+                                                path:
+                                                  description: |-
+                                                    path is the path relative to the mount point of the file to project the
+                                                    token into.
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  quobyte:
+                                    description: quobyte represents a Quobyte mount
+                                      on the host that shares a pod's lifetime
+                                    properties:
+                                      group:
+                                        description: |-
+                                          group to map volume access to
+                                          Default is no group
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                          Defaults to false.
+                                        type: boolean
+                                      registry:
+                                        description: |-
+                                          registry represents a single or multiple Quobyte Registry services
+                                          specified as a string as host:port pair (multiple entries are separated with commas)
+                                          which acts as the central registry for volumes
+                                        type: string
+                                      tenant:
+                                        description: |-
+                                          tenant owning the given Quobyte volume in the Backend
+                                          Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                        type: string
+                                      user:
+                                        description: |-
+                                          user to map volume access to
+                                          Defaults to serivceaccount user
+                                        type: string
+                                      volume:
+                                        description: volume is a string that references
+                                          an already created Quobyte volume by name.
+                                        type: string
+                                    required:
+                                    - registry
+                                    - volume
+                                    type: object
+                                  rbd:
+                                    description: |-
+                                      rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
+                                        type: string
+                                      image:
+                                        description: |-
+                                          image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        type: string
+                                      keyring:
+                                        description: |-
+                                          keyring is the path to key ring for RBDUser.
+                                          Default is /etc/ceph/keyring.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        type: string
+                                      monitors:
+                                        description: |-
+                                          monitors is a collection of Ceph monitors.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      pool:
+                                        description: |-
+                                          pool is the rados pool name.
+                                          Default is rbd.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        type: boolean
+                                      secretRef:
+                                        description: |-
+                                          secretRef is name of the authentication secret for RBDUser. If provided
+                                          overrides keyring.
+                                          Default is nil.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      user:
+                                        description: |-
+                                          user is the rados user name.
+                                          Default is admin.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        type: string
+                                    required:
+                                    - image
+                                    - monitors
+                                    type: object
+                                  scaleIO:
+                                    description: scaleIO represents a ScaleIO persistent
+                                      volume attached and mounted on Kubernetes nodes.
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs".
+                                          Default is "xfs".
+                                        type: string
+                                      gateway:
+                                        description: gateway is the host address of
+                                          the ScaleIO API Gateway.
+                                        type: string
+                                      protectionDomain:
+                                        description: protectionDomain is the name
+                                          of the ScaleIO Protection Domain for the
+                                          configured storage.
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: |-
+                                          secretRef references to the secret for ScaleIO user and other
+                                          sensitive information. If this is not provided, Login operation will fail.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      sslEnabled:
+                                        description: sslEnabled Flag enable/disable
+                                          SSL communication with Gateway, default
+                                          false
+                                        type: boolean
+                                      storageMode:
+                                        description: |-
+                                          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                          Default is ThinProvisioned.
+                                        type: string
+                                      storagePool:
+                                        description: storagePool is the ScaleIO Storage
+                                          Pool associated with the protection domain.
+                                        type: string
+                                      system:
+                                        description: system is the name of the storage
+                                          system as configured in ScaleIO.
+                                        type: string
+                                      volumeName:
+                                        description: |-
+                                          volumeName is the name of a volume already created in the ScaleIO system
+                                          that is associated with this volume source.
+                                        type: string
+                                    required:
+                                    - gateway
+                                    - secretRef
+                                    - system
+                                    type: object
+                                  secret:
+                                    description: |-
+                                      secret represents a secret that should populate this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                    properties:
+                                      defaultMode:
+                                        description: |-
+                                          defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values
+                                          for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: |-
+                                          items If unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the Secret,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its keys must be defined
+                                        type: boolean
+                                      secretName:
+                                        description: |-
+                                          secretName is the name of the secret in the pod's namespace to use.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                        type: string
+                                    type: object
+                                  storageos:
+                                    description: storageOS represents a StorageOS
+                                      volume attached and mounted on Kubernetes nodes.
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: |-
+                                          secretRef specifies the secret to use for obtaining the StorageOS API
+                                          credentials.  If not specified, default values will be attempted.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      volumeName:
+                                        description: |-
+                                          volumeName is the human-readable name of the StorageOS volume.  Volume
+                                          names are only unique within a namespace.
+                                        type: string
+                                      volumeNamespace:
+                                        description: |-
+                                          volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                          namespace is specified then the Pod's namespace will be used.  This allows the
+                                          Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                          Set VolumeName to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces within StorageOS.
+                                          Namespaces that do not pre-exist within StorageOS will be created.
+                                        type: string
+                                    type: object
+                                  vsphereVolume:
+                                    description: vsphereVolume represents a vSphere
+                                      volume attached and mounted on kubelets host
+                                      machine
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      storagePolicyID:
+                                        description: storagePolicyID is the storage
+                                          Policy Based Management (SPBM) profile ID
+                                          associated with the StoragePolicyName.
+                                        type: string
+                                      storagePolicyName:
+                                        description: storagePolicyName is the storage
+                                          Policy Based Management (SPBM) profile name.
+                                        type: string
+                                      volumePath:
+                                        description: volumePath is the path that identifies
+                                          vSphere volume vmdk
+                                        type: string
+                                    required:
+                                    - volumePath
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                          type: object
+                        strategy:
+                          description: The daemonset strategy to use to replace existing
+                            pods with new ones.
+                          properties:
+                            rollingUpdate:
+                              description: |-
+                                Rolling update config params. Present only if type = "RollingUpdate".
+                                ---
+                                TODO: Update this to follow our convention for oneOf, whatever we decide it
+                                to be. Same as Deployment `strategy.rollingUpdate`.
+                                See https://github.com/kubernetes/kubernetes/issues/35345
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    The maximum number of nodes with an existing available DaemonSet pod that
+                                    can have an updated DaemonSet pod during during an update.
+                                    Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                    This can not be 0 if MaxUnavailable is 0.
+                                    Absolute number is calculated from percentage by rounding up to a minimum of 1.
+                                    Default value is 0.
+                                    Example: when this is set to 30%, at most 30% of the total number of nodes
+                                    that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                                    can have their a new pod created before the old pod is marked as deleted.
+                                    The update starts by launching new pods on 30% of nodes. Once an updated
+                                    pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
+                                    on that node is marked deleted. If the old pod becomes unavailable for any
+                                    reason (Ready transitions to false, is evicted, or is drained) an updated
+                                    pod is immediatedly created on that node without considering surge limits.
+                                    Allowing surge implies the possibility that the resources consumed by the
+                                    daemonset on any given node can double if the readiness check fails, and
+                                    so resource intensive daemonsets should take into account that they may
+                                    cause evictions during disruption.
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    The maximum number of DaemonSet pods that can be unavailable during the
+                                    update. Value can be an absolute number (ex: 5) or a percentage of total
+                                    number of DaemonSet pods at the start of the update (ex: 10%). Absolute
+                                    number is calculated from percentage by rounding up.
+                                    This cannot be 0 if MaxSurge is 0
+                                    Default value is 1.
+                                    Example: when this is set to 30%, at most 30% of the total number of nodes
+                                    that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                                    can have their pods stopped for an update at any given time. The update
+                                    starts by stopping at most 30% of those DaemonSet pods and then brings
+                                    up new DaemonSet pods in their place. Once the new pods are available,
+                                    it then proceeds onto other DaemonSet pods, thus ensuring that at least
+                                    70% of original number of DaemonSet pods are available at all times during
+                                    the update.
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of daemon set update. Can be "RollingUpdate"
+                                or "OnDelete". Default is RollingUpdate.
+                              type: string
+                          type: object
+                      type: object
+                    envoyDeployment:
+                      description: |-
+                        EnvoyDeployment defines the desired state of the Envoy deployment resource.
+                        If unspecified, default settings for the managed Envoy deployment resource
+                        are applied.
+                      properties:
+                        container:
+                          description: Container defines the desired specification
+                            of main container.
+                          properties:
+                            env:
+                              description: List of environment variables to set in
+                                the container.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            image:
+                              description: Image specifies the EnvoyProxy container
+                                image to be used, instead of the default image.
+                              type: string
+                            resources:
+                              description: |-
+                                Resources required by this container.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                capabilities:
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                procMount:
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            volumeMounts:
+                              description: |-
+                                VolumeMounts are volumes to mount into the container's filesystem.
+                                Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
+                                  subPath:
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -564,46 +4640,45 @@ spec:
                               type: array
                           type: object
                         initContainers:
-                          description: 'List of initialization containers belonging
-                            to the pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                          description: |-
+                            List of initialization containers belonging to the pod.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                           items:
                             description: A single application container that you want
                               to run within a pod.
                             properties:
                               args:
-                                description: 'Arguments to the entrypoint. The container
-                                  image''s CMD is used if this is not provided. Variable
-                                  references $(VAR_NAME) are expanded using the container''s
-                                  environment. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  Double $$ are reduced to a single $, which allows
-                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                  will produce the string literal "$(VAR_NAME)". Escaped
-                                  references will never be expanded, regardless of
-                                  whether the variable exists or not. Cannot be updated.
-                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The container image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               command:
-                                description: 'Entrypoint array. Not executed within
-                                  a shell. The container image''s ENTRYPOINT is used
-                                  if this is not provided. Variable references $(VAR_NAME)
-                                  are expanded using the container''s environment.
-                                  If a variable cannot be resolved, the reference
-                                  in the input string will be unchanged. Double $$
-                                  are reduced to a single $, which allows for escaping
-                                  the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                  produce the string literal "$(VAR_NAME)". Escaped
-                                  references will never be expanded, regardless of
-                                  whether the variable exists or not. Cannot be updated.
-                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The container image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               env:
-                                description: List of environment variables to set
-                                  in the container. Cannot be updated.
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
                                 items:
                                   description: EnvVar represents an environment variable
                                     present in a Container.
@@ -613,18 +4688,16 @@ spec:
                                         Must be a C_IDENTIFIER.
                                       type: string
                                     value:
-                                      description: 'Variable references $(VAR_NAME)
-                                        are expanded using the previously defined
-                                        environment variables in the container and
-                                        any service environment variables. If a variable
-                                        cannot be resolved, the reference in the input
-                                        string will be unchanged. Double $$ are reduced
-                                        to a single $, which allows for escaping the
-                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                        produce the string literal "$(VAR_NAME)".
-                                        Escaped references will never be expanded,
-                                        regardless of whether the variable exists
-                                        or not. Defaults to "".'
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -637,10 +4710,15 @@ spec:
                                               description: The key to select.
                                               type: string
                                             name:
-                                              description: 'Name of the referent.
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -651,11 +4729,9 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
-                                          description: 'Selects a field of the pod:
-                                            supports metadata.name, metadata.namespace,
-                                            `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                            spec.nodeName, spec.serviceAccountName,
-                                            status.hostIP, status.podIP, status.podIPs.'
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                           properties:
                                             apiVersion:
                                               description: Version of the schema the
@@ -671,11 +4747,9 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, limits.ephemeral-storage,
-                                            requests.cpu, requests.memory and requests.ephemeral-storage)
-                                            are currently supported.'
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                           properties:
                                             containerName:
                                               description: 'Container name: required
@@ -708,10 +4782,15 @@ spec:
                                                 key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent.
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -726,15 +4805,17 @@ spec:
                                   - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               envFrom:
-                                description: List of sources to populate environment
-                                  variables in the container. The keys defined within
-                                  a source must be a C_IDENTIFIER. All invalid keys
-                                  will be reported as an event when the container
-                                  is starting. When a key exists in multiple sources,
-                                  the value associated with the last source will take
-                                  precedence. Values defined by an Env with a duplicate
-                                  key will take precedence. Cannot be updated.
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                  will be reported as an event when the container is starting. When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
                                 items:
                                   description: EnvFromSource represents the source
                                     of a set of ConfigMaps
@@ -743,10 +4824,15 @@ spec:
                                       description: The ConfigMap to select from
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
                                           description: Specify whether the ConfigMap
@@ -762,10 +4848,15 @@ spec:
                                       description: The Secret to select from
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
                                           description: Specify whether the Secret
@@ -775,59 +4866,58 @@ spec:
                                       x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               image:
-                                description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                  This field is optional to allow higher level config
-                                  management to default or override container images
-                                  in workload controllers like Deployments and StatefulSets.'
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                               imagePullPolicy:
-                                description: 'Image pull policy. One of Always, Never,
-                                  IfNotPresent. Defaults to Always if :latest tag
-                                  is specified, or IfNotPresent otherwise. Cannot
-                                  be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                 type: string
                               lifecycle:
-                                description: Actions that the management system should
-                                  take in response to container lifecycle events.
+                                description: |-
+                                  Actions that the management system should take in response to container lifecycle events.
                                   Cannot be updated.
                                 properties:
                                   postStart:
-                                    description: 'PostStart is called immediately
-                                      after a container is created. If the handler
-                                      fails, the container is terminated and restarted
-                                      according to its restart policy. Other management
-                                      of the container blocks until the hook completes.
-                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                    description: |-
+                                      PostStart is called immediately after a container is created. If the handler fails,
+                                      the container is terminated and restarted according to its restart policy.
+                                      Other management of the container blocks until the hook completes.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -837,11 +4927,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -851,6 +4939,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             description: Path to access on the HTTP
                                               server.
@@ -859,25 +4948,37 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
+                                        type: object
                                       tcpSocket:
-                                        description: Deprecated. TCPSocket is NOT
-                                          supported as a LifecycleHandler and kept
-                                          for the backward compatibility. There are
-                                          no validation of this field and lifecycle
-                                          hooks will fail in runtime when tcp handler
-                                          is specified.
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for the backward compatibility. There are no validation of this field and
+                                          lifecycle hooks will fail in runtime when tcp handler is specified.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -887,59 +4988,51 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                     type: object
                                   preStop:
-                                    description: 'PreStop is called immediately before
-                                      a container is terminated due to an API request
-                                      or management event such as liveness/startup
-                                      probe failure, preemption, resource contention,
-                                      etc. The handler is not called if the container
-                                      crashes or exits. The Pod''s termination grace
-                                      period countdown begins before the PreStop hook
-                                      is executed. Regardless of the outcome of the
-                                      handler, the container will eventually terminate
-                                      within the Pod''s termination grace period (unless
-                                      delayed by finalizers). Other management of
-                                      the container blocks until the hook completes
+                                    description: |-
+                                      PreStop is called immediately before a container is terminated due to an
+                                      API request or management event such as liveness/startup probe failure,
+                                      preemption, resource contention, etc. The handler is not called if the
+                                      container crashes or exits. The Pod's termination grace period countdown begins before the
+                                      PreStop hook is executed. Regardless of the outcome of the handler, the
+                                      container will eventually terminate within the Pod's termination grace
+                                      period (unless delayed by finalizers). Other management of the container blocks until the hook completes
                                       or until the termination grace period is reached.
-                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -949,11 +5042,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -963,6 +5054,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             description: Path to access on the HTTP
                                               server.
@@ -971,25 +5063,37 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
+                                        type: object
                                       tcpSocket:
-                                        description: Deprecated. TCPSocket is NOT
-                                          supported as a LifecycleHandler and kept
-                                          for the backward compatibility. There are
-                                          no validation of this field and lifecycle
-                                          hooks will fail in runtime when tcp handler
-                                          is specified.
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for the backward compatibility. There are no validation of this field and
+                                          lifecycle hooks will fail in runtime when tcp handler is specified.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -999,10 +5103,10 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
@@ -1010,32 +5114,31 @@ spec:
                                     type: object
                                 type: object
                               livenessProbe:
-                                description: 'Periodic probe of container liveness.
+                                description: |-
+                                  Periodic probe of container liveness.
                                   Container will be restarted if the probe fails.
-                                  Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 properties:
                                   exec:
                                     description: Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description: Command is the command line to
-                                          execute inside the container, the working
-                                          directory for the command  is root ('/')
-                                          in the container's filesystem. The command
-                                          is simply exec'd, it is not run inside a
-                                          shell, so traditional shell instructions
-                                          ('|', etc) won't work. To use a shell, you
-                                          need to explicitly call out to that shell.
-                                          Exit status of 0 is treated as live/healthy
-                                          and non-zero is unhealthy.
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
-                                    description: Minimum consecutive failures for
-                                      the probe to be considered failed after having
-                                      succeeded. Defaults to 3. Minimum value is 1.
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   grpc:
@@ -1048,11 +5151,12 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
-                                        description: "Service is the name of the service
-                                          to place in the gRPC HealthCheckRequest
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                          \n If this is not specified, the default
-                                          behavior is defined by gRPC."
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
                                         type: string
                                     required:
                                     - port
@@ -1062,8 +5166,8 @@ spec:
                                       to perform.
                                     properties:
                                       host:
-                                        description: Host name to connect to, defaults
-                                          to the pod IP. You probably want to set
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
                                           "Host" in httpHeaders instead.
                                         type: string
                                       httpHeaders:
@@ -1074,10 +5178,9 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name.
-                                                This will be canonicalized upon output,
-                                                so case-variant names will be understood
-                                                as the same header.
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -1087,6 +5190,7 @@ spec:
                                           - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
@@ -1094,35 +5198,35 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Name or number of the port to
-                                          access on the container. Number must be
-                                          in the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description: Scheme to use for connecting
-                                          to the host. Defaults to HTTP.
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
                                         type: string
                                     required:
                                     - port
                                     type: object
                                   initialDelaySeconds:
-                                    description: 'Number of seconds after the container
-                                      has started before liveness probes are initiated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                   periodSeconds:
-                                    description: How often (in seconds) to perform
-                                      the probe. Default to 10 seconds. Minimum value
-                                      is 1.
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   successThreshold:
-                                    description: Minimum consecutive successes for
-                                      the probe to be considered successful after
-                                      having failed. Defaults to 1. Must be 1 for
-                                      liveness and startup. Minimum value is 1.
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
@@ -1137,63 +5241,59 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Number or name of the port to
-                                          access on the container. Number must be
-                                          in the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                     - port
                                     type: object
                                   terminationGracePeriodSeconds:
-                                    description: Optional duration in seconds the
-                                      pod needs to terminate gracefully upon probe
-                                      failure. The grace period is the duration in
-                                      seconds after the processes running in the pod
-                                      are sent a termination signal and the time when
-                                      the processes are forcibly halted with a kill
-                                      signal. Set this value longer than the expected
-                                      cleanup time for your process. If this value
-                                      is nil, the pod's terminationGracePeriodSeconds
-                                      will be used. Otherwise, this value overrides
-                                      the value provided by the pod spec. Value must
-                                      be non-negative integer. The value zero indicates
-                                      stop immediately via the kill signal (no opportunity
-                                      to shut down). This is a beta field and requires
-                                      enabling ProbeTerminationGracePeriod feature
-                                      gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                      is used if unset.
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                     format: int64
                                     type: integer
                                   timeoutSeconds:
-                                    description: 'Number of seconds after which the
-                                      probe times out. Defaults to 1 second. Minimum
-                                      value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                 type: object
                               name:
-                                description: Name of the container specified as a
-                                  DNS_LABEL. Each container in a pod must have a unique
-                                  name (DNS_LABEL). Cannot be updated.
+                                description: |-
+                                  Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
+                                  Cannot be updated.
                                 type: string
                               ports:
-                                description: List of ports to expose from the container.
-                                  Not specifying a port here DOES NOT prevent that
-                                  port from being exposed. Any port which is listening
-                                  on the default "0.0.0.0" address inside a container
-                                  will be accessible from the network. Modifying this
-                                  array with strategic merge patch may corrupt the
-                                  data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                description: |-
+                                  List of ports to expose from the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed. Any port which is
+                                  listening on the default "0.0.0.0" address inside a container will be
+                                  accessible from the network.
+                                  Modifying this array with strategic merge patch may corrupt the data.
+                                  For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                   Cannot be updated.
                                 items:
                                   description: ContainerPort represents a network
                                     port in a single container.
                                   properties:
                                     containerPort:
-                                      description: Number of port to expose on the
-                                        pod's IP address. This must be a valid port
-                                        number, 0 < x < 65536.
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
                                       format: int32
                                       type: integer
                                     hostIP:
@@ -1201,23 +5301,24 @@ spec:
                                         port to.
                                       type: string
                                     hostPort:
-                                      description: Number of port to expose on the
-                                        host. If specified, this must be a valid port
-                                        number, 0 < x < 65536. If HostNetwork is specified,
-                                        this must match ContainerPort. Most containers
-                                        do not need this.
+                                      description: |-
+                                        Number of port to expose on the host.
+                                        If specified, this must be a valid port number, 0 < x < 65536.
+                                        If HostNetwork is specified, this must match ContainerPort.
+                                        Most containers do not need this.
                                       format: int32
                                       type: integer
                                     name:
-                                      description: If specified, this must be an IANA_SVC_NAME
-                                        and unique within the pod. Each named port
-                                        in a pod must have a unique name. Name for
-                                        the port that can be referred to by services.
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
                                       type: string
                                     protocol:
                                       default: TCP
-                                      description: Protocol for port. Must be UDP,
-                                        TCP, or SCTP. Defaults to "TCP".
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
                                       type: string
                                   required:
                                   - containerPort
@@ -1228,33 +5329,31 @@ spec:
                                 - protocol
                                 x-kubernetes-list-type: map
                               readinessProbe:
-                                description: 'Periodic probe of container service
-                                  readiness. Container will be removed from service
-                                  endpoints if the probe fails. Cannot be updated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: |-
+                                  Periodic probe of container service readiness.
+                                  Container will be removed from service endpoints if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 properties:
                                   exec:
                                     description: Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description: Command is the command line to
-                                          execute inside the container, the working
-                                          directory for the command  is root ('/')
-                                          in the container's filesystem. The command
-                                          is simply exec'd, it is not run inside a
-                                          shell, so traditional shell instructions
-                                          ('|', etc) won't work. To use a shell, you
-                                          need to explicitly call out to that shell.
-                                          Exit status of 0 is treated as live/healthy
-                                          and non-zero is unhealthy.
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
-                                    description: Minimum consecutive failures for
-                                      the probe to be considered failed after having
-                                      succeeded. Defaults to 3. Minimum value is 1.
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   grpc:
@@ -1267,11 +5366,12 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
-                                        description: "Service is the name of the service
-                                          to place in the gRPC HealthCheckRequest
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                          \n If this is not specified, the default
-                                          behavior is defined by gRPC."
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
                                         type: string
                                     required:
                                     - port
@@ -1281,8 +5381,8 @@ spec:
                                       to perform.
                                     properties:
                                       host:
-                                        description: Host name to connect to, defaults
-                                          to the pod IP. You probably want to set
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
                                           "Host" in httpHeaders instead.
                                         type: string
                                       httpHeaders:
@@ -1293,10 +5393,9 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name.
-                                                This will be canonicalized upon output,
-                                                so case-variant names will be understood
-                                                as the same header.
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -1306,6 +5405,7 @@ spec:
                                           - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
@@ -1313,35 +5413,35 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Name or number of the port to
-                                          access on the container. Number must be
-                                          in the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description: Scheme to use for connecting
-                                          to the host. Defaults to HTTP.
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
                                         type: string
                                     required:
                                     - port
                                     type: object
                                   initialDelaySeconds:
-                                    description: 'Number of seconds after the container
-                                      has started before liveness probes are initiated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                   periodSeconds:
-                                    description: How often (in seconds) to perform
-                                      the probe. Default to 10 seconds. Minimum value
-                                      is 1.
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   successThreshold:
-                                    description: Minimum consecutive successes for
-                                      the probe to be considered successful after
-                                      having failed. Defaults to 1. Must be 1 for
-                                      liveness and startup. Minimum value is 1.
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
@@ -1356,38 +5456,33 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Number or name of the port to
-                                          access on the container. Number must be
-                                          in the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                     - port
                                     type: object
                                   terminationGracePeriodSeconds:
-                                    description: Optional duration in seconds the
-                                      pod needs to terminate gracefully upon probe
-                                      failure. The grace period is the duration in
-                                      seconds after the processes running in the pod
-                                      are sent a termination signal and the time when
-                                      the processes are forcibly halted with a kill
-                                      signal. Set this value longer than the expected
-                                      cleanup time for your process. If this value
-                                      is nil, the pod's terminationGracePeriodSeconds
-                                      will be used. Otherwise, this value overrides
-                                      the value provided by the pod spec. Value must
-                                      be non-negative integer. The value zero indicates
-                                      stop immediately via the kill signal (no opportunity
-                                      to shut down). This is a beta field and requires
-                                      enabling ProbeTerminationGracePeriod feature
-                                      gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                      is used if unset.
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                     format: int64
                                     type: integer
                                   timeoutSeconds:
-                                    description: 'Number of seconds after which the
-                                      probe times out. Defaults to 1 second. Minimum
-                                      value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                 type: object
@@ -1398,14 +5493,14 @@ spec:
                                     resize policy for the container.
                                   properties:
                                     resourceName:
-                                      description: 'Name of the resource to which
-                                        this resource resize policy applies. Supported
-                                        values: cpu, memory.'
+                                      description: |-
+                                        Name of the resource to which this resource resize policy applies.
+                                        Supported values: cpu, memory.
                                       type: string
                                     restartPolicy:
-                                      description: Restart policy to apply when specified
-                                        resource is resized. If not specified, it
-                                        defaults to NotRequired.
+                                      description: |-
+                                        Restart policy to apply when specified resource is resized.
+                                        If not specified, it defaults to NotRequired.
                                       type: string
                                   required:
                                   - resourceName
@@ -1414,25 +5509,31 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               resources:
-                                description: 'Compute Resources required by this container.
-                                  Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Compute Resources required by this container.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 properties:
                                   claims:
-                                    description: "Claims lists the names of resources,
-                                      defined in spec.resourceClaims, that are used
-                                      by this container. \n This is an alpha field
-                                      and requires enabling the DynamicResourceAllocation
-                                      feature gate. \n This field is immutable. It
-                                      can only be set for containers."
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+
+                                      This is an alpha field and requires enabling the
+                                      DynamicResourceAllocation feature gate.
+
+
+                                      This field is immutable. It can only be set for containers.
                                     items:
                                       description: ResourceClaim references one entry
                                         in PodSpec.ResourceClaims.
                                       properties:
                                         name:
-                                          description: Name must match the name of
-                                            one entry in pod.spec.resourceClaims of
-                                            the Pod where this field is used. It makes
-                                            that resource available inside a container.
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
                                           type: string
                                       required:
                                       - name
@@ -1448,8 +5549,9 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount
-                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -1458,60 +5560,76 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Requests describes the minimum amount
-                                      of compute resources required. If Requests is
-                                      omitted for a container, it defaults to Limits
-                                      if that is explicitly specified, otherwise to
-                                      an implementation-defined value. Requests cannot
-                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     type: object
                                 type: object
                               restartPolicy:
-                                description: 'RestartPolicy defines the restart behavior
-                                  of individual containers in a pod. This field may
-                                  only be set for init containers, and the only allowed
-                                  value is "Always". For non-init containers or when
-                                  this field is not specified, the restart behavior
-                                  is defined by the Pod''s restart policy and the
-                                  container type. Setting the RestartPolicy as "Always"
-                                  for the init container will have the following effect:
-                                  this init container will be continually restarted
-                                  on exit until all regular containers have terminated.
-                                  Once all regular containers have completed, all
-                                  init containers with restartPolicy "Always" will
-                                  be shut down. This lifecycle differs from normal
-                                  init containers and is often referred to as a "sidecar"
-                                  container. Although this init container still starts
-                                  in the init container sequence, it does not wait
-                                  for the container to complete before proceeding
-                                  to the next init container. Instead, the next init
-                                  container starts immediately after this init container
-                                  is started, or after any startupProbe has successfully
-                                  completed.'
+                                description: |-
+                                  RestartPolicy defines the restart behavior of individual containers in a pod.
+                                  This field may only be set for init containers, and the only allowed value is "Always".
+                                  For non-init containers or when this field is not specified,
+                                  the restart behavior is defined by the Pod's restart policy and the container type.
+                                  Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                  this init container will be continually restarted on
+                                  exit until all regular containers have terminated. Once all regular
+                                  containers have completed, all init containers with restartPolicy "Always"
+                                  will be shut down. This lifecycle differs from normal init containers and
+                                  is often referred to as a "sidecar" container. Although this init
+                                  container still starts in the init container sequence, it does not wait
+                                  for the container to complete before proceeding to the next init
+                                  container. Instead, the next init container starts immediately after this
+                                  init container is started, or after any startupProbe has successfully
+                                  completed.
                                 type: string
                               securityContext:
-                                description: 'SecurityContext defines the security
-                                  options the container should be run with. If set,
-                                  the fields of SecurityContext override the equivalent
-                                  fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                description: |-
+                                  SecurityContext defines the security options the container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                 properties:
                                   allowPrivilegeEscalation:
-                                    description: 'AllowPrivilegeEscalation controls
-                                      whether a process can gain more privileges than
-                                      its parent process. This bool directly controls
-                                      if the no_new_privs flag will be set on the
-                                      container process. AllowPrivilegeEscalation
-                                      is true always when the container is: 1) run
-                                      as Privileged 2) has CAP_SYS_ADMIN Note that
-                                      this field cannot be set when spec.os.name is
-                                      windows.'
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                      overrides the pod's appArmorProfile.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
                                   capabilities:
-                                    description: The capabilities to add/drop when
-                                      running containers. Defaults to the default
-                                      set of capabilities granted by the container
-                                      runtime. Note that this field cannot be set
-                                      when spec.os.name is windows.
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     properties:
                                       add:
                                         description: Added capabilities
@@ -1520,6 +5638,7 @@ spec:
                                             capabilities type
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       drop:
                                         description: Removed capabilities
                                         items:
@@ -1527,71 +5646,63 @@ spec:
                                             capabilities type
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   privileged:
-                                    description: Run container in privileged mode.
-                                      Processes in privileged containers are essentially
-                                      equivalent to root on the host. Defaults to
-                                      false. Note that this field cannot be set when
-                                      spec.os.name is windows.
+                                    description: |-
+                                      Run container in privileged mode.
+                                      Processes in privileged containers are essentially equivalent to root on the host.
+                                      Defaults to false.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
                                   procMount:
-                                    description: procMount denotes the type of proc
-                                      mount to use for the containers. The default
-                                      is DefaultProcMount which uses the container
-                                      runtime defaults for readonly paths and masked
-                                      paths. This requires the ProcMountType feature
-                                      flag to be enabled. Note that this field cannot
-                                      be set when spec.os.name is windows.
+                                    description: |-
+                                      procMount denotes the type of proc mount to use for the containers.
+                                      The default is DefaultProcMount which uses the container runtime defaults for
+                                      readonly paths and masked paths.
+                                      This requires the ProcMountType feature flag to be enabled.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
-                                    description: Whether this container has a read-only
-                                      root filesystem. Default is false. Note that
-                                      this field cannot be set when spec.os.name is
-                                      windows.
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
                                   runAsGroup:
-                                    description: The GID to run the entrypoint of
-                                      the container process. Uses runtime default
-                                      if unset. May also be set in PodSecurityContext.  If
-                                      set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence. Note that this field cannot be set
-                                      when spec.os.name is windows.
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   runAsNonRoot:
-                                    description: Indicates that the container must
-                                      run as a non-root user. If true, the Kubelet
-                                      will validate the image at runtime to ensure
-                                      that it does not run as UID 0 (root) and fail
-                                      to start the container if it does. If unset
-                                      or false, no such validation will be performed.
-                                      May also be set in PodSecurityContext.  If set
-                                      in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence.
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: boolean
                                   runAsUser:
-                                    description: The UID to run the entrypoint of
-                                      the container process. Defaults to user specified
-                                      in image metadata if unspecified. May also be
-                                      set in PodSecurityContext.  If set in both SecurityContext
-                                      and PodSecurityContext, the value specified
-                                      in SecurityContext takes precedence. Note that
-                                      this field cannot be set when spec.os.name is
-                                      windows.
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   seLinuxOptions:
-                                    description: The SELinux context to be applied
-                                      to the container. If unspecified, the container
-                                      runtime will allocate a random SELinux context
-                                      for each container.  May also be set in PodSecurityContext.  If
-                                      set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence. Note that this field cannot be set
-                                      when spec.os.name is windows.
+                                    description: |-
+                                      The SELinux context to be applied to the container.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     properties:
                                       level:
                                         description: Level is SELinux level label
@@ -1611,110 +5722,94 @@ spec:
                                         type: string
                                     type: object
                                   seccompProfile:
-                                    description: The seccomp options to use by this
-                                      container. If seccomp options are provided at
-                                      both the pod & container level, the container
-                                      options override the pod options. Note that
-                                      this field cannot be set when spec.os.name is
-                                      windows.
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     properties:
                                       localhostProfile:
-                                        description: localhostProfile indicates a
-                                          profile defined in a file on the node should
-                                          be used. The profile must be preconfigured
-                                          on the node to work. Must be a descending
-                                          path, relative to the kubelet's configured
-                                          seccomp profile location. Must be set if
-                                          type is "Localhost". Must NOT be set for
-                                          any other type.
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
                                         type: string
                                       type:
-                                        description: "type indicates which kind of
-                                          seccomp profile will be applied. Valid options
-                                          are: \n Localhost - a profile defined in
-                                          a file on the node should be used. RuntimeDefault
-                                          - the container runtime default profile
-                                          should be used. Unconfined - no profile
-                                          should be applied."
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
                                         type: string
                                     required:
                                     - type
                                     type: object
                                   windowsOptions:
-                                    description: The Windows specific settings applied
-                                      to all containers. If unspecified, the options
-                                      from the PodSecurityContext will be used. If
-                                      set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence. Note that this field cannot be set
-                                      when spec.os.name is linux.
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options from the PodSecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is linux.
                                     properties:
                                       gmsaCredentialSpec:
-                                        description: GMSACredentialSpec is where the
-                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                          inlines the contents of the GMSA credential
-                                          spec named by the GMSACredentialSpecName
-                                          field.
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
                                         type: string
                                       gmsaCredentialSpecName:
                                         description: GMSACredentialSpecName is the
                                           name of the GMSA credential spec to use.
                                         type: string
                                       hostProcess:
-                                        description: HostProcess determines if a container
-                                          should be run as a 'Host Process' container.
-                                          All of a Pod's containers must have the
-                                          same effective HostProcess value (it is
-                                          not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).
-                                          In addition, if HostProcess is true then
-                                          HostNetwork must also be set to true.
+                                        description: |-
+                                          HostProcess determines if a container should be run as a 'Host Process' container.
+                                          All of a Pod's containers must have the same effective HostProcess value
+                                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
-                                        description: The UserName in Windows to run
-                                          the entrypoint of the container process.
-                                          Defaults to the user specified in image
-                                          metadata if unspecified. May also be set
-                                          in PodSecurityContext. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: string
                                     type: object
                                 type: object
                               startupProbe:
-                                description: 'StartupProbe indicates that the Pod
-                                  has successfully initialized. If specified, no other
-                                  probes are executed until this completes successfully.
-                                  If this probe fails, the Pod will be restarted,
-                                  just as if the livenessProbe failed. This can be
-                                  used to provide different probe parameters at the
-                                  beginning of a Pod''s lifecycle, when it might take
-                                  a long time to load data or warm a cache, than during
-                                  steady-state operation. This cannot be updated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: |-
+                                  StartupProbe indicates that the Pod has successfully initialized.
+                                  If specified, no other probes are executed until this completes successfully.
+                                  If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                  This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                  when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                  This cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 properties:
                                   exec:
                                     description: Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description: Command is the command line to
-                                          execute inside the container, the working
-                                          directory for the command  is root ('/')
-                                          in the container's filesystem. The command
-                                          is simply exec'd, it is not run inside a
-                                          shell, so traditional shell instructions
-                                          ('|', etc) won't work. To use a shell, you
-                                          need to explicitly call out to that shell.
-                                          Exit status of 0 is treated as live/healthy
-                                          and non-zero is unhealthy.
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
-                                    description: Minimum consecutive failures for
-                                      the probe to be considered failed after having
-                                      succeeded. Defaults to 3. Minimum value is 1.
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   grpc:
@@ -1727,11 +5822,12 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
-                                        description: "Service is the name of the service
-                                          to place in the gRPC HealthCheckRequest
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                          \n If this is not specified, the default
-                                          behavior is defined by gRPC."
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
                                         type: string
                                     required:
                                     - port
@@ -1741,8 +5837,8 @@ spec:
                                       to perform.
                                     properties:
                                       host:
-                                        description: Host name to connect to, defaults
-                                          to the pod IP. You probably want to set
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
                                           "Host" in httpHeaders instead.
                                         type: string
                                       httpHeaders:
@@ -1753,10 +5849,9 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name.
-                                                This will be canonicalized upon output,
-                                                so case-variant names will be understood
-                                                as the same header.
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -1766,6 +5861,7 @@ spec:
                                           - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
@@ -1773,35 +5869,35 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Name or number of the port to
-                                          access on the container. Number must be
-                                          in the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description: Scheme to use for connecting
-                                          to the host. Defaults to HTTP.
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
                                         type: string
                                     required:
                                     - port
                                     type: object
                                   initialDelaySeconds:
-                                    description: 'Number of seconds after the container
-                                      has started before liveness probes are initiated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                   periodSeconds:
-                                    description: How often (in seconds) to perform
-                                      the probe. Default to 10 seconds. Minimum value
-                                      is 1.
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   successThreshold:
-                                    description: Minimum consecutive successes for
-                                      the probe to be considered successful after
-                                      having failed. Defaults to 1. Must be 1 for
-                                      liveness and startup. Minimum value is 1.
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
@@ -1816,86 +5912,75 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Number or name of the port to
-                                          access on the container. Number must be
-                                          in the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                     - port
                                     type: object
                                   terminationGracePeriodSeconds:
-                                    description: Optional duration in seconds the
-                                      pod needs to terminate gracefully upon probe
-                                      failure. The grace period is the duration in
-                                      seconds after the processes running in the pod
-                                      are sent a termination signal and the time when
-                                      the processes are forcibly halted with a kill
-                                      signal. Set this value longer than the expected
-                                      cleanup time for your process. If this value
-                                      is nil, the pod's terminationGracePeriodSeconds
-                                      will be used. Otherwise, this value overrides
-                                      the value provided by the pod spec. Value must
-                                      be non-negative integer. The value zero indicates
-                                      stop immediately via the kill signal (no opportunity
-                                      to shut down). This is a beta field and requires
-                                      enabling ProbeTerminationGracePeriod feature
-                                      gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                      is used if unset.
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                     format: int64
                                     type: integer
                                   timeoutSeconds:
-                                    description: 'Number of seconds after which the
-                                      probe times out. Defaults to 1 second. Minimum
-                                      value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                 type: object
                               stdin:
-                                description: Whether this container should allocate
-                                  a buffer for stdin in the container runtime. If
-                                  this is not set, reads from stdin in the container
-                                  will always result in EOF. Default is false.
+                                description: |-
+                                  Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                  is not set, reads from stdin in the container will always result in EOF.
+                                  Default is false.
                                 type: boolean
                               stdinOnce:
-                                description: Whether the container runtime should
-                                  close the stdin channel after it has been opened
-                                  by a single attach. When stdin is true the stdin
-                                  stream will remain open across multiple attach sessions.
-                                  If stdinOnce is set to true, stdin is opened on
-                                  container start, is empty until the first client
-                                  attaches to stdin, and then remains open and accepts
-                                  data until the client disconnects, at which time
-                                  stdin is closed and remains closed until the container
-                                  is restarted. If this flag is false, a container
-                                  processes that reads from stdin will never receive
-                                  an EOF. Default is false
+                                description: |-
+                                  Whether the container runtime should close the stdin channel after it has been opened by
+                                  a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                  sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                  first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                  at which time stdin is closed and remains closed until the container is restarted. If this
+                                  flag is false, a container processes that reads from stdin will never receive an EOF.
+                                  Default is false
                                 type: boolean
                               terminationMessagePath:
-                                description: 'Optional: Path at which the file to
-                                  which the container''s termination message will
-                                  be written is mounted into the container''s filesystem.
-                                  Message written is intended to be brief final status,
-                                  such as an assertion failure message. Will be truncated
-                                  by the node if greater than 4096 bytes. The total
-                                  message length across all containers will be limited
-                                  to 12kb. Defaults to /dev/termination-log. Cannot
-                                  be updated.'
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
                                 type: string
                               terminationMessagePolicy:
-                                description: Indicate how the termination message
-                                  should be populated. File will use the contents
-                                  of terminationMessagePath to populate the container
-                                  status message on both success and failure. FallbackToLogsOnError
-                                  will use the last chunk of container log output
-                                  if the termination message file is empty and the
-                                  container exited with an error. The log output is
-                                  limited to 2048 bytes or 80 lines, whichever is
-                                  smaller. Defaults to File. Cannot be updated.
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
                                 type: string
                               tty:
-                                description: Whether this container should allocate
-                                  a TTY for itself, also requires 'stdin' to be true.
+                                description: |-
+                                  Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
                                   Default is false.
                                 type: boolean
                               volumeDevices:
@@ -1919,61 +6004,116 @@ spec:
                                   - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - devicePath
+                                x-kubernetes-list-type: map
                               volumeMounts:
-                                description: Pod volumes to mount into the container's
-                                  filesystem. Cannot be updated.
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem.
+                                  Cannot be updated.
                                 items:
                                   description: VolumeMount describes a mounting of
                                     a Volume within a container.
                                   properties:
                                     mountPath:
-                                      description: Path within the container at which
-                                        the volume should be mounted.  Must not contain
-                                        ':'.
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
                                       type: string
                                     mountPropagation:
-                                      description: mountPropagation determines how
-                                        mounts are propagated from the host to container
-                                        and the other way around. When not set, MountPropagationNone
-                                        is used. This field is beta in 1.10.
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
+                                        When not set, MountPropagationNone is used.
+                                        This field is beta in 1.10.
+                                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                        (which defaults to None).
                                       type: string
                                     name:
                                       description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
-                                      description: Mounted read-only if true, read-write
-                                        otherwise (false or unspecified). Defaults
-                                        to false.
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
                                       type: boolean
+                                    recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
+
+
+                                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                                        recursively read-only, if it is supported by the container runtime.  If this
+                                        field is set to Enabled, the mount is made recursively read-only if it is
+                                        supported by the container runtime, otherwise the pod will not be started and
+                                        an error will be generated to indicate the reason.
+
+
+                                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                        None (or be unspecified, which defaults to None).
+
+
+                                        If this field is not specified, it is treated as an equivalent of Disabled.
+                                      type: string
                                     subPath:
-                                      description: Path within the volume from which
-                                        the container's volume should be mounted.
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
                                         Defaults to "" (volume's root).
                                       type: string
                                     subPathExpr:
-                                      description: Expanded path within the volume
-                                        from which the container's volume should be
-                                        mounted. Behaves similarly to SubPath but
-                                        environment variable references $(VAR_NAME)
-                                        are expanded using the container's environment.
-                                        Defaults to "" (volume's root). SubPathExpr
-                                        and SubPath are mutually exclusive.
+                                      description: |-
+                                        Expanded path within the volume from which the container's volume should be mounted.
+                                        Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                        Defaults to "" (volume's root).
+                                        SubPathExpr and SubPath are mutually exclusive.
                                       type: string
                                   required:
                                   - mountPath
                                   - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - mountPath
+                                x-kubernetes-list-type: map
                               workingDir:
-                                description: Container's working directory. If not
-                                  specified, the container runtime's default will
-                                  be used, which might be configured in the container
-                                  image. Cannot be updated.
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
                                 type: string
                             required:
                             - name
                             type: object
                           type: array
+                        name:
+                          description: |-
+                            Name of the deployment.
+                            When unset, this defaults to an autogenerated name.
+                          type: string
+                        patch:
+                          description: Patch defines how to perform the patch operation
+                            to deployment
+                          properties:
+                            type:
+                              description: |-
+                                Type is the type of merge operation to perform
+
+
+                                By default, StrategicMerge is used as the patch type.
+                              type: string
+                            value:
+                              description: Object contains the raw configuration for
+                                merged object
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - value
+                          type: object
                         pod:
                           description: Pod defines the desired specification of pod.
                           properties:
@@ -1985,26 +6125,20 @@ spec:
                                     rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node matches the corresponding matchExpressions;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.),
+                                        compute a sum by iterating through the elements of this field and adding
+                                        "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                        node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: An empty preferred scheduling
-                                          term matches all objects with implicit weight
-                                          0 (i.e. it's a no-op). A null preferred
-                                          scheduling term matches no objects (i.e.
-                                          is also a no-op).
+                                        description: |-
+                                          An empty preferred scheduling term matches all objects with implicit weight 0
+                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
                                             description: A node selector term, associated
@@ -2014,84 +6148,70 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchFields:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           weight:
@@ -2105,110 +6225,96 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to an update), the system
+                                        may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
                                             terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector
-                                              term matches no objects. The requirements
-                                              of them are ANDed. The TopologySelectorTerm
-                                              type implements a subset of the NodeSelectorTerm.
+                                            description: |-
+                                              A null or empty node selector term matches no objects. The requirements of
+                                              them are ANDed.
+                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchFields:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                       - nodeSelectorTerms
                                       type: object
@@ -2220,20 +6326,16 @@ spec:
                                     etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node has pods which matches the corresponding
-                                        podAffinityTerm; the node(s) with the highest
-                                        sum are the most preferred.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.),
+                                        compute a sum by iterating through the elements of this field and adding
+                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                        node(s) with the highest sum are the most preferred.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -2245,8 +6347,9 @@ spec:
                                               weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a
-                                                  set of resources, in this case pods.
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -2254,11 +6357,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -2266,57 +6367,73 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -2324,11 +6441,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -2336,78 +6451,61 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -2415,42 +6513,38 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node. When there are
-                                        multiple elements, the lists of nodes corresponding
-                                        to each podAffinityTerm are intersected, i.e.
-                                        all terms must be satisfied.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
+                                        When there are multiple elements, the lists of nodes corresponding to each
+                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set
-                                              of resources, in this case pods.
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -2458,52 +6552,72 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -2511,10 +6625,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -2522,71 +6635,59 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 podAntiAffinity:
                                   description: Describes pod anti-affinity scheduling
@@ -2594,21 +6695,16 @@ spec:
                                     node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the anti-affinity
-                                        expressions specified by this field, but it
-                                        may choose a node that violates one or more
-                                        of the expressions. The node that is most
-                                        preferred is the one with the greatest sum
-                                        of weights, i.e. for each node that meets
-                                        all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling anti-affinity
-                                        expressions, etc.), compute a sum by iterating
-                                        through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which
-                                        matches the corresponding podAffinityTerm;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the anti-affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                        compute a sum by iterating through the elements of this field and adding
+                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                        node(s) with the highest sum are the most preferred.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -2620,8 +6716,9 @@ spec:
                                               weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a
-                                                  set of resources, in this case pods.
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -2629,11 +6726,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -2641,57 +6736,73 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -2699,11 +6810,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -2711,78 +6820,61 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -2790,42 +6882,38 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements
-                                        specified by this field are not met at scheduling
-                                        time, the pod will not be scheduled onto the
-                                        node. If the anti-affinity requirements specified
-                                        by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node. When
-                                        there are multiple elements, the lists of
-                                        nodes corresponding to each podAffinityTerm
-                                        are intersected, i.e. all terms must be satisfied.
+                                      description: |-
+                                        If the anti-affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the anti-affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
+                                        When there are multiple elements, the lists of nodes corresponding to each
+                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set
-                                              of resources, in this case pods.
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -2833,52 +6921,72 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -2886,10 +6994,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -2897,160 +7004,199 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                               type: object
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations are the annotations that should
-                                be appended to the pods. By default, no pod annotations
-                                are appended.
+                              description: |-
+                                Annotations are the annotations that should be appended to the pods.
+                                By default, no pod annotations are appended.
                               type: object
+                            imagePullSecrets:
+                              description: |-
+                                ImagePullSecrets is an optional list of references to secrets
+                                in the same namespace to use for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual puller implementations for them to use.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                              items:
+                                description: |-
+                                  LocalObjectReference contains enough information to let you locate the
+                                  referenced object inside the same namespace.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels are the additional labels that should
-                                be tagged to the pods. By default, no additional pod
-                                labels are tagged.
+                              description: |-
+                                Labels are the additional labels that should be tagged to the pods.
+                                By default, no additional pod labels are tagged.
+                              type: object
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                NodeSelector is a selector which must be true for the pod to fit on a node.
+                                Selector which must match a node's labels for the pod to be scheduled on that node.
+                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                               type: object
                             securityContext:
-                              description: 'SecurityContext holds pod-level security
-                                attributes and common container settings. Optional:
-                                Defaults to empty.  See type description for default
-                                values of each field.'
+                              description: |-
+                                SecurityContext holds pod-level security attributes and common container settings.
+                                Optional: Defaults to empty.  See type description for default values of each field.
                               properties:
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 fsGroup:
-                                  description: "A special supplemental group that
-                                    applies to all containers in a pod. Some volume
-                                    types allow the Kubelet to change the ownership
-                                    of that volume to be owned by the pod: \n 1. The
-                                    owning GID will be the FSGroup 2. The setgid bit
-                                    is set (new files created in the volume will be
-                                    owned by FSGroup) 3. The permission bits are OR'd
-                                    with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows."
+                                  description: |-
+                                    A special supplemental group that applies to all containers in a pod.
+                                    Some volume types allow the Kubelet to change the ownership of that volume
+                                    to be owned by the pod:
+
+
+                                    1. The owning GID will be the FSGroup
+                                    2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                    3. The permission bits are OR'd with rw-rw----
+
+
+                                    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
-                                    of changing ownership and permission of the volume
-                                    before being exposed inside Pod. This field will
-                                    only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.'
+                                  description: |-
+                                    fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will only apply to
+                                    volume types which support fsGroup based ownership(and permissions).
+                                    It will have no effect on ephemeral volume types such as: secret, configmaps
+                                    and emptydir.
+                                    Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in SecurityContext.  If set in
-                                    both SecurityContext and PodSecurityContext, the
-                                    value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    all containers. If unspecified, the container
-                                    runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The SELinux context to be applied to all containers.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                    takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -3070,53 +7216,49 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by the containers
-                                    in this pod. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first
-                                    process run in each container, in addition to
-                                    the container's primary GID, the fsGroup (if specified),
-                                    and group memberships defined in the container
-                                    image for the uid of the container process. If
-                                    unspecified, no additional groups are added to
-                                    any container. Note that group memberships defined
-                                    in the container image for the uid of the container
-                                    process are still effective, even if they are
-                                    not included in this list. Note that this field
-                                    cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    A list of groups applied to the first process run in each container, in addition
+                                    to the container's primary GID, the fsGroup (if specified), and group memberships
+                                    defined in the container image for the uid of the container process. If unspecified,
+                                    no additional groups are added to any container. Note that group memberships
+                                    defined in the container image for the uid of the container process are still effective,
+                                    even if they are not included in this list.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls
-                                    used for the pod. Pods with unsupported sysctls
-                                    (by the container runtime) might fail to launch.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                    sysctls (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -3132,134 +7274,303 @@ spec:
                                     - value
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    within a container's SecurityContext will be used.
-                                    If set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             tolerations:
                               description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to
-                                  tolerates any taint that matches the triple <key,value,effect>
-                                  using the matching operator <operator>.
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect
-                                      to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule,
-                                      PreferNoSchedule and NoExecute.
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration
-                                      applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists;
-                                      this combination means to match all values and
-                                      all keys.
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship
-                                      to the value. Valid operators are Exists and
-                                      Equal. Defaults to Equal. Exists is equivalent
-                                      to wildcard for value, so that a pod can tolerate
-                                      all taints of a particular category.
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the
-                                      period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is
-                                      ignored) tolerates the taint. By default, it
-                                      is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration
-                                      matches to. If the operator is Exists, the value
-                                      should be empty, otherwise just a regular string.
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
+                            topologySpreadConstraints:
+                              description: |-
+                                TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                All topologySpreadConstraints are ANDed.
+                              items:
+                                description: TopologySpreadConstraint specifies how
+                                  to spread matching pods among the given topology.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is used to find matching pods.
+                                      Pods that match this label selector are counted to determine the number of pods
+                                      in their corresponding topology domain.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select the pods over which
+                                      spreading will be calculated. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are ANDed with labelSelector
+                                      to select the group of existing pods over which spreading will be calculated
+                                      for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                      MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      Keys that don't exist in the incoming pod labels will
+                                      be ignored. A null or empty list means only match against labelSelector.
+
+
+                                      This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  maxSkew:
+                                    description: |-
+                                      MaxSkew describes the degree to which pods may be unevenly distributed.
+                                      When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                      between the number of matching pods in the target topology and the global minimum.
+                                      The global minimum is the minimum number of matching pods in an eligible domain
+                                      or zero if the number of eligible domains is less than MinDomains.
+                                      For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                      labelSelector spread as 2/2/1:
+                                      In this case, the global minimum is 1.
+                                      | zone1 | zone2 | zone3 |
+                                      |  P P  |  P P  |   P   |
+                                      - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                      scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                      violate MaxSkew(1).
+                                      - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                      When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                      to topologies that satisfy it.
+                                      It's a required field. Default value is 1 and 0 is not allowed.
+                                    format: int32
+                                    type: integer
+                                  minDomains:
+                                    description: |-
+                                      MinDomains indicates a minimum number of eligible domains.
+                                      When the number of eligible domains with matching topology keys is less than minDomains,
+                                      Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                      And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                      this value has no effect on scheduling.
+                                      As a result, when the number of eligible domains is less than minDomains,
+                                      scheduler won't schedule more than maxSkew Pods to those domains.
+                                      If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                      Valid values are integers greater than 0.
+                                      When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                                      For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                      labelSelector spread as 2/2/2:
+                                      | zone1 | zone2 | zone3 |
+                                      |  P P  |  P P  |  P P  |
+                                      The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                      In this situation, new pod with the same labelSelector cannot be scheduled,
+                                      because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                      it will violate MaxSkew.
+                                    format: int32
+                                    type: integer
+                                  nodeAffinityPolicy:
+                                    description: |-
+                                      NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options are:
+                                      - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                      - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                      If this value is nil, the behavior is equivalent to the Honor policy.
+                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    description: |-
+                                      NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                      pod topology spread skew. Options are:
+                                      - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                      has a toleration, are included.
+                                      - Ignore: node taints are ignored. All nodes are included.
+
+
+                                      If this value is nil, the behavior is equivalent to the Ignore policy.
+                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                    type: string
+                                  topologyKey:
+                                    description: |-
+                                      TopologyKey is the key of node labels. Nodes that have a label with this key
+                                      and identical values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket", and try to put balanced number
+                                      of pods into each bucket.
+                                      We define a domain as a particular instance of a topology.
+                                      Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                      nodeAffinityPolicy and nodeTaintsPolicy.
+                                      e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                      And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                      It's a required field.
+                                    type: string
+                                  whenUnsatisfiable:
+                                    description: |-
+                                      WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                      the spread constraint.
+                                      - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                      - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                        but giving higher precedence to topologies that would help reduce the
+                                        skew.
+                                      A constraint is considered "Unsatisfiable" for an incoming pod
+                                      if and only if every possible node assignment for that pod would violate
+                                      "MaxSkew" on some topology.
+                                      For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                      labelSelector spread as 3/1/1:
+                                      | zone1 | zone2 | zone3 |
+                                      | P P P |   P   |   P   |
+                                      If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                      to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                      MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                      won't make it *more* imbalanced.
+                                      It's a required field.
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
+                                type: object
+                              type: array
                             volumes:
-                              description: 'Volumes that can be mounted by containers
-                                belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              description: |-
+                                Volumes that can be mounted by containers belonging to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes
                               items:
                                 description: Volume represents a named volume in a
                                   pod that may be accessed by any container in the
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'awsElasticBlockStore represents
-                                      an AWS Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: |-
+                                      awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly value true will force
-                                          the readOnly setting in VolumeMounts. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          readOnly value true will force the readOnly setting in VolumeMounts.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: boolean
                                       volumeID:
-                                        description: 'volumeID is unique ID of the
-                                          persistent disk resource in AWS (Amazon
-                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: string
                                     required:
                                     - volumeID
@@ -3282,11 +7593,10 @@ spec:
                                           in the blob storage
                                         type: string
                                       fsType:
-                                        description: fsType is Filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is Filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
                                         description: 'kind expected values are Shared:
@@ -3296,9 +7606,9 @@ spec:
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
@@ -3310,9 +7620,9 @@ spec:
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
                                         description: secretName is the  name of secret
@@ -3332,83 +7642,95 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'monitors is Required: Monitors
-                                          is a collection of Ceph monitors More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is Required: Monitors is a collection of Ceph monitors
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description: 'path is Optional: Used as the
                                           mounted root, rather than the full Ceph
                                           tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: boolean
                                       secretFile:
-                                        description: 'secretFile is Optional: SecretFile
-                                          is the path to key ring for User, default
-                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                       secretRef:
-                                        description: 'secretRef is Optional: SecretRef
-                                          is reference to the authentication secret
-                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is optional: User is the
-                                          rados user name, default is admin More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          user is optional: User is the rados user name, default is admin
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'cinder represents a cinder volume
-                                      attached and mounted on kubelets host machine.
-                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                       readOnly:
-                                        description: 'readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is optional: points
-                                          to a secret object containing parameters
-                                          used to connect to OpenStack.'
+                                        description: |-
+                                          secretRef is optional: points to a secret object containing parameters used to connect
+                                          to OpenStack.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeID:
-                                        description: 'volumeID used to identify the
-                                          volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          volumeID used to identify the volume in cinder.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                     required:
                                     - volumeID
@@ -3418,33 +7740,25 @@ spec:
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                        description: |-
+                                          defaultMode is optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items if unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the ConfigMap, the volume setup will
-                                          error unless it is marked optional. Paths
-                                          must be relative and may not contain the
-                                          '..' path or start with '..'.
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the ConfigMap,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -3453,37 +7767,38 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
                                           - path
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                       optional:
                                         description: optional specify whether the
@@ -3497,48 +7812,48 @@ spec:
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: driver is the name of the CSI
-                                          driver that handles this volume. Consult
-                                          with your admin for the correct name as
-                                          registered in the cluster.
+                                        description: |-
+                                          driver is the name of the CSI driver that handles this volume.
+                                          Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: fsType to mount. Ex. "ext4",
-                                          "xfs", "ntfs". If not provided, the empty
-                                          value is passed to the associated CSI driver
-                                          which will determine the default filesystem
-                                          to apply.
+                                        description: |-
+                                          fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                          If not provided, the empty value is passed to the associated CSI driver
+                                          which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: nodePublishSecretRef is a reference
-                                          to the secret object containing sensitive
-                                          information to pass to the CSI driver to
-                                          complete the CSI NodePublishVolume and NodeUnpublishVolume
-                                          calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                        description: |-
+                                          nodePublishSecretRef is a reference to the secret object containing
+                                          sensitive information to pass to the CSI driver to complete the CSI
+                                          NodePublishVolume and NodeUnpublishVolume calls.
+                                          This field is optional, and  may be empty if no secret is required. If the
+                                          secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       readOnly:
-                                        description: readOnly specifies a read-only
-                                          configuration for the volume. Defaults to
-                                          false (read/write).
+                                        description: |-
+                                          readOnly specifies a read-only configuration for the volume.
+                                          Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: volumeAttributes stores driver-specific
-                                          properties that are passed to the CSI driver.
-                                          Consult your driver's documentation for
-                                          supported values.
+                                        description: |-
+                                          volumeAttributes stores driver-specific properties that are passed to the CSI
+                                          driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
@@ -3548,19 +7863,15 @@ spec:
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on
-                                          created files by default. Must be a Optional:
-                                          mode bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                        description: |-
+                                          Optional: mode bits to use on created files by default. Must be a
+                                          Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       items:
@@ -3574,7 +7885,7 @@ spec:
                                             fieldRef:
                                               description: 'Required: Selects a field
                                                 of the pod: only annotations, labels,
-                                                name and namespace are supported.'
+                                                name, namespace and uid are supported.'
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -3590,18 +7901,13 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file, must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
                                               format: int32
                                               type: integer
                                             path:
@@ -3613,11 +7919,9 @@ spec:
                                                 path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                requests.cpu and requests.memory)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -3645,136 +7949,129 @@ spec:
                                           - path
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   emptyDir:
-                                    description: 'emptyDir represents a temporary
-                                      directory that shares a pod''s lifetime. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      emptyDir represents a temporary directory that shares a pod's lifetime.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     properties:
                                       medium:
-                                        description: 'medium represents what type
-                                          of storage medium should back this directory.
-                                          The default is "" which means to use the
-                                          node''s default medium. Must be an empty
-                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: |-
+                                          medium represents what type of storage medium should back this directory.
+                                          The default is "" which means to use the node's default medium.
+                                          Must be an empty string (default) or Memory.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
-                                          of local storage required for this EmptyDir
-                                          volume. The size limit is also applicable
-                                          for memory medium. The maximum usage on
-                                          memory medium EmptyDir would be the minimum
-                                          value between the SizeLimit specified here
-                                          and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: |-
+                                          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                          The size limit is also applicable for memory medium.
+                                          The maximum usage on memory medium EmptyDir would be the minimum value between
+                                          the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                          The default is nil which means that the limit is undefined.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "ephemeral represents a volume that
-                                      is handled by a cluster storage driver. The
-                                      volume's lifecycle is tied to the pod that defines
-                                      it - it will be created before the pod starts,
-                                      and deleted when the pod is removed. \n Use
-                                      this if: a) the volume is only needed while
-                                      the pod runs, b) features of normal volumes
-                                      like restoring from snapshot or capacity tracking
-                                      are needed, c) the storage driver is specified
-                                      through a storage class, and d) the storage
-                                      driver supports dynamic volume provisioning
-                                      through a PersistentVolumeClaim (see EphemeralVolumeSource
-                                      for more information on the connection between
-                                      this volume type and PersistentVolumeClaim).
-                                      \n Use PersistentVolumeClaim or one of the vendor-specific
-                                      APIs for volumes that persist for longer than
-                                      the lifecycle of an individual pod. \n Use CSI
-                                      for light-weight local ephemeral volumes if
-                                      the CSI driver is meant to be used that way
-                                      - see the documentation of the driver for more
-                                      information. \n A pod can use both types of
-                                      ephemeral volumes and persistent volumes at
-                                      the same time."
+                                    description: |-
+                                      ephemeral represents a volume that is handled by a cluster storage driver.
+                                      The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                      and deleted when the pod is removed.
+
+
+                                      Use this if:
+                                      a) the volume is only needed while the pod runs,
+                                      b) features of normal volumes like restoring from snapshot or capacity
+                                         tracking are needed,
+                                      c) the storage driver is specified through a storage class, and
+                                      d) the storage driver supports dynamic volume provisioning through
+                                         a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                         information on the connection between this volume type
+                                         and PersistentVolumeClaim).
+
+
+                                      Use PersistentVolumeClaim or one of the vendor-specific
+                                      APIs for volumes that persist for longer than the lifecycle
+                                      of an individual pod.
+
+
+                                      Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                      be used that way - see the documentation of the driver for
+                                      more information.
+
+
+                                      A pod can use both types of ephemeral volumes and
+                                      persistent volumes at the same time.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: "Will be used to create a stand-alone
-                                          PVC to provision the volume. The pod in
-                                          which this EphemeralVolumeSource is embedded
-                                          will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
-                                          Pod validation will reject the pod if the
-                                          concatenated name is not valid for a PVC
-                                          (for example, too long). \n An existing
-                                          PVC with that name that is not owned by
-                                          the pod will *not* be used for the pod to
-                                          avoid using an unrelated volume by mistake.
-                                          Starting the pod is then blocked until the
-                                          unrelated PVC is removed. If such a pre-created
-                                          PVC is meant to be used by the pod, the
-                                          PVC has to updated with an owner reference
-                                          to the pod once the pod exists. Normally
-                                          this should not be necessary, but it may
-                                          be useful when manually reconstructing a
-                                          broken cluster. \n This field is read-only
-                                          and no changes will be made by Kubernetes
-                                          to the PVC after it has been created. \n
-                                          Required, must not be nil."
+                                        description: |-
+                                          Will be used to create a stand-alone PVC to provision the volume.
+                                          The pod in which this EphemeralVolumeSource is embedded will be the
+                                          owner of the PVC, i.e. the PVC will be deleted together with the
+                                          pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                          `<volume name>` is the name from the `PodSpec.Volumes` array
+                                          entry. Pod validation will reject the pod if the concatenated name
+                                          is not valid for a PVC (for example, too long).
+
+
+                                          An existing PVC with that name that is not owned by the pod
+                                          will *not* be used for the pod to avoid using an unrelated
+                                          volume by mistake. Starting the pod is then blocked until
+                                          the unrelated PVC is removed. If such a pre-created PVC is
+                                          meant to be used by the pod, the PVC has to updated with an
+                                          owner reference to the pod once the pod exists. Normally
+                                          this should not be necessary, but it may be useful when
+                                          manually reconstructing a broken cluster.
+
+
+                                          This field is read-only and no changes will be made by Kubernetes
+                                          to the PVC after it has been created.
+
+
+                                          Required, must not be nil.
                                         properties:
                                           metadata:
-                                            description: May contain labels and annotations
-                                              that will be copied into the PVC when
-                                              creating it. No other fields are allowed
-                                              and will be rejected during validation.
+                                            description: |-
+                                              May contain labels and annotations that will be copied into the PVC
+                                              when creating it. No other fields are allowed and will be rejected during
+                                              validation.
                                             type: object
                                           spec:
-                                            description: The specification for the
-                                              PersistentVolumeClaim. The entire content
-                                              is copied unchanged into the PVC that
-                                              gets created from this template. The
-                                              same fields as in a PersistentVolumeClaim
+                                            description: |-
+                                              The specification for the PersistentVolumeClaim. The entire content is
+                                              copied unchanged into the PVC that gets created from this
+                                              template. The same fields as in a PersistentVolumeClaim
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'accessModes contains
-                                                  the desired access modes the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                description: |-
+                                                  accessModes contains the desired access modes the volume should have.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               dataSource:
-                                                description: 'dataSource field can
-                                                  be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                description: |-
+                                                  dataSource field can be used to specify either:
+                                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                   * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source. When
-                                                  the AnyVolumeDataSource feature
-                                                  gate is enabled, dataSource contents
-                                                  will be copied to dataSourceRef,
-                                                  and dataSourceRef contents will
-                                                  be copied to dataSource when dataSourceRef.namespace
-                                                  is not specified. If the namespace
-                                                  is specified, then dataSourceRef
-                                                  will not be copied to dataSource.'
+                                                  If the provisioner or an external controller can support the specified data source,
+                                                  it will create a new volume based on the contents of the specified data source.
+                                                  When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                                  and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                                  If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -3790,57 +8087,36 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: 'dataSourceRef specifies
-                                                  the object from which to populate
-                                                  the volume with data, if a non-empty
-                                                  volume is desired. This may be any
-                                                  object from a non-empty API group
-                                                  (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner. This field
-                                                  will replace the functionality of
-                                                  the dataSource field and as such
-                                                  if both fields are non-empty, they
-                                                  must have the same value. For backwards
-                                                  compatibility, when namespace isn''t
-                                                  specified in dataSourceRef, both
-                                                  fields (dataSource and dataSourceRef)
-                                                  will be set to the same value automatically
-                                                  if one of them is empty and the
-                                                  other is non-empty. When namespace
-                                                  is specified in dataSourceRef, dataSource
-                                                  isn''t set to the same value and
-                                                  must be empty. There are three important
-                                                  differences between dataSource and
-                                                  dataSourceRef: * While dataSource
-                                                  only allows two specific types of
-                                                  objects, dataSourceRef allows any
-                                                  non-core object, as well as PersistentVolumeClaim
-                                                  objects. * While dataSource ignores
-                                                  disallowed values (dropping them),
-                                                  dataSourceRef preserves all values,
-                                                  and generates an error if a disallowed
-                                                  value is specified. * While dataSource
-                                                  only allows local objects, dataSourceRef
-                                                  allows objects in any namespaces.
-                                                  (Beta) Using this field requires
-                                                  the AnyVolumeDataSource feature
-                                                  gate to be enabled. (Alpha) Using
-                                                  the namespace field of dataSourceRef
-                                                  requires the CrossNamespaceVolumeDataSource
-                                                  feature gate to be enabled.'
+                                                description: |-
+                                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                  volume is desired. This may be any object from a non-empty API group (non
+                                                  core object) or a PersistentVolumeClaim object.
+                                                  When this field is specified, volume binding will only succeed if the type of
+                                                  the specified object matches some installed volume populator or dynamic
+                                                  provisioner.
+                                                  This field will replace the functionality of the dataSource field and as such
+                                                  if both fields are non-empty, they must have the same value. For backwards
+                                                  compatibility, when namespace isn't specified in dataSourceRef,
+                                                  both fields (dataSource and dataSourceRef) will be set to the same
+                                                  value automatically if one of them is empty and the other is non-empty.
+                                                  When namespace is specified in dataSourceRef,
+                                                  dataSource isn't set to the same value and must be empty.
+                                                  There are three important differences between dataSource and dataSourceRef:
+                                                  * While dataSource only allows two specific types of objects, dataSourceRef
+                                                    allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                  * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                    preserves all values, and generates an error if a disallowed value is
+                                                    specified.
+                                                  * While dataSource only allows local objects, dataSourceRef allows objects
+                                                    in any namespaces.
+                                                  (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                  (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -3851,63 +8127,23 @@ spec:
                                                       of resource being referenced
                                                     type: string
                                                   namespace:
-                                                    description: Namespace is the
-                                                      namespace of resource being
-                                                      referenced Note that when a
-                                                      namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                                      object is required in the referent
-                                                      namespace to allow that namespace's
-                                                      owner to accept the reference.
-                                                      See the ReferenceGrant documentation
-                                                      for details. (Alpha) This field
-                                                      requires the CrossNamespaceVolumeDataSource
-                                                      feature gate to be enabled.
+                                                    description: |-
+                                                      Namespace is the namespace of resource being referenced
+                                                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                     type: string
                                                 required:
                                                 - kind
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'resources represents
-                                                  the minimum resources the volume
-                                                  should have. If RecoverVolumeExpansionFailure
-                                                  feature is enabled users are allowed
-                                                  to specify resource requirements
-                                                  that are lower than previous value
-                                                  but must still be higher than capacity
-                                                  recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                description: |-
+                                                  resources represents the minimum resources the volume should have.
+                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  that are lower than previous value but must still be higher than capacity recorded in the
+                                                  status field of the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                                 properties:
-                                                  claims:
-                                                    description: "Claims lists the
-                                                      names of resources, defined
-                                                      in spec.resourceClaims, that
-                                                      are used by this container.
-                                                      \n This is an alpha field and
-                                                      requires enabling the DynamicResourceAllocation
-                                                      feature gate. \n This field
-                                                      is immutable. It can only be
-                                                      set for containers."
-                                                    items:
-                                                      description: ResourceClaim references
-                                                        one entry in PodSpec.ResourceClaims.
-                                                      properties:
-                                                        name:
-                                                          description: Name must match
-                                                            the name of one entry
-                                                            in pod.spec.resourceClaims
-                                                            of the Pod where this
-                                                            field is used. It makes
-                                                            that resource available
-                                                            inside a container.
-                                                          type: string
-                                                      required:
-                                                      - name
-                                                      type: object
-                                                    type: array
-                                                    x-kubernetes-list-map-keys:
-                                                    - name
-                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     additionalProperties:
                                                       anyOf:
@@ -3915,10 +8151,9 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Limits describes
-                                                      the maximum amount of compute
-                                                      resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Limits describes the maximum amount of compute resources allowed.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -3927,15 +8162,11 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Requests describes
-                                                      the minimum amount of compute
-                                                      resources required. If Requests
-                                                      is omitted for a container,
-                                                      it defaults to Limits if that
-                                                      is explicitly specified, otherwise
-                                                      to an implementation-defined
-                                                      value. Requests cannot exceed
-                                                      Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Requests describes the minimum amount of compute resources required.
+                                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                 type: object
                                               selector:
@@ -3948,11 +8179,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -3960,56 +8189,60 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               storageClassName:
-                                                description: 'storageClassName is
-                                                  the name of the StorageClass required
-                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: |-
+                                                  storageClassName is the name of the StorageClass required by the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                                type: string
+                                              volumeAttributesClassName:
+                                                description: |-
+                                                  volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                                  If specified, the CSI driver will create or update the volume with the attributes defined
+                                                  in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                                  it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                                  will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                                  If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                                  will be set by the persistentvolume controller if it exists.
+                                                  If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                                  set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                                  exists.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                                  (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                                 type: string
                                               volumeMode:
-                                                description: volumeMode defines what
-                                                  type of volume is required by the
-                                                  claim. Value of Filesystem is implied
-                                                  when not included in claim spec.
+                                                description: |-
+                                                  volumeMode defines what type of volume is required by the claim.
+                                                  Value of Filesystem is implied when not included in claim spec.
                                                 type: string
                                               volumeName:
                                                 description: volumeName is the binding
@@ -4027,13 +8260,11 @@ spec:
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. TODO: how do we prevent
-                                          errors in the filesystem from compromising
-                                          the machine'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       lun:
                                         description: 'lun is Optional: FC target lun
@@ -4041,9 +8272,9 @@ spec:
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       targetWWNs:
                                         description: 'targetWWNs is Optional: FC target
@@ -4051,30 +8282,30 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       wwids:
-                                        description: 'wwids Optional: FC volume world
-                                          wide identifiers (wwids) Either wwids or
-                                          combination of targetWWNs and lun must be
-                                          set, but not both simultaneously.'
+                                        description: |-
+                                          wwids Optional: FC volume world wide identifiers (wwids)
+                                          Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   flexVolume:
-                                    description: flexVolume represents a generic volume
-                                      resource that is provisioned/attached using
-                                      an exec based plugin.
+                                    description: |-
+                                      flexVolume represents a generic volume resource that is
+                                      provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
                                         description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". The default filesystem depends
-                                          on FlexVolume script.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
@@ -4083,24 +8314,28 @@ spec:
                                           holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'readOnly is Optional: defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is Optional: secretRef
-                                          is reference to the secret object containing
-                                          sensitive information to pass to the plugin
-                                          scripts. This may be empty if no secret
-                                          object is specified. If the secret object
-                                          contains more than one secret, all secrets
-                                          are passed to the plugin scripts.'
+                                        description: |-
+                                          secretRef is Optional: secretRef is reference to the secret object containing
+                                          sensitive information to pass to the plugin scripts. This may be
+                                          empty if no secret object is specified. If the secret object
+                                          contains more than one secret, all secrets are passed to the plugin
+                                          scripts.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -4113,9 +8348,9 @@ spec:
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: datasetName is Name of the dataset
-                                          stored as metadata -> name on the dataset
-                                          for Flocker should be considered as deprecated
+                                        description: |-
+                                          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                          should be considered as deprecated
                                         type: string
                                       datasetUUID:
                                         description: datasetUUID is the UUID of the
@@ -4124,60 +8359,55 @@ spec:
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'gcePersistentDisk represents a GCE
-                                      Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     properties:
                                       fsType:
-                                        description: 'fsType is filesystem type of
-                                          the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'pdName is unique name of the
-                                          PD resource in GCE. Used to identify the
-                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'gitRepo represents a git repository
-                                      at a particular revision. DEPRECATED: GitRepo
-                                      is deprecated. To provision a container with
-                                      a git repo, mount an EmptyDir into an InitContainer
-                                      that clones the repo using git, then mount the
-                                      EmptyDir into the Pod''s container.'
+                                    description: |-
+                                      gitRepo represents a git repository at a particular revision.
+                                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                      EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                      into the Pod's container.
                                     properties:
                                       directory:
-                                        description: directory is the target directory
-                                          name. Must not contain or start with '..'.  If
-                                          '.' is supplied, the volume directory will
-                                          be the git repository.  Otherwise, if specified,
-                                          the volume will contain the git repository
-                                          in the subdirectory with the given name.
+                                        description: |-
+                                          directory is the target directory name.
+                                          Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                          git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                          the subdirectory with the given name.
                                         type: string
                                       repository:
                                         description: repository is the URL
@@ -4190,57 +8420,61 @@ spec:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'glusterfs represents a Glusterfs
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                    description: |-
+                                      glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                     properties:
                                       endpoints:
-                                        description: 'endpoints is the endpoint name
-                                          that details Glusterfs topology. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          endpoints is the endpoint name that details Glusterfs topology.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       path:
-                                        description: 'path is the Glusterfs volume
-                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          path is the Glusterfs volume path.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          Glusterfs volume to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'hostPath represents a pre-existing
-                                      file or directory on the host machine that is
-                                      directly exposed to the container. This is generally
-                                      used for system agents or other privileged things
-                                      that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                      --- TODO(jonesdl) We need to restrict who can
-                                      use host directory mounts and who can/can not
-                                      mount host directories as read/write.'
+                                    description: |-
+                                      hostPath represents a pre-existing file or directory on the host
+                                      machine that is directly exposed to the container. This is generally
+                                      used for system agents or other privileged things that are allowed
+                                      to see the host machine. Most containers will NOT need this.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                      ---
+                                      TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                      mount host directories as read/write.
                                     properties:
                                       path:
-                                        description: 'path of the directory on the
-                                          host. If the path is a symlink, it will
-                                          follow the link to the real path. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          path of the directory on the host.
+                                          If the path is a symlink, it will follow the link to the real path.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                       type:
-                                        description: 'type for HostPath Volume Defaults
-                                          to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          type for HostPath Volume
+                                          Defaults to ""
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'iscsi represents an ISCSI Disk resource
-                                      that is attached to a kubelet''s host machine
-                                      and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                    description: |-
+                                      iscsi represents an ISCSI Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://examples.k8s.io/volumes/iscsi/README.md
                                     properties:
                                       chapAuthDiscovery:
                                         description: chapAuthDiscovery defines whether
@@ -4251,31 +8485,27 @@ spec:
                                           support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       initiatorName:
-                                        description: initiatorName is the custom iSCSI
-                                          Initiator Name. If initiatorName is specified
-                                          with iscsiInterface simultaneously, new
-                                          iSCSI interface <target portal>:<volume
-                                          name> will be created for the connection.
+                                        description: |-
+                                          initiatorName is the custom iSCSI Initiator Name.
+                                          If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                          <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
                                         description: iqn is the target iSCSI Qualified
                                           Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iscsiInterface is the interface
-                                          Name that uses an iSCSI transport. Defaults
-                                          to 'default' (tcp).
+                                        description: |-
+                                          iscsiInterface is the interface Name that uses an iSCSI transport.
+                                          Defaults to 'default' (tcp).
                                         type: string
                                       lun:
                                         description: lun represents iSCSI Target Lun
@@ -4283,35 +8513,39 @@ spec:
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: portals is the iSCSI Target Portal
-                                          List. The portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       readOnly:
-                                        description: readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false.
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
                                         type: boolean
                                       secretRef:
                                         description: secretRef is the CHAP Secret
                                           for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       targetPortal:
-                                        description: targetPortal is iSCSI Target
-                                          Portal. The Portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -4319,45 +8553,51 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'name of the volume. Must be a DNS_LABEL
-                                      and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: |-
+                                      name of the volume.
+                                      Must be a DNS_LABEL and unique within the pod.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   nfs:
-                                    description: 'nfs represents an NFS mount on the
-                                      host that shares a pod''s lifetime More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      nfs represents an NFS mount on the host that shares a pod's lifetime
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     properties:
                                       path:
-                                        description: 'path that is exported by the
-                                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          path that is exported by the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          NFS export to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          readOnly here will force the NFS export to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: boolean
                                       server:
-                                        description: 'server is the hostname or IP
-                                          address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          server is the hostname or IP address of the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'persistentVolumeClaimVolumeSource
-                                      represents a reference to a PersistentVolumeClaim
-                                      in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: |-
+                                      persistentVolumeClaimVolumeSource represents a reference to a
+                                      PersistentVolumeClaim in the same namespace.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                     properties:
                                       claimName:
-                                        description: 'claimName is the name of a PersistentVolumeClaim
-                                          in the same namespace as the pod using this
-                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        description: |-
+                                          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                         type: string
                                       readOnly:
-                                        description: readOnly Will force the ReadOnly
-                                          setting in VolumeMounts. Default false.
+                                        description: |-
+                                          readOnly Will force the ReadOnly setting in VolumeMounts.
+                                          Default false.
                                         type: boolean
                                     required:
                                     - claimName
@@ -4368,11 +8608,10 @@ spec:
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
                                         description: pdID is the ID that identifies
@@ -4387,16 +8626,15 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fSType represents the filesystem
-                                          type to mount Must be a filesystem type
-                                          supported by the host operating system.
-                                          Ex. "ext4", "xfs". Implicitly inferred to
-                                          be "ext4" if unspecified.
+                                        description: |-
+                                          fSType represents the filesystem type to mount
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
                                         description: volumeID uniquely identifies
@@ -4410,17 +8648,13 @@ spec:
                                       secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: defaultMode are the mode bits
-                                          used to set permissions on created files
-                                          by default. Must be an octal value between
-                                          0000 and 0777 or a decimal value between
-                                          0 and 511. YAML accepts both octal and decimal
-                                          values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting. This might
-                                          be in conflict with other options that affect
-                                          the file mode, like fsGroup, and the result
-                                          can be other mode bits set.
+                                        description: |-
+                                          defaultMode are the mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
@@ -4430,26 +8664,117 @@ spec:
                                           description: Projection that may be projected
                                             along with other supported volume types
                                           properties:
+                                            clusterTrustBundle:
+                                              description: |-
+                                                ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                                of ClusterTrustBundle objects in an auto-updating file.
+
+
+                                                Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+
+                                                ClusterTrustBundle objects can either be selected by name, or by the
+                                                combination of signer name and a label selector.
+
+
+                                                Kubelet performs aggressive normalization of the PEM contents written
+                                                into the pod filesystem.  Esoteric PEM features such as inter-block
+                                                comments and block headers are stripped.  Certificates are deduplicated.
+                                                The ordering of certificates within the file is arbitrary, and Kubelet
+                                                may change the order over time.
+                                              properties:
+                                                labelSelector:
+                                                  description: |-
+                                                    Select all ClusterTrustBundles that match this label selector.  Only has
+                                                    effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                    interpreted as "match nothing".  If set but empty, interpreted as "match
+                                                    everything".
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                name:
+                                                  description: |-
+                                                    Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                                    with signerName and labelSelector.
+                                                  type: string
+                                                optional:
+                                                  description: |-
+                                                    If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                    aren't available.  If using name, then the named ClusterTrustBundle is
+                                                    allowed not to exist.  If using signerName, then the combination of
+                                                    signerName and labelSelector is allowed to match zero
+                                                    ClusterTrustBundles.
+                                                  type: boolean
+                                                path:
+                                                  description: Relative path from
+                                                    the volume root to write the bundle.
+                                                  type: string
+                                                signerName:
+                                                  description: |-
+                                                    Select all ClusterTrustBundles that match this signer name.
+                                                    Mutually-exclusive with name.  The contents of all selected
+                                                    ClusterTrustBundles will be unified and deduplicated.
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
                                             configMap:
                                               description: configMap information about
                                                 the configMap data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced ConfigMap
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the ConfigMap,
-                                                    the volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    ConfigMap will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present. If a key is specified which is not present in the ConfigMap,
+                                                    the volume setup will error unless it is marked optional. Paths must be
+                                                    relative and may not contain the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -4459,43 +8784,38 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
+                                                          This might be in conflict with other options that affect the file
+                                                          mode, like fsGroup, and the result can be other mode bits set.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
                                                     - path
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                   type: string
                                                 optional:
                                                   description: optional specify whether
@@ -4520,8 +8840,8 @@ spec:
                                                       fieldRef:
                                                         description: 'Required: Selects
                                                           a field of the pod: only
-                                                          annotations, labels, name
-                                                          and namespace are supported.'
+                                                          annotations, labels, name,
+                                                          namespace and uid are supported.'
                                                         properties:
                                                           apiVersion:
                                                             description: Version of
@@ -4539,22 +8859,13 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
-                                                          on this file, must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                        description: |-
+                                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
+                                                          This might be in conflict with other options that affect the file
+                                                          mode, like fsGroup, and the result can be other mode bits set.
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -4569,12 +8880,9 @@ spec:
                                                           ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource
-                                                          of the container: only resources
-                                                          limits and requests (limits.cpu,
-                                                          limits.memory, requests.cpu
-                                                          and requests.memory) are
-                                                          currently supported.'
+                                                        description: |-
+                                                          Selects a resource of the container: only resources limits and requests
+                                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                         properties:
                                                           containerName:
                                                             description: 'Container
@@ -4603,27 +8911,21 @@ spec:
                                                     - path
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             secret:
                                               description: secret information about
                                                 the secret data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced Secret
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the Secret, the
-                                                    volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    Secret will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present. If a key is specified which is not present in the Secret,
+                                                    the volume setup will error unless it is marked optional. Paths must be
+                                                    relative and may not contain the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -4633,43 +8935,38 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
+                                                          This might be in conflict with other options that affect the file
+                                                          mode, like fsGroup, and the result can be other mode bits set.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
                                                     - path
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                   type: string
                                                 optional:
                                                   description: optional field specify
@@ -4684,70 +8981,62 @@ spec:
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: audience is the intended
-                                                    audience of the token. A recipient
-                                                    of a token must identify itself
-                                                    with an identifier specified in
-                                                    the audience of the token, and
-                                                    otherwise should reject the token.
-                                                    The audience defaults to the identifier
-                                                    of the apiserver.
+                                                  description: |-
+                                                    audience is the intended audience of the token. A recipient of a token
+                                                    must identify itself with an identifier specified in the audience of the
+                                                    token, and otherwise should reject the token. The audience defaults to the
+                                                    identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: expirationSeconds is
-                                                    the requested duration of validity
-                                                    of the service account token.
-                                                    As the token approaches expiration,
-                                                    the kubelet volume plugin will
-                                                    proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                  description: |-
+                                                    expirationSeconds is the requested duration of validity of the service
+                                                    account token. As the token approaches expiration, the kubelet volume
+                                                    plugin will proactively rotate the service account token. The kubelet will
+                                                    start trying to rotate the token if the token is older than 80 percent of
+                                                    its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                    and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: path is the path relative
-                                                    to the mount point of the file
-                                                    to project the token into.
+                                                  description: |-
+                                                    path is the path relative to the mount point of the file to project the
+                                                    token into.
                                                   type: string
                                               required:
                                               - path
                                               type: object
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   quobyte:
                                     description: quobyte represents a Quobyte mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: group to map volume access to
+                                        description: |-
+                                          group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: readOnly here will force the
-                                          Quobyte volume to be mounted with read-only
-                                          permissions. Defaults to false.
+                                        description: |-
+                                          readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                          Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: registry represents a single
-                                          or multiple Quobyte Registry services specified
-                                          as a string as host:port pair (multiple
-                                          entries are separated with commas) which
-                                          acts as the central registry for volumes
+                                        description: |-
+                                          registry represents a single or multiple Quobyte Registry services
+                                          specified as a string as host:port pair (multiple entries are separated with commas)
+                                          which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: tenant owning the given Quobyte
-                                          volume in the Backend Used with dynamically
-                                          provisioned Quobyte volumes, value is set
-                                          by the plugin
+                                        description: |-
+                                          tenant owning the given Quobyte volume in the Backend
+                                          Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: user to map volume access to
+                                        description: |-
+                                          user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
@@ -4759,61 +9048,74 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'rbd represents a Rados Block Device
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                    description: |-
+                                      rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       image:
-                                        description: 'image is the rados image name.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       keyring:
-                                        description: 'keyring is the path to key ring
-                                          for RBDUser. Default is /etc/ceph/keyring.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          keyring is the path to key ring for RBDUser.
+                                          Default is /etc/ceph/keyring.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       monitors:
-                                        description: 'monitors is a collection of
-                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is a collection of Ceph monitors.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       pool:
-                                        description: 'pool is the rados pool name.
-                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          pool is the rados pool name.
+                                          Default is rbd.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is name of the authentication
-                                          secret for RBDUser. If provided overrides
-                                          keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is name of the authentication secret for RBDUser. If provided
+                                          overrides keyring.
+                                          Default is nil.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is the rados user name.
-                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          user is the rados user name.
+                                          Default is admin.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - image
@@ -4824,10 +9126,11 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Default is "xfs".
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs".
+                                          Default is "xfs".
                                         type: string
                                       gateway:
                                         description: gateway is the host address of
@@ -4839,21 +9142,25 @@ spec:
                                           configured storage.
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef references to the secret
-                                          for ScaleIO user and other sensitive information.
-                                          If this is not provided, Login operation
-                                          will fail.
+                                        description: |-
+                                          secretRef references to the secret for ScaleIO user and other
+                                          sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -4863,9 +9170,9 @@ spec:
                                           false
                                         type: boolean
                                       storageMode:
-                                        description: storageMode indicates whether
-                                          the storage for a volume should be ThickProvisioned
-                                          or ThinProvisioned. Default is ThinProvisioned.
+                                        description: |-
+                                          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                          Default is ThinProvisioned.
                                         type: string
                                       storagePool:
                                         description: storagePool is the ScaleIO Storage
@@ -4876,9 +9183,9 @@ spec:
                                           system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: volumeName is the name of a volume
-                                          already created in the ScaleIO system that
-                                          is associated with this volume source.
+                                        description: |-
+                                          volumeName is the name of a volume already created in the ScaleIO system
+                                          that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -4886,37 +9193,30 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'secret represents a secret that
-                                      should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: |-
+                                      secret represents a secret that should populate this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is Optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                        description: |-
+                                          defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values
+                                          for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items If unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          Secret will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the Secret, the volume setup will error
-                                          unless it is marked optional. Paths must
-                                          be relative and may not contain the '..'
-                                          path or start with '..'.
+                                        description: |-
+                                          items If unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the Secret,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -4925,40 +9225,36 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
                                           - path
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       optional:
                                         description: optional field specify whether
                                           the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'secretName is the name of the
-                                          secret in the pod''s namespace to use. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: |-
+                                          secretName is the name of the secret in the pod's namespace to use.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                         type: string
                                     type: object
                                   storageos:
@@ -4966,46 +9262,47 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef specifies the secret
-                                          to use for obtaining the StorageOS API credentials.  If
-                                          not specified, default values will be attempted.
+                                        description: |-
+                                          secretRef specifies the secret to use for obtaining the StorageOS API
+                                          credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeName:
-                                        description: volumeName is the human-readable
-                                          name of the StorageOS volume.  Volume names
-                                          are only unique within a namespace.
+                                        description: |-
+                                          volumeName is the human-readable name of the StorageOS volume.  Volume
+                                          names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: volumeNamespace specifies the
-                                          scope of the volume within StorageOS.  If
-                                          no namespace is specified then the Pod's
-                                          namespace will be used.  This allows the
-                                          Kubernetes name scoping to be mirrored within
-                                          StorageOS for tighter integration. Set VolumeName
-                                          to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS. Namespaces that do not
-                                          pre-exist within StorageOS will be created.
+                                        description: |-
+                                          volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                          namespace is specified then the Pod's namespace will be used.  This allows the
+                                          Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                          Set VolumeName to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces within StorageOS.
+                                          Namespaces that do not pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:
@@ -5014,11 +9311,10 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fsType is filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
                                         description: storagePolicyID is the storage
@@ -5051,48 +9347,45 @@ spec:
                             pods with new ones.
                           properties:
                             rollingUpdate:
-                              description: 'Rolling update config params. Present
-                                only if DeploymentStrategyType = RollingUpdate. ---
-                                TODO: Update this to follow our convention for oneOf,
-                                whatever we decide it to be.'
+                              description: |-
+                                Rolling update config params. Present only if DeploymentStrategyType =
+                                RollingUpdate.
+                                ---
+                                TODO: Update this to follow our convention for oneOf, whatever we decide it
+                                to be.
                               properties:
                                 maxSurge:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'The maximum number of pods that can
-                                    be scheduled above the desired number of pods.
-                                    Value can be an absolute number (ex: 5) or a percentage
-                                    of desired pods (ex: 10%). This can not be 0 if
-                                    MaxUnavailable is 0. Absolute number is calculated
-                                    from percentage by rounding up. Defaults to 25%.
-                                    Example: when this is set to 30%, the new ReplicaSet
-                                    can be scaled up immediately when the rolling
-                                    update starts, such that the total number of old
-                                    and new pods do not exceed 130% of desired pods.
-                                    Once old pods have been killed, new ReplicaSet
-                                    can be scaled up further, ensuring that total
-                                    number of pods running at any time during the
-                                    update is at most 130% of desired pods.'
+                                  description: |-
+                                    The maximum number of pods that can be scheduled above the desired number of
+                                    pods.
+                                    Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                    This can not be 0 if MaxUnavailable is 0.
+                                    Absolute number is calculated from percentage by rounding up.
+                                    Defaults to 25%.
+                                    Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                    the rolling update starts, such that the total number of old and new pods do not exceed
+                                    130% of desired pods. Once old pods have been killed,
+                                    new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                    at any time during the update is at most 130% of desired pods.
                                   x-kubernetes-int-or-string: true
                                 maxUnavailable:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'The maximum number of pods that can
-                                    be unavailable during the update. Value can be
-                                    an absolute number (ex: 5) or a percentage of
-                                    desired pods (ex: 10%). Absolute number is calculated
-                                    from percentage by rounding down. This can not
-                                    be 0 if MaxSurge is 0. Defaults to 25%. Example:
-                                    when this is set to 30%, the old ReplicaSet can
-                                    be scaled down to 70% of desired pods immediately
-                                    when the rolling update starts. Once new pods
-                                    are ready, old ReplicaSet can be scaled down further,
-                                    followed by scaling up the new ReplicaSet, ensuring
-                                    that the total number of pods available at all
-                                    times during the update is at least 70% of desired
-                                    pods.'
+                                  description: |-
+                                    The maximum number of pods that can be unavailable during the update.
+                                    Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                    Absolute number is calculated from percentage by rounding down.
+                                    This can not be 0 if MaxSurge is 0.
+                                    Defaults to 25%.
+                                    Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                    immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                    can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                    that the total number of pods available at all times during the update is at
+                                    least 70% of desired pods.
                                   x-kubernetes-int-or-string: true
                               type: object
                             type:
@@ -5101,52 +9394,726 @@ spec:
                               type: string
                           type: object
                       type: object
+                    envoyHpa:
+                      description: |-
+                        EnvoyHpa defines the Horizontal Pod Autoscaler settings for Envoy Proxy Deployment.
+                        Once the HPA is being set, Replicas field from EnvoyDeployment will be ignored.
+                      properties:
+                        behavior:
+                          description: |-
+                            behavior configures the scaling behavior of the target
+                            in both Up and Down directions (scaleUp and scaleDown fields respectively).
+                            If not set, the default HPAScalingRules for scale up and scale down are used.
+                            See k8s.io.autoscaling.v2.HorizontalPodAutoScalerBehavior.
+                          properties:
+                            scaleDown:
+                              description: |-
+                                scaleDown is scaling policy for scaling Down.
+                                If not set, the default value is to allow to scale down to minReplicas pods, with a
+                                300 second stabilization window (i.e., the highest recommendation for
+                                the last 300sec is used).
+                              properties:
+                                policies:
+                                  description: |-
+                                    policies is a list of potential scaling polices which can be used during scaling.
+                                    At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+                                  items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
+                                    properties:
+                                      periodSeconds:
+                                        description: |-
+                                          periodSeconds specifies the window of time for which the policy should hold true.
+                                          PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        description: type is used to specify the scaling
+                                          policy.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          value contains the amount of change which is permitted by the policy.
+                                          It must be greater than zero
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - periodSeconds
+                                    - type
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                selectPolicy:
+                                  description: |-
+                                    selectPolicy is used to specify which policy should be used.
+                                    If not set, the default value Max is used.
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  description: |-
+                                    stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                    considered while scaling up or scaling down.
+                                    StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                    If not set, use the default values:
+                                    - For scale up: 0 (i.e. no stabilization is done).
+                                    - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+                                  format: int32
+                                  type: integer
+                              type: object
+                            scaleUp:
+                              description: |-
+                                scaleUp is scaling policy for scaling Up.
+                                If not set, the default value is the higher of:
+                                  * increase no more than 4 pods per 60 seconds
+                                  * double the number of pods per 60 seconds
+                                No stabilization is used.
+                              properties:
+                                policies:
+                                  description: |-
+                                    policies is a list of potential scaling polices which can be used during scaling.
+                                    At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+                                  items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
+                                    properties:
+                                      periodSeconds:
+                                        description: |-
+                                          periodSeconds specifies the window of time for which the policy should hold true.
+                                          PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        description: type is used to specify the scaling
+                                          policy.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          value contains the amount of change which is permitted by the policy.
+                                          It must be greater than zero
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - periodSeconds
+                                    - type
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                selectPolicy:
+                                  description: |-
+                                    selectPolicy is used to specify which policy should be used.
+                                    If not set, the default value Max is used.
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  description: |-
+                                    stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                    considered while scaling up or scaling down.
+                                    StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                    If not set, use the default values:
+                                    - For scale up: 0 (i.e. no stabilization is done).
+                                    - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        maxReplicas:
+                          description: |-
+                            maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
+                            It cannot be less that minReplicas.
+                          format: int32
+                          type: integer
+                          x-kubernetes-validations:
+                          - message: maxReplicas must be greater than 0
+                            rule: self > 0
+                        metrics:
+                          description: |-
+                            metrics contains the specifications for which to use to calculate the
+                            desired replica count (the maximum replica count across all metrics will
+                            be used).
+                            If left empty, it defaults to being based on CPU utilization with average on 80% usage.
+                          items:
+                            description: |-
+                              MetricSpec specifies how to scale based on a single metric
+                              (only `type` and one other matching field should be set at once).
+                            properties:
+                              containerResource:
+                                description: |-
+                                  containerResource refers to a resource metric (such as those specified in
+                                  requests and limits) known to Kubernetes describing a single container in
+                                  each pod of the current scale target (e.g. CPU or memory). Such metrics are
+                                  built in to Kubernetes, and have special scaling options on top of those
+                                  available to normal per-pod metrics using the "pods" source.
+                                  This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+                                properties:
+                                  container:
+                                    description: container is the name of the container
+                                      in the pods of the scaling target
+                                    type: string
+                                  name:
+                                    description: name is the name of the resource
+                                      in question.
+                                    type: string
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: |-
+                                          averageUtilization is the target value of the average of the
+                                          resource metric across all relevant pods, represented as a percentage of
+                                          the requested value of the resource for the pods.
+                                          Currently only valid for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          averageValue is the target value of the average of the
+                                          metric across all relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - container
+                                - name
+                                - target
+                                type: object
+                              external:
+                                description: |-
+                                  external refers to a global metric that is not associated
+                                  with any Kubernetes object. It allows autoscaling based on information
+                                  coming from components running outside of cluster
+                                  (for example length of queue in cloud messaging service, or
+                                  QPS from loadbalancer running outside of cluster).
+                                properties:
+                                  metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given
+                                          metric
+                                        type: string
+                                      selector:
+                                        description: |-
+                                          selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                          When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                          When unset, just the metricName will be used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                    - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: |-
+                                          averageUtilization is the target value of the average of the
+                                          resource metric across all relevant pods, represented as a percentage of
+                                          the requested value of the resource for the pods.
+                                          Currently only valid for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          averageValue is the target value of the average of the
+                                          metric across all relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - metric
+                                - target
+                                type: object
+                              object:
+                                description: |-
+                                  object refers to a metric describing a single kubernetes object
+                                  (for example, hits-per-second on an Ingress object).
+                                properties:
+                                  describedObject:
+                                    description: describedObject specifies the descriptions
+                                      of a object,such as kind,name apiVersion
+                                    properties:
+                                      apiVersion:
+                                        description: apiVersion is the API version
+                                          of the referent
+                                        type: string
+                                      kind:
+                                        description: 'kind is the kind of the referent;
+                                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                        type: string
+                                      name:
+                                        description: 'name is the name of the referent;
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given
+                                          metric
+                                        type: string
+                                      selector:
+                                        description: |-
+                                          selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                          When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                          When unset, just the metricName will be used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                    - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: |-
+                                          averageUtilization is the target value of the average of the
+                                          resource metric across all relevant pods, represented as a percentage of
+                                          the requested value of the resource for the pods.
+                                          Currently only valid for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          averageValue is the target value of the average of the
+                                          metric across all relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - describedObject
+                                - metric
+                                - target
+                                type: object
+                              pods:
+                                description: |-
+                                  pods refers to a metric describing each pod in the current scale target
+                                  (for example, transactions-processed-per-second).  The values will be
+                                  averaged together before being compared to the target value.
+                                properties:
+                                  metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given
+                                          metric
+                                        type: string
+                                      selector:
+                                        description: |-
+                                          selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                          When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                          When unset, just the metricName will be used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                    - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: |-
+                                          averageUtilization is the target value of the average of the
+                                          resource metric across all relevant pods, represented as a percentage of
+                                          the requested value of the resource for the pods.
+                                          Currently only valid for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          averageValue is the target value of the average of the
+                                          metric across all relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - metric
+                                - target
+                                type: object
+                              resource:
+                                description: |-
+                                  resource refers to a resource metric (such as those specified in
+                                  requests and limits) known to Kubernetes describing each pod in the
+                                  current scale target (e.g. CPU or memory). Such metrics are built in to
+                                  Kubernetes, and have special scaling options on top of those available
+                                  to normal per-pod metrics using the "pods" source.
+                                properties:
+                                  name:
+                                    description: name is the name of the resource
+                                      in question.
+                                    type: string
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: |-
+                                          averageUtilization is the target value of the average of the
+                                          resource metric across all relevant pods, represented as a percentage of
+                                          the requested value of the resource for the pods.
+                                          Currently only valid for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          averageValue is the target value of the average of the
+                                          metric across all relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - name
+                                - target
+                                type: object
+                              type:
+                                description: |-
+                                  type is the type of metric source.  It should be one of "ContainerResource", "External",
+                                  "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+                                  Note: "ContainerResource" type is available on when the feature-gate
+                                  HPAContainerMetrics is enabled
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          type: array
+                        minReplicas:
+                          description: |-
+                            minReplicas is the lower limit for the number of replicas to which the autoscaler
+                            can scale down. It defaults to 1 replica.
+                          format: int32
+                          type: integer
+                          x-kubernetes-validations:
+                          - message: minReplicas must be greater than 0
+                            rule: self > 0
+                      required:
+                      - maxReplicas
+                      type: object
+                      x-kubernetes-validations:
+                      - message: maxReplicas cannot be less than minReplicas
+                        rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
+                    envoyPDB:
+                      description: EnvoyPDB allows to control the pod disruption budget
+                        of an Envoy Proxy.
+                      properties:
+                        minAvailable:
+                          description: |-
+                            MinAvailable specifies the minimum number of pods that must be available at all times during voluntary disruptions,
+                            such as node drains or updates. This setting ensures that your envoy proxy maintains a certain level of availability
+                            and resilience during maintenance operations.
+                          format: int32
+                          type: integer
+                      type: object
                     envoyService:
-                      description: EnvoyService defines the desired state of the Envoy
-                        service resource. If unspecified, default settings for the
-                        managed Envoy service resource are applied.
+                      description: |-
+                        EnvoyService defines the desired state of the Envoy service resource.
+                        If unspecified, default settings for the managed Envoy service resource
+                        are applied.
                       properties:
                         allocateLoadBalancerNodePorts:
-                          description: AllocateLoadBalancerNodePorts defines if NodePorts
-                            will be automatically allocated for services with type
-                            LoadBalancer. Default is "true". It may be set to "false"
-                            if the cluster load-balancer does not rely on NodePorts.
-                            If the caller requests specific NodePorts (by specifying
-                            a value), those requests will be respected, regardless
-                            of this field. This field may only be set for services
-                            with type LoadBalancer and will be cleared if the type
-                            is changed to any other type.
+                          description: |-
+                            AllocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for
+                            services with type LoadBalancer. Default is "true". It may be set to "false" if the cluster
+                            load-balancer does not rely on NodePorts. If the caller requests specific NodePorts (by specifying a
+                            value), those requests will be respected, regardless of this field. This field may only be set for
+                            services with type LoadBalancer and will be cleared if the type is changed to any other type.
                           type: boolean
                         annotations:
                           additionalProperties:
                             type: string
-                          description: Annotations that should be appended to the
-                            service. By default, no annotations are appended.
+                          description: |-
+                            Annotations that should be appended to the service.
+                            By default, no annotations are appended.
                           type: object
+                        externalTrafficPolicy:
+                          default: Local
+                          description: |-
+                            ExternalTrafficPolicy determines the externalTrafficPolicy for the Envoy Service. Valid options
+                            are Local and Cluster. Default is "Local". "Local" means traffic will only go to pods on the node
+                            receiving the traffic. "Cluster" means connections are loadbalanced to all pods in the cluster.
+                          enum:
+                          - Local
+                          - Cluster
+                          type: string
                         loadBalancerClass:
-                          description: LoadBalancerClass, when specified, allows for
-                            choosing the LoadBalancer provider implementation if more
-                            than one are available or is otherwise expected to be
-                            specified
+                          description: |-
+                            LoadBalancerClass, when specified, allows for choosing the LoadBalancer provider
+                            implementation if more than one are available or is otherwise expected to be specified
                           type: string
                         loadBalancerIP:
-                          description: LoadBalancerIP defines the IP Address of the
-                            underlying load balancer service. This field may be ignored
-                            if the load balancer provider does not support this feature.
-                            This field has been deprecated in Kubernetes, but it is
-                            still used for setting the IP Address in some cloud providers
-                            such as GCP.
+                          description: |-
+                            LoadBalancerIP defines the IP Address of the underlying load balancer service. This field
+                            may be ignored if the load balancer provider does not support this feature.
+                            This field has been deprecated in Kubernetes, but it is still used for setting the IP Address in some cloud
+                            providers such as GCP.
                           type: string
+                          x-kubernetes-validations:
+                          - message: loadBalancerIP must be a valid IPv4 address
+                            rule: self.matches(r"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
+                        loadBalancerSourceRanges:
+                          description: |-
+                            LoadBalancerSourceRanges defines a list of allowed IP addresses which will be configured as
+                            firewall rules on the platform providers load balancer. This is not guaranteed to be working as
+                            it happens outside of kubernetes and has to be supported and handled by the platform provider.
+                            This field may only be set for services with type LoadBalancer and will be cleared if the type
+                            is changed to any other type.
+                          items:
+                            type: string
+                          type: array
+                        name:
+                          description: |-
+                            Name of the service.
+                            When unset, this defaults to an autogenerated name.
+                          type: string
+                        patch:
+                          description: Patch defines how to perform the patch operation
+                            to the service
+                          properties:
+                            type:
+                              description: |-
+                                Type is the type of merge operation to perform
+
+
+                                By default, StrategicMerge is used as the patch type.
+                              type: string
+                            value:
+                              description: Object contains the raw configuration for
+                                merged object
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - value
+                          type: object
                         type:
                           default: LoadBalancer
-                          description: Type determines how the Service is exposed.
-                            Defaults to LoadBalancer. Valid options are ClusterIP,
-                            LoadBalancer and NodePort. "LoadBalancer" means a service
-                            will be exposed via an external load balancer (if the
-                            cloud provider supports it). "ClusterIP" means a service
-                            will only be accessible inside the cluster, via the cluster
-                            IP. "NodePort" means a service will be exposed on a static
-                            Port on all Nodes of the cluster.
+                          description: |-
+                            Type determines how the Service is exposed. Defaults to LoadBalancer.
+                            Valid options are ClusterIP, LoadBalancer and NodePort.
+                            "LoadBalancer" means a service will be exposed via an external load balancer (if the cloud provider supports it).
+                            "ClusterIP" means a service will only be accessible inside the cluster, via the cluster IP.
+                            "NodePort" means a service will be exposed on a static Port on all Nodes of the cluster.
                           enum:
                           - ClusterIP
                           - LoadBalancer
@@ -5158,56 +10125,97 @@ spec:
                           LoadBalancer type
                         rule: '!has(self.allocateLoadBalancerNodePorts) || self.type
                           == ''LoadBalancer'''
+                      - message: loadBalancerSourceRanges can only be set for LoadBalancer
+                          type
+                        rule: '!has(self.loadBalancerSourceRanges) || self.type ==
+                          ''LoadBalancer'''
                       - message: loadBalancerIP can only be set for LoadBalancer type
                         rule: '!has(self.loadBalancerIP) || self.type == ''LoadBalancer'''
-                      - message: loadBalancerIP must be a valid IPv4 address
-                        rule: '!has(self.loadBalancerIP) || self.loadBalancerIP.matches(r"^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})")'
+                    useListenerPortAsContainerPort:
+                      description: |-
+                        UseListenerPortAsContainerPort disables the port shifting feature in the Envoy Proxy.
+                        When set to false (default value), if the service port is a privileged port (1-1023), add a constant to the value converting it into an ephemeral port.
+                        This allows the container to bind to the port without needing a CAP_NET_BIND_SERVICE capability.
+                      type: boolean
                   type: object
+                  x-kubernetes-validations:
+                  - message: only one of envoyDeployment or envoyDaemonSet can be
+                      specified
+                    rule: ((has(self.envoyDeployment) && !has(self.envoyDaemonSet))
+                      || (!has(self.envoyDeployment) && has(self.envoyDaemonSet)))
+                      || (!has(self.envoyDeployment) && !has(self.envoyDaemonSet))
+                  - message: cannot use envoyHpa if envoyDaemonSet is used
+                    rule: ((has(self.envoyHpa) && !has(self.envoyDaemonSet)) || (!has(self.envoyHpa)
+                      && has(self.envoyDaemonSet))) || (!has(self.envoyHpa) && !has(self.envoyDaemonSet))
                 type:
-                  description: Type is the type of resource provider to use. A resource
-                    provider provides infrastructure resources for running the data
-                    plane, e.g. Envoy proxy, and optional auxiliary control planes.
-                    Supported types are "Kubernetes".
+                  description: |-
+                    Type is the type of resource provider to use. A resource provider provides
+                    infrastructure resources for running the data plane, e.g. Envoy proxy, and
+                    optional auxiliary control planes. Supported types are "Kubernetes".
                   enum:
                   - Kubernetes
                   type: string
               required:
               - type
               type: object
+            routingType:
+              description: |-
+                RoutingType can be set to "Service" to use the Service Cluster IP for routing to the backend,
+                or it can be set to "Endpoint" to use Endpoint routing. The default is "Endpoint".
+              type: string
+            shutdown:
+              description: Shutdown defines configuration for graceful envoy shutdown
+                process.
+              properties:
+                drainTimeout:
+                  description: |-
+                    DrainTimeout defines the graceful drain timeout. This should be less than the pod's terminationGracePeriodSeconds.
+                    If unspecified, defaults to 600 seconds.
+                  type: string
+                minDrainDuration:
+                  description: |-
+                    MinDrainDuration defines the minimum drain duration allowing time for endpoint deprogramming to complete.
+                    If unspecified, defaults to 5 seconds.
+                  type: string
+              type: object
             telemetry:
               description: Telemetry defines telemetry parameters for managed proxies.
               properties:
                 accessLog:
-                  description: AccessLogs defines accesslog parameters for managed
-                    proxies. If unspecified, will send default format to stdout.
+                  description: |-
+                    AccessLogs defines accesslog parameters for managed proxies.
+                    If unspecified, will send default format to stdout.
                   properties:
                     disable:
                       description: Disable disables access logging for managed proxies
                         if set to true.
                       type: boolean
                     settings:
-                      description: Settings defines accesslog settings for managed
-                        proxies. If unspecified, will send default format to stdout.
+                      description: |-
+                        Settings defines accesslog settings for managed proxies.
+                        If unspecified, will send default format to stdout.
                       items:
                         properties:
                           format:
-                            description: Format defines the format of accesslog.
+                            description: |-
+                              Format defines the format of accesslog.
+                              This will be ignored if sink type is ALS.
                             properties:
                               json:
                                 additionalProperties:
                                   type: string
-                                description: JSON is additional attributes that describe
-                                  the specific event occurrence. Structured format
-                                  for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)
+                                description: |-
+                                  JSON is additional attributes that describe the specific event occurrence.
+                                  Structured format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)
                                   can be used as values for fields within the Struct.
                                   It's required when the format type is "JSON".
                                 type: object
                               text:
-                                description: Text defines the text accesslog format,
-                                  following Envoy accesslog formatting, It's required
-                                  when the format type is "Text". Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)
-                                  may be used in the format. The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings)
-                                  provides more information.
+                                description: |-
+                                  Text defines the text accesslog format, following Envoy accesslog formatting,
+                                  It's required when the format type is "Text".
+                                  Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be used in the format.
+                                  The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings) provides more information.
                                 type: string
                               type:
                                 description: Type defines the type of accesslog format.
@@ -5216,10 +10224,169 @@ spec:
                                 - JSON
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: If AccessLogFormat type is Text, text field
+                                needs to be set.
+                              rule: 'self.type == ''Text'' ? has(self.text) : !has(self.text)'
+                            - message: If AccessLogFormat type is JSON, json field
+                                needs to be set.
+                              rule: 'self.type == ''JSON'' ? has(self.json) : !has(self.json)'
+                          matches:
+                            description: |-
+                              Matches defines the match conditions for accesslog in CEL expression.
+                              An accesslog will be emitted only when one or more match conditions are evaluated to true.
+                              Invalid [CEL](https://www.envoyproxy.io/docs/envoy/latest/xds/type/v3/cel.proto.html#common-expression-language-cel-proto) expressions will be ignored.
+                            items:
+                              type: string
+                            type: array
                           sinks:
                             description: Sinks defines the sinks of accesslog.
                             items:
+                              description: ProxyAccessLogSink defines the sink of
+                                accesslog.
                               properties:
+                                als:
+                                  description: ALS defines the gRPC Access Log Service
+                                    (ALS) sink.
+                                  properties:
+                                    backendRefs:
+                                      description: |-
+                                        BackendRefs references a Kubernetes object that represents the gRPC service to which
+                                        the access logs will be sent. Currently only Service is supported.
+                                      items:
+                                        description: BackendRef defines how an ObjectReference
+                                          that is specific to BackendRef.
+                                        properties:
+                                          group:
+                                            default: ""
+                                            description: |-
+                                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                              When unspecified or empty string, core API group is inferred.
+                                            maxLength: 253
+                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                            type: string
+                                          kind:
+                                            default: Service
+                                            description: |-
+                                              Kind is the Kubernetes resource kind of the referent. For example
+                                              "Service".
+
+
+                                              Defaults to "Service" when not specified.
+
+
+                                              ExternalName services can refer to CNAME DNS records that may live
+                                              outside of the cluster and as such are difficult to reason about in
+                                              terms of conformance. They also may not be safe to forward to (see
+                                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                              support ExternalName Services.
+
+
+                                              Support: Core (Services with a type other than ExternalName)
+
+
+                                              Support: Implementation-specific (Services with type ExternalName)
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                            type: string
+                                          name:
+                                            description: Name is the name of the referent.
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of the backend. When unspecified, the local
+                                              namespace is inferred.
+
+
+                                              Note that when a namespace different than the local namespace is specified,
+                                              a ReferenceGrant object is required in the referent namespace to allow that
+                                              namespace's owner to accept the reference. See the ReferenceGrant
+                                              documentation for details.
+
+
+                                              Support: Core
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                            type: string
+                                          port:
+                                            description: |-
+                                              Port specifies the destination port number to use for this resource.
+                                              Port is required when the referent is a Kubernetes Service. In this
+                                              case, the port number is the service port number, not the target port.
+                                              For other resources, destination port might be derived from the referent
+                                              resource or this field.
+                                            format: int32
+                                            maximum: 65535
+                                            minimum: 1
+                                            type: integer
+                                        required:
+                                        - name
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: Must have port for Service reference
+                                          rule: '(size(self.group) == 0 && self.kind
+                                            == ''Service'') ? has(self.port) : true'
+                                      maxItems: 1
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-validations:
+                                      - message: BackendRefs only supports Service
+                                          kind.
+                                        rule: self.all(f, f.kind == 'Service')
+                                      - message: BackendRefs only supports Core group.
+                                        rule: self.all(f, f.group == '')
+                                    http:
+                                      description: HTTP defines additional configuration
+                                        specific to HTTP access logs.
+                                      properties:
+                                        requestHeaders:
+                                          description: RequestHeaders defines request
+                                            headers to include in log entries sent
+                                            to the access log service.
+                                          items:
+                                            type: string
+                                          type: array
+                                        responseHeaders:
+                                          description: ResponseHeaders defines response
+                                            headers to include in log entries sent
+                                            to the access log service.
+                                          items:
+                                            type: string
+                                          type: array
+                                        responseTrailers:
+                                          description: ResponseTrailers defines response
+                                            trailers to include in log entries sent
+                                            to the access log service.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    logName:
+                                      description: |-
+                                        LogName defines the friendly name of the access log to be returned in
+                                        StreamAccessLogsMessage.Identifier. This allows the access log server
+                                        to differentiate between different access logs coming from the same Envoy.
+                                      minLength: 1
+                                      type: string
+                                    type:
+                                      description: Type defines the type of accesslog.
+                                        Supported types are "HTTP" and "TCP".
+                                      enum:
+                                      - HTTP
+                                      - TCP
+                                      type: string
+                                  required:
+                                  - backendRefs
+                                  - type
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: The http field may only be set when type
+                                      is HTTP.
+                                    rule: self.type == 'HTTP' || !has(self.http)
                                 file:
                                   description: File defines the file accesslog sink.
                                   properties:
@@ -5233,74 +10400,192 @@ spec:
                                   description: OpenTelemetry defines the OpenTelemetry
                                     accesslog sink.
                                   properties:
+                                    backendRefs:
+                                      description: |-
+                                        BackendRefs references a Kubernetes object that represents the
+                                        backend server to which the access log will be sent.
+                                        Only Service kind is supported for now.
+                                      items:
+                                        description: BackendRef defines how an ObjectReference
+                                          that is specific to BackendRef.
+                                        properties:
+                                          group:
+                                            default: ""
+                                            description: |-
+                                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                              When unspecified or empty string, core API group is inferred.
+                                            maxLength: 253
+                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                            type: string
+                                          kind:
+                                            default: Service
+                                            description: |-
+                                              Kind is the Kubernetes resource kind of the referent. For example
+                                              "Service".
+
+
+                                              Defaults to "Service" when not specified.
+
+
+                                              ExternalName services can refer to CNAME DNS records that may live
+                                              outside of the cluster and as such are difficult to reason about in
+                                              terms of conformance. They also may not be safe to forward to (see
+                                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                              support ExternalName Services.
+
+
+                                              Support: Core (Services with a type other than ExternalName)
+
+
+                                              Support: Implementation-specific (Services with type ExternalName)
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                            type: string
+                                          name:
+                                            description: Name is the name of the referent.
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of the backend. When unspecified, the local
+                                              namespace is inferred.
+
+
+                                              Note that when a namespace different than the local namespace is specified,
+                                              a ReferenceGrant object is required in the referent namespace to allow that
+                                              namespace's owner to accept the reference. See the ReferenceGrant
+                                              documentation for details.
+
+
+                                              Support: Core
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                            type: string
+                                          port:
+                                            description: |-
+                                              Port specifies the destination port number to use for this resource.
+                                              Port is required when the referent is a Kubernetes Service. In this
+                                              case, the port number is the service port number, not the target port.
+                                              For other resources, destination port might be derived from the referent
+                                              resource or this field.
+                                            format: int32
+                                            maximum: 65535
+                                            minimum: 1
+                                            type: integer
+                                        required:
+                                        - name
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: Must have port for Service reference
+                                          rule: '(size(self.group) == 0 && self.kind
+                                            == ''Service'') ? has(self.port) : true'
+                                      maxItems: 1
+                                      type: array
+                                      x-kubernetes-validations:
+                                      - message: only support Service kind.
+                                        rule: self.all(f, f.kind == 'Service')
+                                      - message: BackendRefs only supports Core group.
+                                        rule: self.all(f, f.group == '')
                                     host:
-                                      description: Host define the extension service
-                                        hostname.
+                                      description: |-
+                                        Host define the extension service hostname.
+                                        Deprecated: Use BackendRefs instead.
                                       type: string
                                     port:
                                       default: 4317
-                                      description: Port defines the port the extension
-                                        service is exposed on.
+                                      description: |-
+                                        Port defines the port the extension service is exposed on.
+                                        Deprecated: Use BackendRefs instead.
                                       format: int32
                                       minimum: 0
                                       type: integer
                                     resources:
                                       additionalProperties:
                                         type: string
-                                      description: Resources is a set of labels that
-                                        describe the source of a log entry, including
-                                        envoy node info. It's recommended to follow
-                                        [semantic conventions](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/).
+                                      description: |-
+                                        Resources is a set of labels that describe the source of a log entry, including envoy node info.
+                                        It's recommended to follow [semantic conventions](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/).
                                       type: object
-                                  required:
-                                  - host
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: host or backendRefs needs to be set
+                                    rule: has(self.host) || self.backendRefs.size()
+                                      > 0
                                 type:
                                   description: Type defines the type of accesslog
                                     sink.
                                   enum:
+                                  - ALS
                                   - File
                                   - OpenTelemetry
                                   type: string
                               type: object
+                              x-kubernetes-validations:
+                              - message: If AccessLogSink type is ALS, als field needs
+                                  to be set.
+                                rule: 'self.type == ''ALS'' ? has(self.als) : !has(self.als)'
+                              - message: If AccessLogSink type is File, file field
+                                  needs to be set.
+                                rule: 'self.type == ''File'' ? has(self.file) : !has(self.file)'
+                              - message: If AccessLogSink type is OpenTelemetry, openTelemetry
+                                  field needs to be set.
+                                rule: 'self.type == ''OpenTelemetry'' ? has(self.openTelemetry)
+                                  : !has(self.openTelemetry)'
+                            maxItems: 50
                             minItems: 1
                             type: array
                         required:
-                        - format
                         - sinks
                         type: object
+                      maxItems: 50
+                      minItems: 1
                       type: array
                   type: object
                 metrics:
                   description: Metrics defines metrics configuration for managed proxies.
                   properties:
+                    enablePerEndpointStats:
+                      description: |-
+                        EnablePerEndpointStats enables per endpoint envoy stats metrics.
+                        Please use with caution.
+                      type: boolean
                     enableVirtualHostStats:
                       description: EnableVirtualHostStats enables envoy stat metrics
                         for virtual hosts.
                       type: boolean
                     matches:
-                      description: 'Matches defines configuration for selecting specific
-                        metrics instead of generating all metrics stats that are enabled
-                        by default. This helps reduce CPU and memory overhead in Envoy,
-                        but eliminating some stats may after critical functionality.
-                        Here are the stats that we strongly recommend not disabling:
+                      description: |-
+                        Matches defines configuration for selecting specific metrics instead of generating all metrics stats
+                        that are enabled by default. This helps reduce CPU and memory overhead in Envoy, but eliminating some stats
+                        may after critical functionality. Here are the stats that we strongly recommend not disabling:
                         `cluster_manager.warming_clusters`, `cluster.<cluster_name>.membership_total`,`cluster.<cluster_name>.membership_healthy`,
                         `cluster.<cluster_name>.membership_degraded`，reference  https://github.com/envoyproxy/envoy/issues/9856,
-                        https://github.com/envoyproxy/envoy/issues/14610'
+                        https://github.com/envoyproxy/envoy/issues/14610
                       items:
-                        description: Match defines the stats match configuration.
+                        description: |-
+                          StringMatch defines how to match any strings.
+                          This is a general purpose match condition that can be used by other EG APIs
+                          that need to match against a string.
                         properties:
                           type:
-                            description: MatcherType defines the stats matcher type
+                            default: Exact
+                            description: Type specifies how to match against a string.
                             enum:
-                            - RegularExpression
+                            - Exact
                             - Prefix
                             - Suffix
+                            - RegularExpression
                             type: string
                           value:
+                            description: Value specifies the string value that the
+                              match must have.
+                            maxLength: 1024
+                            minLength: 1
                             type: string
                         required:
-                        - type
                         - value
                         type: object
                       type: array
@@ -5308,6 +10593,24 @@ spec:
                       description: Prometheus defines the configuration for Admin
                         endpoint `/stats/prometheus`.
                       properties:
+                        compression:
+                          description: Configure the compression on Prometheus endpoint.
+                            Compression is useful in situations when bandwidth is
+                            scarce and large payloads can be effectively compressed
+                            at the expense of higher CPU load.
+                          properties:
+                            gzip:
+                              description: The configuration for GZIP compressor.
+                              type: object
+                            type:
+                              description: CompressorType defines the compressor type
+                                to use for compression.
+                              enum:
+                              - Gzip
+                              type: string
+                          required:
+                          - type
+                          type: object
                         disable:
                           description: Disable the Prometheus endpoint.
                           type: boolean
@@ -5316,48 +10619,152 @@ spec:
                       description: Sinks defines the metric sinks where metrics are
                         sent to.
                       items:
+                        description: |-
+                          ProxyMetricSink defines the sink of metrics.
+                          Default metrics sink is OpenTelemetry.
                         properties:
                           openTelemetry:
-                            description: OpenTelemetry defines the configuration for
-                              OpenTelemetry sink. It's required if the sink type is
-                              OpenTelemetry.
+                            description: |-
+                              OpenTelemetry defines the configuration for OpenTelemetry sink.
+                              It's required if the sink type is OpenTelemetry.
                             properties:
+                              backendRefs:
+                                description: |-
+                                  BackendRefs references a Kubernetes object that represents the
+                                  backend server to which the metric will be sent.
+                                  Only Service kind is supported for now.
+                                items:
+                                  description: BackendRef defines how an ObjectReference
+                                    that is specific to BackendRef.
+                                  properties:
+                                    group:
+                                      default: ""
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      default: Service
+                                      description: |-
+                                        Kind is the Kubernetes resource kind of the referent. For example
+                                        "Service".
+
+
+                                        Defaults to "Service" when not specified.
+
+
+                                        ExternalName services can refer to CNAME DNS records that may live
+                                        outside of the cluster and as such are difficult to reason about in
+                                        terms of conformance. They also may not be safe to forward to (see
+                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                        support ExternalName Services.
+
+
+                                        Support: Core (Services with a type other than ExternalName)
+
+
+                                        Support: Implementation-specific (Services with type ExternalName)
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of the backend. When unspecified, the local
+                                        namespace is inferred.
+
+
+                                        Note that when a namespace different than the local namespace is specified,
+                                        a ReferenceGrant object is required in the referent namespace to allow that
+                                        namespace's owner to accept the reference. See the ReferenceGrant
+                                        documentation for details.
+
+
+                                        Support: Core
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    port:
+                                      description: |-
+                                        Port specifies the destination port number to use for this resource.
+                                        Port is required when the referent is a Kubernetes Service. In this
+                                        case, the port number is the service port number, not the target port.
+                                        For other resources, destination port might be derived from the referent
+                                        resource or this field.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: Must have port for Service reference
+                                    rule: '(size(self.group) == 0 && self.kind ==
+                                      ''Service'') ? has(self.port) : true'
+                                maxItems: 1
+                                type: array
+                                x-kubernetes-validations:
+                                - message: only support Service kind.
+                                  rule: self.all(f, f.kind == 'Service')
+                                - message: BackendRefs only supports Core group.
+                                  rule: self.all(f, f.group == '')
                               host:
-                                description: Host define the service hostname.
+                                description: |-
+                                  Host define the service hostname.
+                                  Deprecated: Use BackendRefs instead.
                                 type: string
                               port:
                                 default: 4317
-                                description: Port defines the port the service is
-                                  exposed on.
+                                description: |-
+                                  Port defines the port the service is exposed on.
+                                  Deprecated: Use BackendRefs instead.
                                 format: int32
                                 maximum: 65535
                                 minimum: 0
                                 type: integer
-                            required:
-                            - host
                             type: object
+                            x-kubernetes-validations:
+                            - message: host or backendRefs needs to be set
+                              rule: has(self.host) || self.backendRefs.size() > 0
                           type:
                             default: OpenTelemetry
-                            description: Type defines the metric sink type. EG currently
-                              only supports OpenTelemetry.
+                            description: |-
+                              Type defines the metric sink type.
+                              EG currently only supports OpenTelemetry.
                             enum:
                             - OpenTelemetry
                             type: string
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: If MetricSink type is OpenTelemetry, openTelemetry
+                            field needs to be set.
+                          rule: 'self.type == ''OpenTelemetry'' ? has(self.openTelemetry)
+                            : !has(self.openTelemetry)'
                       type: array
                   type: object
                 tracing:
-                  description: Tracing defines tracing configuration for managed proxies.
+                  description: |-
+                    Tracing defines tracing configuration for managed proxies.
                     If unspecified, will not send tracing data.
                   properties:
                     customTags:
                       additionalProperties:
                         properties:
                           environment:
-                            description: Environment adds value from environment variable
-                              to each span. It's required when the type is "Environment".
+                            description: |-
+                              Environment adds value from environment variable to each span.
+                              It's required when the type is "Environment".
                             properties:
                               defaultValue:
                                 description: DefaultValue defines the default value
@@ -5371,7 +10778,8 @@ spec:
                             - name
                             type: object
                           literal:
-                            description: Literal adds hard-coded value to each span.
+                            description: |-
+                              Literal adds hard-coded value to each span.
                               It's required when the type is "Literal".
                             properties:
                               value:
@@ -5382,8 +10790,9 @@ spec:
                             - value
                             type: object
                           requestHeader:
-                            description: RequestHeader adds value from request header
-                              to each span. It's required when the type is "RequestHeader".
+                            description: |-
+                              RequestHeader adds value from request header to each span.
+                              It's required when the type is "RequestHeader".
                             properties:
                               defaultValue:
                                 description: DefaultValue defines the default value
@@ -5407,41 +10816,150 @@ spec:
                         required:
                         - type
                         type: object
-                      description: CustomTags defines the custom tags to add to each
-                        span. If provider is kubernetes, pod name and namespace are
-                        added by default.
+                      description: |-
+                        CustomTags defines the custom tags to add to each span.
+                        If provider is kubernetes, pod name and namespace are added by default.
                       type: object
                     provider:
-                      description: Provider defines the tracing provider. Only OpenTelemetry
-                        is supported currently.
+                      description: Provider defines the tracing provider.
                       properties:
+                        backendRefs:
+                          description: |-
+                            BackendRefs references a Kubernetes object that represents the
+                            backend server to which the trace will be sent.
+                            Only Service kind is supported for now.
+                          items:
+                            description: BackendRef defines how an ObjectReference
+                              that is specific to BackendRef.
+                            properties:
+                              group:
+                                default: ""
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Service
+                                description: |-
+                                  Kind is the Kubernetes resource kind of the referent. For example
+                                  "Service".
+
+
+                                  Defaults to "Service" when not specified.
+
+
+                                  ExternalName services can refer to CNAME DNS records that may live
+                                  outside of the cluster and as such are difficult to reason about in
+                                  terms of conformance. They also may not be safe to forward to (see
+                                  CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                  support ExternalName Services.
+
+
+                                  Support: Core (Services with a type other than ExternalName)
+
+
+                                  Support: Implementation-specific (Services with type ExternalName)
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace is the namespace of the backend. When unspecified, the local
+                                  namespace is inferred.
+
+
+                                  Note that when a namespace different than the local namespace is specified,
+                                  a ReferenceGrant object is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the ReferenceGrant
+                                  documentation for details.
+
+
+                                  Support: Core
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                              port:
+                                description: |-
+                                  Port specifies the destination port number to use for this resource.
+                                  Port is required when the referent is a Kubernetes Service. In this
+                                  case, the port number is the service port number, not the target port.
+                                  For other resources, destination port might be derived from the referent
+                                  resource or this field.
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-validations:
+                            - message: Must have port for Service reference
+                              rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                ? has(self.port) : true'
+                          maxItems: 1
+                          type: array
+                          x-kubernetes-validations:
+                          - message: only support Service kind.
+                            rule: self.all(f, f.kind == 'Service')
+                          - message: BackendRefs only supports Core group.
+                            rule: self.all(f, f.group == '')
                         host:
-                          description: Host define the provider service hostname.
+                          description: |-
+                            Host define the provider service hostname.
+                            Deprecated: Use BackendRefs instead.
                           type: string
                         port:
                           default: 4317
-                          description: Port defines the port the provider service
-                            is exposed on.
+                          description: |-
+                            Port defines the port the provider service is exposed on.
+                            Deprecated: Use BackendRefs instead.
                           format: int32
                           minimum: 0
                           type: integer
                         type:
                           default: OpenTelemetry
-                          description: Type defines the tracing provider type. EG
-                            currently only supports OpenTelemetry.
+                          description: Type defines the tracing provider type.
                           enum:
                           - OpenTelemetry
+                          - Zipkin
                           type: string
+                        zipkin:
+                          description: Zipkin defines the Zipkin tracing provider
+                            configuration
+                          properties:
+                            disableSharedSpanContext:
+                              description: |-
+                                DisableSharedSpanContext determines whether the default Envoy behaviour of
+                                client and server spans sharing the same span context should be disabled.
+                              type: boolean
+                            enable128BitTraceId:
+                              description: |-
+                                Enable128BitTraceID determines whether a 128bit trace id will be used
+                                when creating a new trace instance. If set to false, a 64bit trace
+                                id will be used.
+                              type: boolean
+                          type: object
                       required:
-                      - host
                       - type
                       type: object
+                      x-kubernetes-validations:
+                      - message: host or backendRefs needs to be set
+                        rule: has(self.host) || self.backendRefs.size() > 0
                     samplingRate:
                       default: 100
-                      description: SamplingRate controls the rate at which traffic
-                        will be selected for tracing if no prior sampling decision
-                        has been made. Defaults to 100, valid values [0-100]. 100
-                        indicates 100% sampling.
+                      description: |-
+                        SamplingRate controls the rate at which traffic will be
+                        selected for tracing if no prior sampling decision has been made.
+                        Defaults to 100, valid values [0-100]. 100 indicates 100% sampling.
                       format: int32
                       maximum: 100
                       minimum: 0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/securitypolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.envoyproxy.io/v1alpha1/securitypolicies.yaml
@@ -17,18 +17,24 @@ spec:
     version: v1alpha1
   validation:
     openAPIV3Schema:
-      description: SecurityPolicy allows the user to configure various security settings
-        for a Gateway.
+      description: |-
+        SecurityPolicy allows the user to configure various security settings for a
+        Gateway.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -66,10 +72,146 @@ spec:
         spec:
           description: Spec defines the desired state of SecurityPolicy.
           properties:
+            authorization:
+              description: Authorization defines the authorization configuration.
+              properties:
+                defaultAction:
+                  description: |-
+                    DefaultAction defines the default action to be taken if no rules match.
+                    If not specified, the default action is Deny.
+                  enum:
+                  - Allow
+                  - Deny
+                  type: string
+                rules:
+                  description: |-
+                    Rules defines a list of authorization rules.
+                    These rules are evaluated in order, the first matching rule will be applied,
+                    and the rest will be skipped.
+
+
+                    For example, if there are two rules: the first rule allows the request
+                    and the second rule denies it, when a request matches both rules, it will be allowed.
+                  items:
+                    description: AuthorizationRule defines a single authorization
+                      rule.
+                    properties:
+                      action:
+                        description: Action defines the action to be taken if the
+                          rule matches.
+                        enum:
+                        - Allow
+                        - Deny
+                        type: string
+                      name:
+                        description: |-
+                          Name is a user-friendly name for the rule.
+                          If not specified, Envoy Gateway will generate a unique name for the rule.n
+                        type: string
+                      principal:
+                        description: Principal specifies the client identity of a
+                          request.
+                        properties:
+                          clientCIDRs:
+                            description: |-
+                              ClientCIDRs are the IP CIDR ranges of the client.
+                              Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+
+
+                              The client IP is inferred from the X-Forwarded-For header, a custom header,
+                              or the proxy protocol.
+                              You can use the `ClientIPDetection` or the `EnableProxyProtocol` field in
+                              the `ClientTrafficPolicy` to configure how the client IP is detected.
+                            items:
+                              description: |-
+                                CIDR defines a CIDR Address range.
+                                A CIDR can be an IPv4 address range such as "192.168.1.0/24" or an IPv6 address range such as "2001:0db8:11a3:09d7::/64".
+                              pattern: ((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]+))|((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/([0-9]+))
+                              type: string
+                            minItems: 1
+                            type: array
+                        required:
+                        - clientCIDRs
+                        type: object
+                    required:
+                    - action
+                    - principal
+                    type: object
+                  type: array
+              type: object
+            basicAuth:
+              description: BasicAuth defines the configuration for the HTTP Basic
+                Authentication.
+              properties:
+                users:
+                  description: |-
+                    The Kubernetes secret which contains the username-password pairs in
+                    htpasswd format, used to verify user credentials in the "Authorization"
+                    header.
+
+
+                    This is an Opaque secret. The username-password pairs should be stored in
+                    the key ".htpasswd". As the key name indicates, the value needs to be the
+                    htpasswd format, for example: "user1:{SHA}hashed_user1_password".
+                    Right now, only SHA hash algorithm is supported.
+                    Reference to https://httpd.apache.org/docs/2.4/programs/htpasswd.html
+                    for more details.
+
+
+                    Note: The secret must be in the same namespace as the SecurityPolicy.
+                  properties:
+                    group:
+                      default: ""
+                      description: |-
+                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                        When unspecified or empty string, core API group is inferred.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Secret
+                      description: Kind is kind of the referent. For example "Secret".
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referenced object. When unspecified, the local
+                        namespace is inferred.
+
+
+                        Note that when a namespace different than the local namespace is specified,
+                        a ReferenceGrant object is required in the referent namespace to allow that
+                        namespace's owner to accept the reference. See the ReferenceGrant
+                        documentation for details.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - name
+                  type: object
+              required:
+              - users
+              type: object
             cors:
               description: CORS defines the configuration for Cross-Origin Resource
                 Sharing (CORS).
               properties:
+                allowCredentials:
+                  description: |-
+                    AllowCredentials indicates whether a request can include user credentials
+                    like cookies, authentication headers, or TLS client certificates.
+                  type: boolean
                 allowHeaders:
                   description: AllowHeaders defines the headers that are allowed to
                     be sent with requests.
@@ -87,28 +229,25 @@ spec:
                   description: AllowOrigins defines the origins that are allowed to
                     make requests.
                   items:
-                    description: StringMatch defines how to match any strings. This
-                      is a general purpose match condition that can be used by other
-                      EG APIs that need to match against a string.
-                    properties:
-                      type:
-                        default: Exact
-                        description: Type specifies how to match against a string.
-                        enum:
-                        - Exact
-                        - Prefix
-                        - Suffix
-                        - RegularExpression
-                        type: string
-                      value:
-                        description: Value specifies the string value that the match
-                          must have.
-                        maxLength: 1024
-                        minLength: 1
-                        type: string
-                    required:
-                    - value
-                    type: object
+                    description: |-
+                      Origin is defined by the scheme (protocol), hostname (domain), and port of
+                      the URL used to access it. The hostname can be "precise" which is just the
+                      domain name or "wildcard" which is a domain name prefixed with a single
+                      wildcard label such as "*.example.com".
+                      In addition to that a single wildcard (with or without scheme) can be
+                      configured to match any origin.
+
+
+                      For example, the following are valid origins:
+                      - https://foo.example.com
+                      - https://*.example.com
+                      - http://foo.example.com:8080
+                      - http://*.example.com:8080
+                      - https://*
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$
+                    type: string
                   minItems: 1
                   type: array
                 exposeHeaders:
@@ -122,41 +261,475 @@ spec:
                     request can be cached.
                   type: string
               type: object
+            extAuth:
+              description: ExtAuth defines the configuration for External Authorization.
+              properties:
+                failOpen:
+                  default: false
+                  description: |-
+                    FailOpen is a switch used to control the behavior when a response from the External Authorization service cannot be obtained.
+                    If FailOpen is set to true, the system allows the traffic to pass through.
+                    Otherwise, if it is set to false or not set (defaulting to false),
+                    the system blocks the traffic and returns a HTTP 5xx error, reflecting a fail-closed approach.
+                    This setting determines whether to prioritize accessibility over strict security in case of authorization service failure.
+                  type: boolean
+                grpc:
+                  description: |-
+                    GRPC defines the gRPC External Authorization service.
+                    Either GRPCService or HTTPService must be specified,
+                    and only one of them can be provided.
+                  properties:
+                    backendRef:
+                      description: |-
+                        BackendRef references a Kubernetes object that represents the
+                        backend server to which the authorization request will be sent.
+                        Only Service kind is supported for now.
+
+
+                        Deprecated: Use BackendRefs instead.
+                      properties:
+                        group:
+                          default: ""
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Service
+                          description: |-
+                            Kind is the Kubernetes resource kind of the referent. For example
+                            "Service".
+
+
+                            Defaults to "Service" when not specified.
+
+
+                            ExternalName services can refer to CNAME DNS records that may live
+                            outside of the cluster and as such are difficult to reason about in
+                            terms of conformance. They also may not be safe to forward to (see
+                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                            support ExternalName Services.
+
+
+                            Support: Core (Services with a type other than ExternalName)
+
+
+                            Support: Implementation-specific (Services with type ExternalName)
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the backend. When unspecified, the local
+                            namespace is inferred.
+
+
+                            Note that when a namespace different than the local namespace is specified,
+                            a ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port specifies the destination port number to use for this resource.
+                            Port is required when the referent is a Kubernetes Service. In this
+                            case, the port number is the service port number, not the target port.
+                            For other resources, destination port might be derived from the referent
+                            resource or this field.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                      x-kubernetes-validations:
+                      - message: Must have port for Service reference
+                        rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                          ? has(self.port) : true'
+                    backendRefs:
+                      description: |-
+                        BackendRefs references a Kubernetes object that represents the
+                        backend server to which the authorization request will be sent.
+                        Only Service kind is supported for now.
+                      items:
+                        description: BackendRef defines how an ObjectReference that
+                          is specific to BackendRef.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 1
+                      type: array
+                      x-kubernetes-validations:
+                      - message: only support Service kind.
+                        rule: self.all(f, f.kind == 'Service')
+                      - message: BackendRefs only supports Core group.
+                        rule: self.all(f, f.group == '')
+                  type: object
+                  x-kubernetes-validations:
+                  - message: backendRef or backendRefs needs to be set
+                    rule: has(self.backendRef) || self.backendRefs.size() > 0
+                headersToExtAuth:
+                  description: |-
+                    HeadersToExtAuth defines the client request headers that will be included
+                    in the request to the external authorization service.
+                    Note: If not specified, the default behavior for gRPC and HTTP external
+                    authorization services is different due to backward compatibility reasons.
+                    All headers will be included in the check request to a gRPC authorization server.
+                    Only the following headers will be included in the check request to an HTTP
+                    authorization server: Host, Method, Path, Content-Length, and Authorization.
+                    And these headers will always be included to the check request to an HTTP
+                    authorization server by default, no matter whether they are specified
+                    in HeadersToExtAuth or not.
+                  items:
+                    type: string
+                  type: array
+                http:
+                  description: |-
+                    HTTP defines the HTTP External Authorization service.
+                    Either GRPCService or HTTPService must be specified,
+                    and only one of them can be provided.
+                  properties:
+                    backendRef:
+                      description: |-
+                        BackendRef references a Kubernetes object that represents the
+                        backend server to which the authorization request will be sent.
+                        Only Service kind is supported for now.
+
+
+                        Deprecated: Use BackendRefs instead.
+                      properties:
+                        group:
+                          default: ""
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Service
+                          description: |-
+                            Kind is the Kubernetes resource kind of the referent. For example
+                            "Service".
+
+
+                            Defaults to "Service" when not specified.
+
+
+                            ExternalName services can refer to CNAME DNS records that may live
+                            outside of the cluster and as such are difficult to reason about in
+                            terms of conformance. They also may not be safe to forward to (see
+                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                            support ExternalName Services.
+
+
+                            Support: Core (Services with a type other than ExternalName)
+
+
+                            Support: Implementation-specific (Services with type ExternalName)
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the backend. When unspecified, the local
+                            namespace is inferred.
+
+
+                            Note that when a namespace different than the local namespace is specified,
+                            a ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port specifies the destination port number to use for this resource.
+                            Port is required when the referent is a Kubernetes Service. In this
+                            case, the port number is the service port number, not the target port.
+                            For other resources, destination port might be derived from the referent
+                            resource or this field.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                      x-kubernetes-validations:
+                      - message: Must have port for Service reference
+                        rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                          ? has(self.port) : true'
+                    backendRefs:
+                      description: |-
+                        BackendRefs references a Kubernetes object that represents the
+                        backend server to which the authorization request will be sent.
+                        Only Service kind is supported for now.
+                      items:
+                        description: BackendRef defines how an ObjectReference that
+                          is specific to BackendRef.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 1
+                      type: array
+                      x-kubernetes-validations:
+                      - message: only support Service kind.
+                        rule: self.all(f, f.kind == 'Service')
+                      - message: BackendRefs only supports Core group.
+                        rule: self.all(f, f.group == '')
+                    headersToBackend:
+                      description: |-
+                        HeadersToBackend are the authorization response headers that will be added
+                        to the original client request before sending it to the backend server.
+                        Note that coexisting headers will be overridden.
+                        If not specified, no authorization response headers will be added to the
+                        original client request.
+                      items:
+                        type: string
+                      type: array
+                    path:
+                      description: |-
+                        Path is the path of the HTTP External Authorization service.
+                        If path is specified, the authorization request will be sent to that path,
+                        or else the authorization request will be sent to the root path.
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                  - message: backendRef or backendRefs needs to be set
+                    rule: has(self.backendRef) || self.backendRefs.size() > 0
+              type: object
+              x-kubernetes-validations:
+              - message: one of grpc or http must be specified
+                rule: (has(self.grpc) || has(self.http))
+              - message: only one of grpc or http can be specified
+                rule: (has(self.grpc) && !has(self.http)) || (!has(self.grpc) && has(self.http))
+              - message: group is invalid, only the core API group (specified by omitting
+                  the group field or setting it to an empty string) is supported
+                rule: 'has(self.grpc) ? (!has(self.grpc.backendRef) || !has(self.grpc.backendRef.group)
+                  || self.grpc.backendRef.group == "") : true'
+              - message: kind is invalid, only Service (specified by omitting the
+                  kind field or setting it to 'Service') is supported
+                rule: 'has(self.grpc) ? (!has(self.grpc.backendRef) || !has(self.grpc.backendRef.kind)
+                  || self.grpc.backendRef.kind == ''Service'') : true'
+              - message: group is invalid, only the core API group (specified by omitting
+                  the group field or setting it to an empty string) is supported
+                rule: 'has(self.http) ? (!has(self.http.backendRef) || !has(self.http.backendRef.group)
+                  || self.http.backendRef.group == "") : true'
+              - message: kind is invalid, only Service (specified by omitting the
+                  kind field or setting it to 'Service') is supported
+                rule: 'has(self.http) ? (!has(self.http.backendRef) || !has(self.http.backendRef.kind)
+                  || self.http.backendRef.kind == ''Service'') : true'
             jwt:
               description: JWT defines the configuration for JSON Web Token (JWT)
                 authentication.
               properties:
+                optional:
+                  description: |-
+                    Optional determines whether a missing JWT is acceptable, defaulting to false if not specified.
+                    Note: Even if optional is set to true, JWT authentication will still fail if an invalid JWT is presented.
+                  type: boolean
                 providers:
-                  description: "Providers defines the JSON Web Token (JWT) authentication
-                    provider type. \n When multiple JWT providers are specified, the
-                    JWT is considered valid if any of the providers successfully validate
-                    the JWT. For additional details, see https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/jwt_authn_filter.html."
+                  description: |-
+                    Providers defines the JSON Web Token (JWT) authentication provider type.
+                    When multiple JWT providers are specified, the JWT is considered valid if
+                    any of the providers successfully validate the JWT. For additional details,
+                    see https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/jwt_authn_filter.html.
                   items:
                     description: JWTProvider defines how a JSON Web Token (JWT) can
                       be verified.
                     properties:
                       audiences:
-                        description: Audiences is a list of JWT audiences allowed
-                          access. For additional details, see https://tools.ietf.org/html/rfc7519#section-4.1.3.
-                          If not provided, JWT audiences are not checked.
+                        description: |-
+                          Audiences is a list of JWT audiences allowed access. For additional details, see
+                          https://tools.ietf.org/html/rfc7519#section-4.1.3. If not provided, JWT audiences
+                          are not checked.
                         items:
                           type: string
                         maxItems: 8
                         type: array
                       claimToHeaders:
-                        description: 'ClaimToHeaders is a list of JWT claims that
-                          must be extracted into HTTP request headers For examples,
-                          following config: The claim must be of type; string, int,
-                          double, bool. Array type claims are not supported'
+                        description: |-
+                          ClaimToHeaders is a list of JWT claims that must be extracted into HTTP request headers
+                          For examples, following config:
+                          The claim must be of type; string, int, double, bool. Array type claims are not supported
                         items:
                           description: ClaimToHeader defines a configuration to convert
                             JWT claims into HTTP headers
                           properties:
                             claim:
-                              description: 'Claim is the JWT Claim that should be
-                                saved into the header : it can be a nested claim of
-                                type (eg. "claim.nested.key", "sub"). The nested claim
-                                name must use dot "." to separate the JSON name path.'
+                              description: |-
+                                Claim is the JWT Claim that should be saved into the header : it can be a nested claim of type
+                                (eg. "claim.nested.key", "sub"). The nested claim name must use dot "."
+                                to separate the JSON name path.
                               type: string
                             header:
                               description: Header defines the name of the HTTP request
@@ -167,29 +740,77 @@ spec:
                           - header
                           type: object
                         type: array
+                      extractFrom:
+                        description: |-
+                          ExtractFrom defines different ways to extract the JWT token from HTTP request.
+                          If empty, it defaults to extract JWT token from the Authorization HTTP request header using Bearer schema
+                          or access_token from query parameters.
+                        properties:
+                          cookies:
+                            description: Cookies represents a list of cookie names
+                              to extract the JWT token from.
+                            items:
+                              type: string
+                            type: array
+                          headers:
+                            description: Headers represents a list of HTTP request
+                              headers to extract the JWT token from.
+                            items:
+                              description: JWTHeaderExtractor defines an HTTP header
+                                location to extract JWT token
+                              properties:
+                                name:
+                                  description: Name is the HTTP header name to retrieve
+                                    the token
+                                  type: string
+                                valuePrefix:
+                                  description: |-
+                                    ValuePrefix is the prefix that should be stripped before extracting the token.
+                                    The format would be used by Envoy like "{ValuePrefix}<TOKEN>".
+                                    For example, "Authorization: Bearer <TOKEN>", then the ValuePrefix="Bearer " with a space at the end.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          params:
+                            description: Params represents a list of query parameters
+                              to extract the JWT token from.
+                            items:
+                              type: string
+                            type: array
+                        type: object
                       issuer:
-                        description: Issuer is the principal that issued the JWT and
-                          takes the form of a URL or email address. For additional
-                          details, see https://tools.ietf.org/html/rfc7519#section-4.1.1
-                          for URL format and https://rfc-editor.org/rfc/rfc5322.html
-                          for email format. If not provided, the JWT issuer is not
-                          checked.
+                        description: |-
+                          Issuer is the principal that issued the JWT and takes the form of a URL or email address.
+                          For additional details, see https://tools.ietf.org/html/rfc7519#section-4.1.1 for
+                          URL format and https://rfc-editor.org/rfc/rfc5322.html for email format. If not provided,
+                          the JWT issuer is not checked.
                         maxLength: 253
                         type: string
                       name:
-                        description: Name defines a unique name for the JWT provider.
-                          A name can have a variety of forms, including RFC1123 subdomains,
-                          RFC 1123 labels, or RFC 1035 labels.
+                        description: |-
+                          Name defines a unique name for the JWT provider. A name can have a variety of forms,
+                          including RFC1123 subdomains, RFC 1123 labels, or RFC 1035 labels.
                         maxLength: 253
                         minLength: 1
                         type: string
+                      recomputeRoute:
+                        description: |-
+                          RecomputeRoute clears the route cache and recalculates the routing decision.
+                          This field must be enabled if the headers generated from the claim are used for
+                          route matching decisions. If the recomputation selects a new route, features targeting
+                          the new matched route will be applied.
+                        type: boolean
                       remoteJWKS:
-                        description: RemoteJWKS defines how to fetch and cache JSON
-                          Web Key Sets (JWKS) from a remote HTTP/HTTPS endpoint.
+                        description: |-
+                          RemoteJWKS defines how to fetch and cache JSON Web Key Sets (JWKS) from a remote
+                          HTTP/HTTPS endpoint.
                         properties:
                           uri:
-                            description: URI is the HTTPS URI to fetch the JWKS. Envoy's
-                              system trust bundle is used to validate the server certificate.
+                            description: |-
+                              URI is the HTTPS URI to fetch the JWKS. Envoy's system trust bundle is used to
+                              validate the server certificate.
                             maxLength: 253
                             minLength: 1
                             type: string
@@ -200,17 +821,199 @@ spec:
                     - name
                     - remoteJWKS
                     type: object
+                    x-kubernetes-validations:
+                    - message: claimToHeaders must be specified if recomputeRoute
+                        is enabled
+                      rule: '(has(self.recomputeRoute) && self.recomputeRoute) ? size(self.claimToHeaders)
+                        > 0 : true'
                   maxItems: 4
                   minItems: 1
                   type: array
               required:
               - providers
               type: object
+            oidc:
+              description: OIDC defines the configuration for the OpenID Connect (OIDC)
+                authentication.
+              properties:
+                clientID:
+                  description: |-
+                    The client ID to be used in the OIDC
+                    [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+                  minLength: 1
+                  type: string
+                clientSecret:
+                  description: |-
+                    The Kubernetes secret which contains the OIDC client secret to be used in the
+                    [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+
+
+                    This is an Opaque secret. The client secret should be stored in the key
+                    "client-secret".
+                  properties:
+                    group:
+                      default: ""
+                      description: |-
+                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                        When unspecified or empty string, core API group is inferred.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Secret
+                      description: Kind is kind of the referent. For example "Secret".
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referenced object. When unspecified, the local
+                        namespace is inferred.
+
+
+                        Note that when a namespace different than the local namespace is specified,
+                        a ReferenceGrant object is required in the referent namespace to allow that
+                        namespace's owner to accept the reference. See the ReferenceGrant
+                        documentation for details.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                cookieNames:
+                  description: |-
+                    The optional cookie name overrides to be used for Bearer and IdToken cookies in the
+                    [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+                    If not specified, uses a randomly generated suffix
+                  properties:
+                    accessToken:
+                      description: |-
+                        The name of the cookie used to store the AccessToken in the
+                        [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+                        If not specified, defaults to "AccessToken-(randomly generated uid)"
+                      type: string
+                    idToken:
+                      description: |-
+                        The name of the cookie used to store the IdToken in the
+                        [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+                        If not specified, defaults to "IdToken-(randomly generated uid)"
+                      type: string
+                  type: object
+                defaultRefreshTokenTTL:
+                  description: |-
+                    DefaultRefreshTokenTTL is the default lifetime of the refresh token.
+                    This field is only used when the exp (expiration time) claim is omitted in
+                    the refresh token or the refresh token is not JWT.
+
+
+                    If not specified, defaults to 604800s (one week).
+                    Note: this field is only applicable when the "refreshToken" field is set to true.
+                  type: string
+                defaultTokenTTL:
+                  description: |-
+                    DefaultTokenTTL is the default lifetime of the id token and access token.
+                    Please note that Envoy will always use the expiry time from the response
+                    of the authorization server if it is provided. This field is only used when
+                    the expiry time is not provided by the authorization.
+
+
+                    If not specified, defaults to 0. In this case, the "expires_in" field in
+                    the authorization response must be set by the authorization server, or the
+                    OAuth flow will fail.
+                  type: string
+                forwardAccessToken:
+                  description: |-
+                    ForwardAccessToken indicates whether the Envoy should forward the access token
+                    via the Authorization header Bearer scheme to the upstream.
+                    If not specified, defaults to false.
+                  type: boolean
+                logoutPath:
+                  description: |-
+                    The path to log a user out, clearing their credential cookies.
+
+
+                    If not specified, uses a default logout path "/logout"
+                  type: string
+                provider:
+                  description: The OIDC Provider configuration.
+                  properties:
+                    authorizationEndpoint:
+                      description: |-
+                        The OIDC Provider's [authorization endpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint).
+                        If not provided, EG will try to discover it from the provider's [Well-Known Configuration Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse).
+                      type: string
+                    issuer:
+                      description: |-
+                        The OIDC Provider's [issuer identifier](https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery).
+                        Issuer MUST be a URI RFC 3986 [RFC3986] with a scheme component that MUST
+                        be https, a host component, and optionally, port and path components and
+                        no query or fragment components.
+                      minLength: 1
+                      type: string
+                    tokenEndpoint:
+                      description: |-
+                        The OIDC Provider's [token endpoint](https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint).
+                        If not provided, EG will try to discover it from the provider's [Well-Known Configuration Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse).
+                      type: string
+                  required:
+                  - issuer
+                  type: object
+                redirectURL:
+                  description: |-
+                    The redirect URL to be used in the OIDC
+                    [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+                    If not specified, uses the default redirect URI "%REQ(x-forwarded-proto)%://%REQ(:authority)%/oauth2/callback"
+                  type: string
+                refreshToken:
+                  description: |-
+                    RefreshToken indicates whether the Envoy should automatically refresh the
+                    id token and access token when they expire.
+                    When set to true, the Envoy will use the refresh token to get a new id token
+                    and access token when they expire.
+
+
+                    If not specified, defaults to false.
+                  type: boolean
+                resources:
+                  description: |-
+                    The OIDC resources to be used in the
+                    [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+                  items:
+                    type: string
+                  type: array
+                scopes:
+                  description: |-
+                    The OIDC scopes to be used in the
+                    [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+                    The "openid" scope is always added to the list of scopes if not already
+                    specified.
+                  items:
+                    type: string
+                  type: array
+              required:
+              - clientID
+              - clientSecret
+              - provider
+              type: object
             targetRef:
-              description: TargetRef is the name of the Gateway resource this policy
-                is being attached to. This Policy and the TargetRef MUST be in the
-                same namespace for this Policy to have effect and be applied to the
-                Gateway. TargetRef
+              description: |-
+                TargetRef is the name of the resource this policy is being attached to.
+                This policy and the TargetRef MUST be in the same namespace for this
+                Policy to have effect
+
+
+                Deprecated: use targetRefs/targetSelectors instead
               properties:
                 group:
                   description: Group is the group of the target resource.
@@ -228,24 +1031,21 @@ spec:
                   maxLength: 253
                   minLength: 1
                   type: string
-                namespace:
-                  description: Namespace is the namespace of the referent. When unspecified,
-                    the local namespace is inferred. Even when policy targets a resource
-                    in a different namespace, it MUST only apply to traffic originating
-                    from the same namespace as the policy.
-                  maxLength: 63
-                  minLength: 1
-                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                  type: string
                 sectionName:
-                  description: "SectionName is the name of a section within the target
-                    resource. When unspecified, this targetRef targets the entire
-                    resource. In the following resources, SectionName is interpreted
-                    as the following: \n * Gateway: Listener Name * Service: Port
-                    Name \n If a SectionName is specified, but does not exist on the
-                    targeted object, the Policy must fail to attach, and the policy
-                    implementation should record a `ResolvedRefs` or similar Condition
-                    in the Policy's status."
+                  description: |-
+                    SectionName is the name of a section within the target resource. When
+                    unspecified, this targetRef targets the entire resource. In the following
+                    resources, SectionName is interpreted as the following:
+
+
+                    * Gateway: Listener name
+                    * HTTPRoute: HTTPRouteRule name
+                    * Service: Port name
+
+
+                    If a SectionName is specified, but does not exist on the targeted object,
+                    the Policy must fail to attach, and the policy implementation should record
+                    a `ResolvedRefs` or similar Condition in the Policy's status.
                   maxLength: 253
                   minLength: 1
                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -255,16 +1055,120 @@ spec:
               - kind
               - name
               type: object
-              x-kubernetes-validations:
-              - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
-                rule: self.group == 'gateway.networking.k8s.io'
-              - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute
-                rule: self.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute']
-              - message: this policy does not yet support the sectionName field
-                rule: '!has(self.sectionName)'
-          required:
-          - targetRef
+            targetRefs:
+              description: |-
+                TargetRefs are the names of the Gateway resources this policy
+                is being attached to.
+              items:
+                description: |-
+                  LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                  direct policy to. This should be used as part of Policy resources that can
+                  target single resources. For more information on how this policy attachment
+                  mode works, and a sample Policy resource, refer to the policy attachment
+                  documentation for Gateway API.
+
+
+                  Note: This should only be used for direct policy attachment when references
+                  to SectionName are actually needed. In all other cases,
+                  LocalPolicyTargetReference should be used.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              type: array
+            targetSelectors:
+              description: TargetSelectors allow targeting resources for this policy
+                based on labels
+              items:
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: Group is the group that this selector targets. Defaults
+                      to gateway.networking.k8s.io
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is the resource kind that this selector targets.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: MatchLabels are the set of label selectors for identifying
+                      the targeted resource
+                    type: object
+                required:
+                - kind
+                - matchLabels
+                type: object
+                x-kubernetes-validations:
+                - message: group must be gateway.networking.k8s.io
+                  rule: 'has(self.group) ? self.group == ''gateway.networking.k8s.io''
+                    : true '
+              type: array
           type: object
+          x-kubernetes-validations:
+          - message: either targetRef or targetRefs must be used
+            rule: '(has(self.targetRef) && !has(self.targetRefs)) || (!has(self.targetRef)
+              && has(self.targetRefs)) || (has(self.targetSelectors) && self.targetSelectors.size()
+              > 0) '
+          - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
+            rule: 'has(self.targetRef) ? self.targetRef.group == ''gateway.networking.k8s.io''
+              : true'
+          - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute
+            rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''HTTPRoute'',
+              ''GRPCRoute''] : true'
+          - message: this policy does not yet support the sectionName field
+            rule: 'has(self.targetRef) ? !has(self.targetRef.sectionName) : true'
+          - message: this policy can only have a targetRefs[*].group of gateway.networking.k8s.io
+            rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.group == ''gateway.networking.k8s.io'')
+              : true '
+          - message: this policy can only have a targetRefs[*].kind of Gateway/HTTPRoute/GRPCRoute
+            rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind in [''Gateway'',
+              ''HTTPRoute'', ''GRPCRoute'']) : true '
+          - message: this policy does not yet support the sectionName field
+            rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, !has(ref.sectionName))
+              : true'
       required:
       - spec
       type: object

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1/gatewayclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1/gatewayclasses.yaml
@@ -17,29 +17,42 @@ spec:
     version: v1
   validation:
     openAPIV3Schema:
-      description: "GatewayClass describes a class of Gateways available to the user
-        for creating Gateway resources. \n It is recommended that this resource be
-        used as a template for Gateways. This means that a Gateway is based on the
-        state of the GatewayClass at the time it was created and changes to the GatewayClass
-        or associated parameters are not propagated down to existing Gateways. This
-        recommendation is intended to limit the blast radius of changes to GatewayClass
-        or associated parameters. If implementations choose to propagate GatewayClass
-        changes to existing Gateways, that MUST be clearly documented by the implementation.
-        \n Whenever one or more Gateways are using a GatewayClass, implementations
-        SHOULD add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer
-        on the associated GatewayClass. This ensures that a GatewayClass associated
-        with a Gateway is not deleted while in use. \n GatewayClass is a Cluster level
-        resource."
+      description: |-
+        GatewayClass describes a class of Gateways available to the user for creating
+        Gateway resources.
+
+
+        It is recommended that this resource be used as a template for Gateways. This
+        means that a Gateway is based on the state of the GatewayClass at the time it
+        was created and changes to the GatewayClass or associated parameters are not
+        propagated down to existing Gateways. This recommendation is intended to
+        limit the blast radius of changes to GatewayClass or associated parameters.
+        If implementations choose to propagate GatewayClass changes to existing
+        Gateways, that MUST be clearly documented by the implementation.
+
+
+        Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
+        add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
+        associated GatewayClass. This ensures that a GatewayClass associated with a
+        Gateway is not deleted while in use.
+
+
+        GatewayClass is a Cluster level resource.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -70,10 +83,18 @@ spec:
           description: Spec defines the desired state of GatewayClass.
           properties:
             controllerName:
-              description: "ControllerName is the name of the controller that is managing
-                Gateways of this class. The value of this field MUST be a domain prefixed
-                path. \n Example: \"example.net/gateway-controller\". \n This field
-                is not mutable and cannot be empty. \n Support: Core"
+              description: |-
+                ControllerName is the name of the controller that is managing Gateways of
+                this class. The value of this field MUST be a domain prefixed path.
+
+
+                Example: "example.net/gateway-controller".
+
+
+                This field is not mutable and cannot be empty.
+
+
+                Support: Core
               maxLength: 253
               minLength: 1
               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
@@ -86,14 +107,27 @@ spec:
               maxLength: 64
               type: string
             parametersRef:
-              description: "ParametersRef is a reference to a resource that contains
-                the configuration parameters corresponding to the GatewayClass. This
-                is optional if the controller does not require any additional configuration.
-                \n ParametersRef can reference a standard Kubernetes resource, i.e.
-                ConfigMap, or an implementation-specific custom resource. The resource
-                can be cluster-scoped or namespace-scoped. \n If the referent cannot
-                be found, the GatewayClass's \"InvalidParameters\" status condition
-                will be true. \n Support: Implementation-specific"
+              description: |-
+                ParametersRef is a reference to a resource that contains the configuration
+                parameters corresponding to the GatewayClass. This is optional if the
+                controller does not require any additional configuration.
+
+
+                ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
+                or an implementation-specific custom resource. The resource can be
+                cluster-scoped or namespace-scoped.
+
+
+                If the referent cannot be found, the GatewayClass's "InvalidParameters"
+                status condition will be true.
+
+
+                A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
+                the merging behavior is implementation specific.
+                It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+
+                Support: Implementation-specific
               properties:
                 group:
                   description: Group is the group of the referent.
@@ -112,8 +146,9 @@ spec:
                   minLength: 1
                   type: string
                 namespace:
-                  description: Namespace is the namespace of the referent. This field
-                    is required when referring to a Namespace-scoped resource and
+                  description: |-
+                    Namespace is the namespace of the referent.
+                    This field is required when referring to a Namespace-scoped resource and
                     MUST be unset when referring to a Cluster-scoped resource.
                   maxLength: 63
                   minLength: 1

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1/gateways.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1/gateways.yaml
@@ -17,18 +17,24 @@ spec:
     version: v1
   validation:
     openAPIV3Schema:
-      description: Gateway represents an instance of a service-traffic handling infrastructure
+      description: |-
+        Gateway represents an instance of a service-traffic handling infrastructure
         by binding Listeners to a set of IP addresses.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -67,20 +73,33 @@ spec:
           description: Spec defines the desired state of Gateway.
           properties:
             addresses:
-              description: "Addresses requested for this Gateway. This is optional
-                and behavior can depend on the implementation. If a value is set in
-                the spec and the requested address is invalid or unavailable, the
-                implementation MUST indicate this in the associated entry in GatewayStatus.Addresses.
-                \n The Addresses field represents a request for the address(es) on
-                the \"outside of the Gateway\", that traffic bound for this Gateway
-                will use. This could be the IP address or hostname of an external
-                load balancer or other networking infrastructure, or some other address
-                that traffic will be sent to. \n If no Addresses are specified, the
-                implementation MAY schedule the Gateway in an implementation-specific
-                manner, assigning an appropriate set of Addresses. \n The implementation
-                MUST bind all Listeners to every GatewayAddress that it assigns to
-                the Gateway and add a corresponding entry in GatewayStatus.Addresses.
-                \n Support: Extended \n "
+              description: |+
+                Addresses requested for this Gateway. This is optional and behavior can
+                depend on the implementation. If a value is set in the spec and the
+                requested address is invalid or unavailable, the implementation MUST
+                indicate this in the associated entry in GatewayStatus.Addresses.
+
+
+                The Addresses field represents a request for the address(es) on the
+                "outside of the Gateway", that traffic bound for this Gateway will use.
+                This could be the IP address or hostname of an external load balancer or
+                other networking infrastructure, or some other address that traffic will
+                be sent to.
+
+
+                If no Addresses are specified, the implementation MAY schedule the
+                Gateway in an implementation-specific manner, assigning an appropriate
+                set of Addresses.
+
+
+                The implementation MUST bind all Listeners to every GatewayAddress that
+                it assigns to the Gateway and add a corresponding entry in
+                GatewayStatus.Addresses.
+
+
+                Support: Extended
+
+
               items:
                 description: GatewayAddress describes an address that can be bound
                   to a Gateway.
@@ -107,9 +126,12 @@ spec:
                     pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                     type: string
                   value:
-                    description: "Value of the address. The validity of the values
-                      will depend on the type and support by the controller. \n Examples:
-                      `1.2.3.4`, `128::1`, `my-ip-address`."
+                    description: |-
+                      Value of the address. The validity of the values will depend
+                      on the type and support by the controller.
+
+
+                      Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                     maxLength: 253
                     minLength: 1
                     type: string
@@ -131,176 +153,308 @@ spec:
                 rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
                   a2.type == a1.type && a2.value == a1.value) : true )'
             gatewayClassName:
-              description: GatewayClassName used for this Gateway. This is the name
-                of a GatewayClass resource.
+              description: |-
+                GatewayClassName used for this Gateway. This is the name of a
+                GatewayClass resource.
               maxLength: 253
               minLength: 1
               type: string
             infrastructure:
-              description: "Infrastructure defines infrastructure level attributes
-                about this Gateway instance. \n Support: Core \n "
+              description: |+
+                Infrastructure defines infrastructure level attributes about this Gateway instance.
+
+
+                Support: Core
+
+
               properties:
                 annotations:
                   additionalProperties:
-                    description: AnnotationValue is the value of an annotation in
-                      Gateway API. This is used for validation of maps such as TLS
-                      options. This roughly matches Kubernetes annotation validation,
-                      although the length validation in that case is based on the
-                      entire size of the annotations struct.
+                    description: |-
+                      AnnotationValue is the value of an annotation in Gateway API. This is used
+                      for validation of maps such as TLS options. This roughly matches Kubernetes
+                      annotation validation, although the length validation in that case is based
+                      on the entire size of the annotations struct.
                     maxLength: 4096
                     minLength: 0
                     type: string
-                  description: "Annotations that SHOULD be applied to any resources
-                    created in response to this Gateway. \n For implementations creating
-                    other Kubernetes objects, this should be the `metadata.annotations`
-                    field on resources. For other implementations, this refers to
-                    any relevant (implementation specific) \"annotations\" concepts.
-                    \n An implementation may chose to add additional implementation-specific
-                    annotations as they see fit. \n Support: Extended"
+                  description: |-
+                    Annotations that SHOULD be applied to any resources created in response to this Gateway.
+
+
+                    For implementations creating other Kubernetes objects, this should be the `metadata.annotations` field on resources.
+                    For other implementations, this refers to any relevant (implementation specific) "annotations" concepts.
+
+
+                    An implementation may chose to add additional implementation-specific annotations as they see fit.
+
+
+                    Support: Extended
                   maxProperties: 8
                   type: object
                 labels:
                   additionalProperties:
-                    description: AnnotationValue is the value of an annotation in
-                      Gateway API. This is used for validation of maps such as TLS
-                      options. This roughly matches Kubernetes annotation validation,
-                      although the length validation in that case is based on the
-                      entire size of the annotations struct.
+                    description: |-
+                      AnnotationValue is the value of an annotation in Gateway API. This is used
+                      for validation of maps such as TLS options. This roughly matches Kubernetes
+                      annotation validation, although the length validation in that case is based
+                      on the entire size of the annotations struct.
                     maxLength: 4096
                     minLength: 0
                     type: string
-                  description: "Labels that SHOULD be applied to any resources created
-                    in response to this Gateway. \n For implementations creating other
-                    Kubernetes objects, this should be the `metadata.labels` field
-                    on resources. For other implementations, this refers to any relevant
-                    (implementation specific) \"labels\" concepts. \n An implementation
-                    may chose to add additional implementation-specific labels as
-                    they see fit. \n Support: Extended"
+                  description: |-
+                    Labels that SHOULD be applied to any resources created in response to this Gateway.
+
+
+                    For implementations creating other Kubernetes objects, this should be the `metadata.labels` field on resources.
+                    For other implementations, this refers to any relevant (implementation specific) "labels" concepts.
+
+
+                    An implementation may chose to add additional implementation-specific labels as they see fit.
+
+
+                    Support: Extended
                   maxProperties: 8
+                  type: object
+                parametersRef:
+                  description: |-
+                    ParametersRef is a reference to a resource that contains the configuration
+                    parameters corresponding to the Gateway. This is optional if the
+                    controller does not require any additional configuration.
+
+
+                    This follows the same semantics as GatewayClass's `parametersRef`, but on a per-Gateway basis
+
+
+                    The Gateway's GatewayClass may provide its own `parametersRef`. When both are specified,
+                    the merging behavior is implementation specific.
+                    It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+
+                    Support: Implementation-specific
+                  properties:
+                    group:
+                      description: Group is the group of the referent.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the referent.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
                   type: object
               type: object
             listeners:
-              description: "Listeners associated with this Gateway. Listeners define
-                logical endpoints that are bound on this Gateway's addresses. At least
-                one Listener MUST be specified. \n Each Listener in a set of Listeners
-                (for example, in a single Gateway) MUST be _distinct_, in that a traffic
-                flow MUST be able to be assigned to exactly one listener. (This section
-                uses \"set of Listeners\" rather than \"Listeners in a single Gateway\"
-                because implementations MAY merge configuration from multiple Gateways
-                onto a single data plane, and these rules _also_ apply in that case).
-                \n Practically, this means that each listener in a set MUST have a
-                unique combination of Port, Protocol, and, if supported by the protocol,
-                Hostname. \n Some combinations of port, protocol, and TLS settings
-                are considered Core support and MUST be supported by implementations
-                based on their targeted conformance profile: \n HTTP Profile \n 1.
-                HTTPRoute, Port: 80, Protocol: HTTP 2. HTTPRoute, Port: 443, Protocol:
-                HTTPS, TLS Mode: Terminate, TLS keypair provided \n TLS Profile \n
-                1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough \n \"Distinct\"
-                Listeners have the following property: \n The implementation can match
-                inbound requests to a single distinct Listener. When multiple Listeners
-                share values for fields (for example, two Listeners with the same
-                Port value), the implementation can match requests to only one of
-                the Listeners using other Listener fields. \n For example, the following
-                Listener scenarios are distinct: \n 1. Multiple Listeners with the
-                same Port that all use the \"HTTP\" Protocol that all have unique
-                Hostname values. 2. Multiple Listeners with the same Port that use
-                either the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
-                values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners, where
-                no Listener with the same Protocol has the same Port value. \n Some
-                fields in the Listener struct have possible values that affect whether
-                the Listener is distinct. Hostname is particularly relevant for HTTP
-                or HTTPS protocols. \n When using the Hostname value to select between
-                same-Port, same-Protocol Listeners, the Hostname value must be different
-                on each Listener for the Listener to be distinct. \n When the Listeners
-                are distinct based on Hostname, inbound request hostnames MUST match
-                from the most specific to least specific Hostname values to choose
-                the correct Listener and its associated set of Routes. \n Exact matches
-                must be processed before wildcard matches, and wildcard matches must
-                be processed before fallback (empty Hostname value) matches. For example,
-                `\"foo.example.com\"` takes precedence over `\"*.example.com\"`, and
-                `\"*.example.com\"` takes precedence over `\"\"`. \n Additionally,
-                if there are multiple wildcard entries, more specific wildcard entries
-                must be processed before less specific wildcard entries. For example,
-                `\"*.foo.example.com\"` takes precedence over `\"*.example.com\"`.
-                The precise definition here is that the higher the number of dots
-                in the hostname to the right of the wildcard character, the higher
-                the precedence. \n The wildcard character will match any number of
-                characters _and dots_ to the left, however, so `\"*.example.com\"`
-                will match both `\"foo.bar.example.com\"` _and_ `\"bar.example.com\"`.
-                \n If a set of Listeners contains Listeners that are not distinct,
-                then those Listeners are Conflicted, and the implementation MUST set
-                the \"Conflicted\" condition in the Listener Status to \"True\". \n
+              description: |-
+                Listeners associated with this Gateway. Listeners define
+                logical endpoints that are bound on this Gateway's addresses.
+                At least one Listener MUST be specified.
+
+
+                Each Listener in a set of Listeners (for example, in a single Gateway)
+                MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
+                exactly one listener. (This section uses "set of Listeners" rather than
+                "Listeners in a single Gateway" because implementations MAY merge configuration
+                from multiple Gateways onto a single data plane, and these rules _also_
+                apply in that case).
+
+
+                Practically, this means that each listener in a set MUST have a unique
+                combination of Port, Protocol, and, if supported by the protocol, Hostname.
+
+
+                Some combinations of port, protocol, and TLS settings are considered
+                Core support and MUST be supported by implementations based on their
+                targeted conformance profile:
+
+
+                HTTP Profile
+
+
+                1. HTTPRoute, Port: 80, Protocol: HTTP
+                2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
+
+
+                TLS Profile
+
+
+                1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
+
+
+                "Distinct" Listeners have the following property:
+
+
+                The implementation can match inbound requests to a single distinct
+                Listener. When multiple Listeners share values for fields (for
+                example, two Listeners with the same Port value), the implementation
+                can match requests to only one of the Listeners using other
+                Listener fields.
+
+
+                For example, the following Listener scenarios are distinct:
+
+
+                1. Multiple Listeners with the same Port that all use the "HTTP"
+                   Protocol that all have unique Hostname values.
+                2. Multiple Listeners with the same Port that use either the "HTTPS" or
+                   "TLS" Protocol that all have unique Hostname values.
+                3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
+                   with the same Protocol has the same Port value.
+
+
+                Some fields in the Listener struct have possible values that affect
+                whether the Listener is distinct. Hostname is particularly relevant
+                for HTTP or HTTPS protocols.
+
+
+                When using the Hostname value to select between same-Port, same-Protocol
+                Listeners, the Hostname value must be different on each Listener for the
+                Listener to be distinct.
+
+
+                When the Listeners are distinct based on Hostname, inbound request
+                hostnames MUST match from the most specific to least specific Hostname
+                values to choose the correct Listener and its associated set of Routes.
+
+
+                Exact matches must be processed before wildcard matches, and wildcard
+                matches must be processed before fallback (empty Hostname value)
+                matches. For example, `"foo.example.com"` takes precedence over
+                `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
+
+
+                Additionally, if there are multiple wildcard entries, more specific
+                wildcard entries must be processed before less specific wildcard entries.
+                For example, `"*.foo.example.com"` takes precedence over `"*.example.com"`.
+                The precise definition here is that the higher the number of dots in the
+                hostname to the right of the wildcard character, the higher the precedence.
+
+
+                The wildcard character will match any number of characters _and dots_ to
+                the left, however, so `"*.example.com"` will match both
+                `"foo.bar.example.com"` _and_ `"bar.example.com"`.
+
+
+                If a set of Listeners contains Listeners that are not distinct, then those
+                Listeners are Conflicted, and the implementation MUST set the "Conflicted"
+                condition in the Listener Status to "True".
+
+
                 Implementations MAY choose to accept a Gateway with some Conflicted
                 Listeners only if they only accept the partial Listener set that contains
-                no Conflicted Listeners. To put this another way, implementations
-                may accept a partial Listener set only if they throw out *all* the
-                conflicting Listeners. No picking one of the conflicting listeners
-                as the winner. This also means that the Gateway must have at least
-                one non-conflicting Listener in this case, otherwise it violates the
-                requirement that at least one Listener must be present. \n The implementation
-                MUST set a \"ListenersNotValid\" condition on the Gateway Status when
-                the Gateway contains Conflicted Listeners whether or not they accept
-                the Gateway. That Condition SHOULD clearly indicate in the Message
-                which Listeners are conflicted, and which are Accepted. Additionally,
-                the Listener status for those listeners SHOULD indicate which Listeners
-                are conflicted and not Accepted. \n A Gateway's Listeners are considered
-                \"compatible\" if: \n 1. They are distinct. 2. The implementation
-                can serve them in compliance with the Addresses requirement that all
-                Listeners are available on all assigned addresses. \n Compatible combinations
-                in Extended support are expected to vary across implementations. A
-                combination that is compatible for one implementation may not be compatible
-                for another. \n For example, an implementation that cannot serve both
-                TCP and UDP listeners on the same address, or cannot mix HTTPS and
-                generic TLS listens on the same port would not consider those cases
-                compatible, even though they are distinct. \n Note that requests SHOULD
-                match at most one Listener. For example, if Listeners are defined
-                for \"foo.example.com\" and \"*.example.com\", a request to \"foo.example.com\"
-                SHOULD only be routed using routes attached to the \"foo.example.com\"
-                Listener (and not the \"*.example.com\" Listener). This concept is
-                known as \"Listener Isolation\". Implementations that do not support
-                Listener Isolation MUST clearly document this. \n Implementations
-                MAY merge separate Gateways onto a single set of Addresses if all
-                Listeners across all Gateways are compatible. \n Support: Core"
+                no Conflicted Listeners. To put this another way, implementations may
+                accept a partial Listener set only if they throw out *all* the conflicting
+                Listeners. No picking one of the conflicting listeners as the winner.
+                This also means that the Gateway must have at least one non-conflicting
+                Listener in this case, otherwise it violates the requirement that at
+                least one Listener must be present.
+
+
+                The implementation MUST set a "ListenersNotValid" condition on the
+                Gateway Status when the Gateway contains Conflicted Listeners whether or
+                not they accept the Gateway. That Condition SHOULD clearly
+                indicate in the Message which Listeners are conflicted, and which are
+                Accepted. Additionally, the Listener status for those listeners SHOULD
+                indicate which Listeners are conflicted and not Accepted.
+
+
+                A Gateway's Listeners are considered "compatible" if:
+
+
+                1. They are distinct.
+                2. The implementation can serve them in compliance with the Addresses
+                   requirement that all Listeners are available on all assigned
+                   addresses.
+
+
+                Compatible combinations in Extended support are expected to vary across
+                implementations. A combination that is compatible for one implementation
+                may not be compatible for another.
+
+
+                For example, an implementation that cannot serve both TCP and UDP listeners
+                on the same address, or cannot mix HTTPS and generic TLS listens on the same port
+                would not consider those cases compatible, even though they are distinct.
+
+
+                Note that requests SHOULD match at most one Listener. For example, if
+                Listeners are defined for "foo.example.com" and "*.example.com", a
+                request to "foo.example.com" SHOULD only be routed using routes attached
+                to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+                This concept is known as "Listener Isolation". Implementations that do
+                not support Listener Isolation MUST clearly document this.
+
+
+                Implementations MAY merge separate Gateways onto a single set of
+                Addresses if all Listeners across all Gateways are compatible.
+
+
+                Support: Core
               items:
-                description: Listener embodies the concept of a logical endpoint where
-                  a Gateway accepts network connections.
+                description: |-
+                  Listener embodies the concept of a logical endpoint where a Gateway accepts
+                  network connections.
                 properties:
                   allowedRoutes:
                     default:
                       namespaces:
                         from: Same
-                    description: "AllowedRoutes defines the types of routes that MAY
-                      be attached to a Listener and the trusted namespaces where those
-                      Route resources MAY be present. \n Although a client request
-                      may match multiple route rules, only one rule may ultimately
-                      receive the request. Matching precedence MUST be determined
-                      in order of the following criteria: \n * The most specific match
-                      as defined by the Route type. * The oldest Route based on creation
-                      timestamp. For example, a Route with a creation timestamp of
-                      \"2020-09-08 01:02:03\" is given precedence over a Route with
-                      a creation timestamp of \"2020-09-08 01:02:04\". * If everything
-                      else is equivalent, the Route appearing first in alphabetical
-                      order (namespace/name) should be given precedence. For example,
-                      foo/bar is given precedence over foo/baz. \n All valid rules
-                      within a Route attached to this Listener should be implemented.
-                      Invalid Route rules can be ignored (sometimes that will mean
+                    description: |-
+                      AllowedRoutes defines the types of routes that MAY be attached to a
+                      Listener and the trusted namespaces where those Route resources MAY be
+                      present.
+
+
+                      Although a client request may match multiple route rules, only one rule
+                      may ultimately receive the request. Matching precedence MUST be
+                      determined in order of the following criteria:
+
+
+                      * The most specific match as defined by the Route type.
+                      * The oldest Route based on creation timestamp. For example, a Route with
+                        a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+                        a Route with a creation timestamp of "2020-09-08 01:02:04".
+                      * If everything else is equivalent, the Route appearing first in
+                        alphabetical order (namespace/name) should be given precedence. For
+                        example, foo/bar is given precedence over foo/baz.
+
+
+                      All valid rules within a Route attached to this Listener should be
+                      implemented. Invalid Route rules can be ignored (sometimes that will mean
                       the full Route). If a Route rule transitions from valid to invalid,
-                      support for that Route rule should be dropped to ensure consistency.
-                      For example, even if a filter specified by a Route rule is invalid,
-                      the rest of the rules within that Route should still be supported.
-                      \n Support: Core"
+                      support for that Route rule should be dropped to ensure consistency. For
+                      example, even if a filter specified by a Route rule is invalid, the rest
+                      of the rules within that Route should still be supported.
+
+
+                      Support: Core
                     properties:
                       kinds:
-                        description: "Kinds specifies the groups and kinds of Routes
-                          that are allowed to bind to this Gateway Listener. When
-                          unspecified or empty, the kinds of Routes selected are determined
-                          using the Listener protocol. \n A RouteGroupKind MUST correspond
-                          to kinds of Routes that are compatible with the application
-                          protocol specified in the Listener's Protocol field. If
-                          an implementation does not support or recognize this resource
-                          type, it MUST set the \"ResolvedRefs\" condition to False
-                          for this Listener with the \"InvalidRouteKinds\" reason.
-                          \n Support: Core"
+                        description: |-
+                          Kinds specifies the groups and kinds of Routes that are allowed to bind
+                          to this Gateway Listener. When unspecified or empty, the kinds of Routes
+                          selected are determined using the Listener protocol.
+
+
+                          A RouteGroupKind MUST correspond to kinds of Routes that are compatible
+                          with the application protocol specified in the Listener's Protocol field.
+                          If an implementation does not support or recognize this resource type, it
+                          MUST set the "ResolvedRefs" condition to False for this Listener with the
+                          "InvalidRouteKinds" reason.
+
+
+                          Support: Core
                         items:
                           description: RouteGroupKind indicates the group and kind
                             of a Route resource.
@@ -325,36 +479,47 @@ spec:
                       namespaces:
                         default:
                           from: Same
-                        description: "Namespaces indicates namespaces from which Routes
-                          may be attached to this Listener. This is restricted to
-                          the namespace of this Gateway by default. \n Support: Core"
+                        description: |-
+                          Namespaces indicates namespaces from which Routes may be attached to this
+                          Listener. This is restricted to the namespace of this Gateway by default.
+
+
+                          Support: Core
                         properties:
                           from:
                             default: Same
-                            description: "From indicates where Routes will be selected
-                              for this Gateway. Possible values are: \n * All: Routes
-                              in all namespaces may be used by this Gateway. * Selector:
-                              Routes in namespaces selected by the selector may be
-                              used by this Gateway. * Same: Only Routes in the same
-                              namespace may be used by this Gateway. \n Support: Core"
+                            description: |-
+                              From indicates where Routes will be selected for this Gateway. Possible
+                              values are:
+
+
+                              * All: Routes in all namespaces may be used by this Gateway.
+                              * Selector: Routes in namespaces selected by the selector may be used by
+                                this Gateway.
+                              * Same: Only Routes in the same namespace may be used by this Gateway.
+
+
+                              Support: Core
                             enum:
                             - All
                             - Selector
                             - Same
                             type: string
                           selector:
-                            description: "Selector must be specified when From is
-                              set to \"Selector\". In that case, only Routes in Namespaces
-                              matching this Selector will be selected by this Gateway.
-                              This field is ignored for other values of \"From\".
-                              \n Support: Core"
+                            description: |-
+                              Selector must be specified when From is set to "Selector". In that case,
+                              only Routes in Namespaces matching this Selector will be selected by this
+                              Gateway. This field is ignored for other values of "From".
+
+
+                              Support: Core
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
                                   requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
                                     relates the key and values.
                                   properties:
                                     key:
@@ -362,131 +527,175 @@ spec:
                                         applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   required:
                                   - key
                                   - operator
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                         type: object
                     type: object
                   hostname:
-                    description: "Hostname specifies the virtual hostname to match
-                      for protocol types that define this concept. When unspecified,
-                      all hostnames are matched. This field is ignored for protocols
-                      that don't require hostname based matching. \n Implementations
-                      MUST apply Hostname matching appropriately for each of the following
-                      protocols: \n * TLS: The Listener Hostname MUST match the SNI.
-                      * HTTP: The Listener Hostname MUST match the Host header of
-                      the request. * HTTPS: The Listener Hostname SHOULD match at
-                      both the TLS and HTTP protocol layers as described above. If
-                      an implementation does not ensure that both the SNI and Host
-                      header match the Listener hostname, it MUST clearly document
-                      that. \n For HTTPRoute and TLSRoute resources, there is an interaction
-                      with the `spec.hostnames` array. When both listener and route
-                      specify hostnames, there MUST be an intersection between the
-                      values for a Route to be accepted. For more information, refer
-                      to the Route specific Hostnames documentation. \n Hostnames
-                      that are prefixed with a wildcard label (`*.`) are interpreted
-                      as a suffix match. That means that a match for `*.example.com`
-                      would match both `test.example.com`, and `foo.test.example.com`,
-                      but not `example.com`. \n Support: Core"
+                    description: |-
+                      Hostname specifies the virtual hostname to match for protocol types that
+                      define this concept. When unspecified, all hostnames are matched. This
+                      field is ignored for protocols that don't require hostname based
+                      matching.
+
+
+                      Implementations MUST apply Hostname matching appropriately for each of
+                      the following protocols:
+
+
+                      * TLS: The Listener Hostname MUST match the SNI.
+                      * HTTP: The Listener Hostname MUST match the Host header of the request.
+                      * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
+                        protocol layers as described above. If an implementation does not
+                        ensure that both the SNI and Host header match the Listener hostname,
+                        it MUST clearly document that.
+
+
+                      For HTTPRoute and TLSRoute resources, there is an interaction with the
+                      `spec.hostnames` array. When both listener and route specify hostnames,
+                      there MUST be an intersection between the values for a Route to be
+                      accepted. For more information, refer to the Route specific Hostnames
+                      documentation.
+
+
+                      Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                      as a suffix match. That means that a match for `*.example.com` would match
+                      both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   name:
-                    description: "Name is the name of the Listener. This name MUST
-                      be unique within a Gateway. \n Support: Core"
+                    description: |-
+                      Name is the name of the Listener. This name MUST be unique within a
+                      Gateway.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   port:
-                    description: "Port is the network port. Multiple listeners may
-                      use the same port, subject to the Listener compatibility rules.
-                      \n Support: Core"
+                    description: |-
+                      Port is the network port. Multiple listeners may use the
+                      same port, subject to the Listener compatibility rules.
+
+
+                      Support: Core
                     format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer
                   protocol:
-                    description: "Protocol specifies the network protocol this listener
-                      expects to receive. \n Support: Core"
+                    description: |-
+                      Protocol specifies the network protocol this listener expects to receive.
+
+
+                      Support: Core
                     maxLength: 255
                     minLength: 1
                     pattern: ^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
                     type: string
                   tls:
-                    description: "TLS is the TLS configuration for the Listener. This
-                      field is required if the Protocol field is \"HTTPS\" or \"TLS\".
-                      It is invalid to set this field if the Protocol field is \"HTTP\",
-                      \"TCP\", or \"UDP\". \n The association of SNIs to Certificate
-                      defined in GatewayTLSConfig is defined based on the Hostname
-                      field for this listener. \n The GatewayClass MUST use the longest
-                      matching SNI out of all available certificates for any TLS handshake.
-                      \n Support: Core"
+                    description: |-
+                      TLS is the TLS configuration for the Listener. This field is required if
+                      the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
+                      if the Protocol field is "HTTP", "TCP", or "UDP".
+
+
+                      The association of SNIs to Certificate defined in GatewayTLSConfig is
+                      defined based on the Hostname field for this listener.
+
+
+                      The GatewayClass MUST use the longest matching SNI out of all
+                      available certificates for any TLS handshake.
+
+
+                      Support: Core
                     properties:
                       certificateRefs:
-                        description: "CertificateRefs contains a series of references
-                          to Kubernetes objects that contains TLS certificates and
-                          private keys. These certificates are used to establish a
-                          TLS handshake for requests that match the hostname of the
-                          associated listener. \n A single CertificateRef to a Kubernetes
-                          Secret has \"Core\" support. Implementations MAY choose
-                          to support attaching multiple certificates to a Listener,
-                          but this behavior is implementation-specific. \n References
-                          to a resource in different namespace are invalid UNLESS
-                          there is a ReferenceGrant in the target namespace that allows
-                          the certificate to be attached. If a ReferenceGrant does
-                          not allow this reference, the \"ResolvedRefs\" condition
-                          MUST be set to False for this listener with the \"RefNotPermitted\"
-                          reason. \n This field is required to have at least one element
-                          when the mode is set to \"Terminate\" (default) and is optional
-                          otherwise. \n CertificateRefs can reference to standard
-                          Kubernetes resources, i.e. Secret, or implementation-specific
-                          custom resources. \n Support: Core - A single reference
-                          to a Kubernetes Secret of type kubernetes.io/tls \n Support:
-                          Implementation-specific (More than one reference or other
-                          resource types)"
+                        description: |-
+                          CertificateRefs contains a series of references to Kubernetes objects that
+                          contains TLS certificates and private keys. These certificates are used to
+                          establish a TLS handshake for requests that match the hostname of the
+                          associated listener.
+
+
+                          A single CertificateRef to a Kubernetes Secret has "Core" support.
+                          Implementations MAY choose to support attaching multiple certificates to
+                          a Listener, but this behavior is implementation-specific.
+
+
+                          References to a resource in different namespace are invalid UNLESS there
+                          is a ReferenceGrant in the target namespace that allows the certificate
+                          to be attached. If a ReferenceGrant does not allow this reference, the
+                          "ResolvedRefs" condition MUST be set to False for this listener with the
+                          "RefNotPermitted" reason.
+
+
+                          This field is required to have at least one element when the mode is set
+                          to "Terminate" (default) and is optional otherwise.
+
+
+                          CertificateRefs can reference to standard Kubernetes resources, i.e.
+                          Secret, or implementation-specific custom resources.
+
+
+                          Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
+
+                          Support: Implementation-specific (More than one reference or other resource types)
                         items:
-                          description: "SecretObjectReference identifies an API object
-                            including its namespace, defaulting to Secret. \n The
-                            API object must be valid in the cluster; the Group and
-                            Kind must be registered in the cluster for this reference
-                            to be valid. \n References to objects with invalid Group
-                            and Kind are not valid, and must be rejected by the implementation,
-                            with appropriate Conditions set on the containing object."
+                          description: |-
+                            SecretObjectReference identifies an API object including its namespace,
+                            defaulting to Secret.
+
+
+                            The API object must be valid in the cluster; the Group and Kind must
+                            be registered in the cluster for this reference to be valid.
+
+
+                            References to objects with invalid Group and Kind are not valid, and must
+                            be rejected by the implementation, with appropriate Conditions set
+                            on the containing object.
                           properties:
                             group:
                               default: ""
-                              description: Group is the group of the referent. For
-                                example, "gateway.networking.k8s.io". When unspecified
-                                or empty string, core API group is inferred.
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
                               maxLength: 253
                               pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
@@ -504,13 +713,18 @@ spec:
                               minLength: 1
                               type: string
                             namespace:
-                              description: "Namespace is the namespace of the referenced
-                                object. When unspecified, the local namespace is inferred.
-                                \n Note that when a namespace different than the local
-                                namespace is specified, a ReferenceGrant object is
-                                required in the referent namespace to allow that namespace's
-                                owner to accept the reference. See the ReferenceGrant
-                                documentation for details. \n Support: Core"
+                              description: |-
+                                Namespace is the namespace of the referenced object. When unspecified, the local
+                                namespace is inferred.
+
+
+                                Note that when a namespace different than the local namespace is specified,
+                                a ReferenceGrant object is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the ReferenceGrant
+                                documentation for details.
+
+
+                                Support: Core
                               maxLength: 63
                               minLength: 1
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -520,48 +734,157 @@ spec:
                           type: object
                         maxItems: 64
                         type: array
+                      frontendValidation:
+                        description: |+
+                          FrontendValidation holds configuration information for validating the frontend (client).
+                          Setting this field will require clients to send a client certificate
+                          required for validation during the TLS handshake. In browsers this may result in a dialog appearing
+                          that requests a user to specify the client certificate.
+                          The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+
+                          Support: Extended
+
+
+                        properties:
+                          caCertificateRefs:
+                            description: |-
+                              CACertificateRefs contains one or more references to
+                              Kubernetes objects that contain TLS certificates of
+                              the Certificate Authorities that can be used
+                              as a trust anchor to validate the certificates presented by the client.
+
+
+                              A single CA certificate reference to a Kubernetes ConfigMap
+                              has "Core" support.
+                              Implementations MAY choose to support attaching multiple CA certificates to
+                              a Listener, but this behavior is implementation-specific.
+
+
+                              Support: Core - A single reference to a Kubernetes ConfigMap
+                              with the CA certificate in a key named `ca.crt`.
+
+
+                              Support: Implementation-specific (More than one reference, or other kinds
+                              of resources).
+
+
+                              References to a resource in a different namespace are invalid UNLESS there
+                              is a ReferenceGrant in the target namespace that allows the certificate
+                              to be attached. If a ReferenceGrant does not allow this reference, the
+                              "ResolvedRefs" condition MUST be set to False for this listener with the
+                              "RefNotPermitted" reason.
+                            items:
+                              description: |-
+                                ObjectReference identifies an API object including its namespace.
+
+
+                                The API object must be valid in the cluster; the Group and Kind must
+                                be registered in the cluster for this reference to be valid.
+
+
+                                References to objects with invalid Group and Kind are not valid, and must
+                                be rejected by the implementation, with appropriate Conditions set
+                                on the containing object.
+                              properties:
+                                group:
+                                  description: |-
+                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                    When unspecified or empty string, core API group is inferred.
+                                  maxLength: 253
+                                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                kind:
+                                  description: Kind is kind of the referent. For example
+                                    "ConfigMap" or "Service".
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  type: string
+                                name:
+                                  description: Name is the name of the referent.
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of the referenced object. When unspecified, the local
+                                    namespace is inferred.
+
+
+                                    Note that when a namespace different than the local namespace is specified,
+                                    a ReferenceGrant object is required in the referent namespace to allow that
+                                    namespace's owner to accept the reference. See the ReferenceGrant
+                                    documentation for details.
+
+
+                                    Support: Core
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                              - group
+                              - kind
+                              - name
+                              type: object
+                            maxItems: 8
+                            minItems: 1
+                            type: array
+                        type: object
                       mode:
                         default: Terminate
-                        description: "Mode defines the TLS behavior for the TLS session
-                          initiated by the client. There are two possible modes: \n
-                          - Terminate: The TLS session between the downstream client
-                          and the Gateway is terminated at the Gateway. This mode
-                          requires certificateRefs to be set and contain at least
-                          one element. - Passthrough: The TLS session is NOT terminated
-                          by the Gateway. This implies that the Gateway can't decipher
-                          the TLS stream except for the ClientHello message of the
-                          TLS protocol. CertificateRefs field is ignored in this mode.
-                          \n Support: Core"
+                        description: |-
+                          Mode defines the TLS behavior for the TLS session initiated by the client.
+                          There are two possible modes:
+
+
+                          - Terminate: The TLS session between the downstream client and the
+                            Gateway is terminated at the Gateway. This mode requires certificates
+                            to be specified in some way, such as populating the certificateRefs
+                            field.
+                          - Passthrough: The TLS session is NOT terminated by the Gateway. This
+                            implies that the Gateway can't decipher the TLS stream except for
+                            the ClientHello message of the TLS protocol. The certificateRefs field
+                            is ignored in this mode.
+
+
+                          Support: Core
                         enum:
                         - Terminate
                         - Passthrough
                         type: string
                       options:
                         additionalProperties:
-                          description: AnnotationValue is the value of an annotation
-                            in Gateway API. This is used for validation of maps such
-                            as TLS options. This roughly matches Kubernetes annotation
-                            validation, although the length validation in that case
-                            is based on the entire size of the annotations struct.
+                          description: |-
+                            AnnotationValue is the value of an annotation in Gateway API. This is used
+                            for validation of maps such as TLS options. This roughly matches Kubernetes
+                            annotation validation, although the length validation in that case is based
+                            on the entire size of the annotations struct.
                           maxLength: 4096
                           minLength: 0
                           type: string
-                        description: "Options are a list of key/value pairs to enable
-                          extended TLS configuration for each implementation. For
-                          example, configuring the minimum TLS version or supported
-                          cipher suites. \n A set of common keys MAY be defined by
-                          the API in the future. To avoid any ambiguity, implementation-specific
-                          definitions MUST use domain-prefixed names, such as `example.com/my-custom-option`.
-                          Un-prefixed names are reserved for key names defined by
-                          Gateway API. \n Support: Implementation-specific"
+                        description: |-
+                          Options are a list of key/value pairs to enable extended TLS
+                          configuration for each implementation. For example, configuring the
+                          minimum TLS version or supported cipher suites.
+
+
+                          A set of common keys MAY be defined by the API in the future. To avoid
+                          any ambiguity, implementation-specific definitions MUST use
+                          domain-prefixed names, such as `example.com/my-custom-option`.
+                          Un-prefixed names are reserved for key names defined by Gateway API.
+
+
+                          Support: Implementation-specific
                         maxProperties: 16
                         type: object
                     type: object
                     x-kubernetes-validations:
-                    - message: certificateRefs must be specified when TLSModeType
+                    - message: certificateRefs or options must be specified when mode
                         is Terminate
                       rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
-                        > 0 : true'
+                        > 0 || size(self.options) > 0 : true'
                 required:
                 - name
                 - port
@@ -574,12 +897,12 @@ spec:
               - name
               x-kubernetes-list-type: map
               x-kubernetes-validations:
-              - message: tls must be specified for protocols ['HTTPS', 'TLS']
-                rule: 'self.all(l, l.protocol in [''HTTPS'', ''TLS''] ? has(l.tls)
-                  : true)'
               - message: tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']
                 rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ? !has(l.tls)
                   : true)'
+              - message: tls mode must be Terminate for protocol HTTPS
+                rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                  == '''' || l.tls.mode == ''Terminate'') : true)'
               - message: hostname must not be specified for protocols ['TCP', 'UDP']
                 rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
                   || l.hostname == '''') : true)'

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1/grpcroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1/grpcroutes.yaml
@@ -4,24 +4,50 @@ metadata:
   creationTimestamp: null
   labels:
     k8s.io/group: gateway.networking.k8s.io
-    k8s.io/kind: HTTPRoute
-    k8s.io/resource: httproutes
+    k8s.io/kind: GRPCRoute
+    k8s.io/resource: grpcroutes
     k8s.io/version: v1
-  name: gateway.networking.k8s.io-v1-httproutes
+  name: gateway.networking.k8s.io-v1-grpcroutes
 spec:
   resource:
     group: gateway.networking.k8s.io
-    kind: HTTPRoute
-    name: httproutes
+    kind: GRPCRoute
+    name: grpcroutes
     scope: Namespaced
     version: v1
   validation:
     openAPIV3Schema:
       description: |-
-        HTTPRoute provides a way to route HTTP requests. This includes the capability
-        to match requests by hostname, path, header, or query param. Filters can be
-        used to specify additional processing steps. Backends specify where matching
-        requests should be routed.
+        GRPCRoute provides a way to route gRPC requests. This includes the capability
+        to match requests by hostname, gRPC service, gRPC method, or HTTP/2 header.
+        Filters can be used to specify additional processing steps. Backends specify
+        where matching requests will be routed.
+
+
+        GRPCRoute falls under extended support within the Gateway API. Within the
+        following specification, the word "MUST" indicates that an implementation
+        supporting GRPCRoute must conform to the indicated requirement, but an
+        implementation not supporting this route type need not follow the requirement
+        unless explicitly indicated.
+
+
+        Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST
+        accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via
+        ALPN. If the implementation does not support this, then it MUST set the
+        "Accepted" condition to "False" for the affected listener with a reason of
+        "UnsupportedProtocol".  Implementations MAY also accept HTTP/2 connections
+        with an upgrade from HTTP/1.
+
+
+        Implementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST
+        support HTTP/2 over cleartext TCP (h2c,
+        https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial
+        upgrade from HTTP/1.1, i.e. with prior knowledge
+        (https://www.rfc-editor.org/rfc/rfc7540#section-3.4). If the implementation
+        does not support this, then it MUST set the "Accepted" condition to "False"
+        for the affected listener with a reason of "UnsupportedProtocol".
+        Implementations MAY also accept HTTP/2 connections with an upgrade from
+        HTTP/1, i.e. without prior knowledge.
       properties:
         apiVersion:
           description: |-
@@ -72,40 +98,33 @@ spec:
               type: object
           type: object
         spec:
-          description: Spec defines the desired state of HTTPRoute.
+          description: Spec defines the desired state of GRPCRoute.
           properties:
             hostnames:
               description: |-
-                Hostnames defines a set of hostnames that should match against the HTTP Host
-                header to select a HTTPRoute used to process the request. Implementations
-                MUST ignore any port value specified in the HTTP Host header while
-                performing a match and (absent of any applicable header modification
-                configuration) MUST forward this header unmodified to the backend.
-
-
-                Valid values for Hostnames are determined by RFC 1123 definition of a
-                hostname with 2 notable exceptions:
+                Hostnames defines a set of hostnames to match against the GRPC
+                Host header to select a GRPCRoute to process the request. This matches
+                the RFC 1123 definition of a hostname with 2 notable exceptions:
 
 
                 1. IPs are not allowed.
                 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
-                   label must appear by itself as the first label.
+                   label MUST appear by itself as the first label.
 
 
-                If a hostname is specified by both the Listener and HTTPRoute, there
-                must be at least one intersecting hostname for the HTTPRoute to be
+                If a hostname is specified by both the Listener and GRPCRoute, there
+                MUST be at least one intersecting hostname for the GRPCRoute to be
                 attached to the Listener. For example:
 
 
-                * A Listener with `test.example.com` as the hostname matches HTTPRoutes
+                * A Listener with `test.example.com` as the hostname matches GRPCRoutes
                   that have either not specified any hostnames, or have specified at
                   least one of `test.example.com` or `*.example.com`.
-                * A Listener with `*.example.com` as the hostname matches HTTPRoutes
+                * A Listener with `*.example.com` as the hostname matches GRPCRoutes
                   that have either not specified any hostnames or have specified at least
                   one hostname that matches the Listener hostname. For example,
-                  `*.example.com`, `test.example.com`, and `foo.test.example.com` would
-                  all match. On the other hand, `example.com` and `test.example.net` would
-                  not match.
+                  `test.example.com` and `*.example.com` would both match. On the other
+                  hand, `example.com` and `test.example.net` would not match.
 
 
                 Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
@@ -113,30 +132,33 @@ spec:
                 both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
 
 
-                If both the Listener and HTTPRoute have specified hostnames, any
-                HTTPRoute hostnames that do not match the Listener hostname MUST be
+                If both the Listener and GRPCRoute have specified hostnames, any
+                GRPCRoute hostnames that do not match the Listener hostname MUST be
                 ignored. For example, if a Listener specified `*.example.com`, and the
-                HTTPRoute specified `test.example.com` and `test.example.net`,
-                `test.example.net` must not be considered for a match.
+                GRPCRoute specified `test.example.com` and `test.example.net`,
+                `test.example.net` MUST NOT be considered for a match.
 
 
-                If both the Listener and HTTPRoute have specified hostnames, and none
-                match with the criteria above, then the HTTPRoute is not accepted. The
-                implementation must raise an 'Accepted' Condition with a status of
-                `False` in the corresponding RouteParentStatus.
+                If both the Listener and GRPCRoute have specified hostnames, and none
+                match with the criteria above, then the GRPCRoute MUST NOT be accepted by
+                the implementation. The implementation MUST raise an 'Accepted' Condition
+                with a status of `False` in the corresponding RouteParentStatus.
 
 
-                In the event that multiple HTTPRoutes specify intersecting hostnames (e.g.
-                overlapping wildcard matching and exact matching hostnames), precedence must
-                be given to rules from the HTTPRoute with the largest number of:
+                If a Route (A) of type HTTPRoute or GRPCRoute is attached to a
+                Listener and that listener already has another Route (B) of the other
+                type attached and the intersection of the hostnames of A and B is
+                non-empty, then the implementation MUST accept exactly one of these two
+                routes, determined by the following criteria, in order:
 
 
-                * Characters in a matching non-wildcard hostname.
-                * Characters in a matching hostname.
+                * The oldest Route based on creation timestamp.
+                * The Route appearing first in alphabetical order by
+                  "{namespace}/{name}".
 
 
-                If ties exist across multiple Routes, the matching precedence rules for
-                HTTPRouteMatches takes over.
+                The rejected Route MUST raise an 'Accepted' condition with a status of
+                'False' in the corresponding RouteParentStatus.
 
 
                 Support: Core
@@ -438,15 +460,10 @@ spec:
                   (((!has(p1.port) || p1.port == 0) && (!has(p2.port) || p2.port ==
                   0)) || (has(p1.port) && has(p2.port) && p1.port == p2.port))))
             rules:
-              default:
-              - matches:
-                - path:
-                    type: PathPrefix
-                    value: /
-              description: Rules are a list of HTTP matchers, filters and actions.
+              description: Rules are a list of GRPC matchers, filters and actions.
               items:
                 description: |-
-                  HTTPRouteRule defines semantics for matching an HTTP request based on
+                  GRPCRouteRule defines the semantics for matching a gRPC request based on
                   conditions (matches), processing it (filters), and forwarding the request to
                   an API object (backendRefs).
                 properties:
@@ -462,29 +479,26 @@ spec:
 
                       If *all* entries in BackendRefs are invalid, and there are also no filters
                       specified in this route rule, *all* traffic which matches this rule MUST
-                      receive a 500 status code.
+                      receive an `UNAVAILABLE` status.
 
 
-                      See the HTTPBackendRef definition for the rules about what makes a single
-                      HTTPBackendRef invalid.
+                      See the GRPCBackendRef definition for the rules about what makes a single
+                      GRPCBackendRef invalid.
 
 
-                      When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
+                      When a GRPCBackendRef is invalid, `UNAVAILABLE` statuses MUST be returned for
                       requests that would have otherwise been routed to an invalid backend. If
                       multiple backends are specified, and some are invalid, the proportion of
                       requests that would otherwise have been routed to an invalid backend
-                      MUST receive a 500 status code.
+                      MUST receive an `UNAVAILABLE` status.
 
 
                       For example, if two backends are specified with equal weights, and one is
-                      invalid, 50 percent of traffic must receive a 500. Implementations may
-                      choose how that 50 percent is determined.
+                      invalid, 50 percent of traffic MUST receive an `UNAVAILABLE` status.
+                      Implementations may choose how that 50 percent is determined.
 
 
                       Support: Core for Kubernetes Service
-
-
-                      Support: Extended for Kubernetes ServiceImport
 
 
                       Support: Implementation-specific for any other resource
@@ -493,7 +507,7 @@ spec:
                       Support for weight: Core
                     items:
                       description: |-
-                        HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.
+                        GRPCBackendRef defines how a GRPCRoute forwards a gRPC request.
 
 
                         Note that when a namespace different than the local namespace is specified, a
@@ -527,16 +541,16 @@ spec:
                       properties:
                         filters:
                           description: |-
-                            Filters defined at this level should be executed if and only if the
+                            Filters defined at this level MUST be executed if and only if the
                             request is being forwarded to the backend defined here.
 
 
                             Support: Implementation-specific (For broader support of filters, use the
-                            Filters field in HTTPRouteRule.)
+                            Filters field in GRPCRouteRule.)
                           items:
                             description: |-
-                              HTTPRouteFilter defines processing steps that must be completed during the
-                              request or response lifecycle. HTTPRouteFilters are meant as an extension
+                              GRPCRouteFilter defines processing steps that must be completed during the
+                              request or response lifecycle. GRPCRouteFilters are meant as an extension
                               point to express processing that may be done in Gateway implementations. Some
                               examples include request or response modification, implementing
                               authentication strategies, rate-limiting, and traffic shaping. API
@@ -550,10 +564,10 @@ spec:
                                   extended filters.
 
 
-                                  This filter can be used multiple times within the same rule.
-
-
                                   Support: Implementation-specific
+
+
+                                  This filter can be used multiple times within the same rule.
                                 properties:
                                   group:
                                     description: |-
@@ -846,191 +860,6 @@ spec:
                                 required:
                                 - backendRef
                                 type: object
-                              requestRedirect:
-                                description: |-
-                                  RequestRedirect defines a schema for a filter that responds to the
-                                  request with an HTTP redirection.
-
-
-                                  Support: Core
-                                properties:
-                                  hostname:
-                                    description: |-
-                                      Hostname is the hostname to be used in the value of the `Location`
-                                      header in the response.
-                                      When empty, the hostname in the `Host` header of the request is used.
-
-
-                                      Support: Core
-                                    maxLength: 253
-                                    minLength: 1
-                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                    type: string
-                                  path:
-                                    description: |-
-                                      Path defines parameters used to modify the path of the incoming request.
-                                      The modified path is then used to construct the `Location` header. When
-                                      empty, the request path is used as-is.
-
-
-                                      Support: Extended
-                                    properties:
-                                      replaceFullPath:
-                                        description: |-
-                                          ReplaceFullPath specifies the value with which to replace the full path
-                                          of a request during a rewrite or redirect.
-                                        maxLength: 1024
-                                        type: string
-                                      replacePrefixMatch:
-                                        description: |-
-                                          ReplacePrefixMatch specifies the value with which to replace the prefix
-                                          match of a request during a rewrite or redirect. For example, a request
-                                          to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
-                                          of "/xyz" would be modified to "/xyz/bar".
-
-
-                                          Note that this matches the behavior of the PathPrefix match type. This
-                                          matches full path elements. A path element refers to the list of labels
-                                          in the path split by the `/` separator. When specified, a trailing `/` is
-                                          ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
-                                          match the prefix `/abc`, but the path `/abcd` would not.
-
-
-                                          ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
-                                          Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
-                                          the implementation setting the Accepted Condition for the Route to `status: False`.
-
-
-                                          Request Path | Prefix Match | Replace Prefix | Modified Path
-                                          -------------|--------------|----------------|----------
-                                          /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                          /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                          /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                          /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                          /foo         | /foo         | /xyz           | /xyz
-                                          /foo/        | /foo         | /xyz           | /xyz/
-                                          /foo/bar     | /foo         | <empty string> | /bar
-                                          /foo/        | /foo         | <empty string> | /
-                                          /foo         | /foo         | <empty string> | /
-                                          /foo/        | /foo         | /              | /
-                                          /foo         | /foo         | /              | /
-                                        maxLength: 1024
-                                        type: string
-                                      type:
-                                        description: |-
-                                          Type defines the type of path modifier. Additional types may be
-                                          added in a future release of the API.
-
-
-                                          Note that values may be added to this enum, implementations
-                                          must ensure that unknown values will not cause a crash.
-
-
-                                          Unknown values here must result in the implementation setting the
-                                          Accepted Condition for the Route to `status: False`, with a
-                                          Reason of `UnsupportedValue`.
-                                        enum:
-                                        - ReplaceFullPath
-                                        - ReplacePrefixMatch
-                                        type: string
-                                    required:
-                                    - type
-                                    type: object
-                                    x-kubernetes-validations:
-                                    - message: replaceFullPath must be specified when
-                                        type is set to 'ReplaceFullPath'
-                                      rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
-                                        : true'
-                                    - message: type must be 'ReplaceFullPath' when
-                                        replaceFullPath is set
-                                      rule: 'has(self.replaceFullPath) ? self.type
-                                        == ''ReplaceFullPath'' : true'
-                                    - message: replacePrefixMatch must be specified
-                                        when type is set to 'ReplacePrefixMatch'
-                                      rule: 'self.type == ''ReplacePrefixMatch'' ?
-                                        has(self.replacePrefixMatch) : true'
-                                    - message: type must be 'ReplacePrefixMatch' when
-                                        replacePrefixMatch is set
-                                      rule: 'has(self.replacePrefixMatch) ? self.type
-                                        == ''ReplacePrefixMatch'' : true'
-                                  port:
-                                    description: |-
-                                      Port is the port to be used in the value of the `Location`
-                                      header in the response.
-
-
-                                      If no port is specified, the redirect port MUST be derived using the
-                                      following rules:
-
-
-                                      * If redirect scheme is not-empty, the redirect port MUST be the well-known
-                                        port associated with the redirect scheme. Specifically "http" to port 80
-                                        and "https" to port 443. If the redirect scheme does not have a
-                                        well-known port, the listener port of the Gateway SHOULD be used.
-                                      * If redirect scheme is empty, the redirect port MUST be the Gateway
-                                        Listener port.
-
-
-                                      Implementations SHOULD NOT add the port number in the 'Location'
-                                      header in the following cases:
-
-
-                                      * A Location header that will use HTTP (whether that is determined via
-                                        the Listener protocol or the Scheme field) _and_ use port 80.
-                                      * A Location header that will use HTTPS (whether that is determined via
-                                        the Listener protocol or the Scheme field) _and_ use port 443.
-
-
-                                      Support: Extended
-                                    format: int32
-                                    maximum: 65535
-                                    minimum: 1
-                                    type: integer
-                                  scheme:
-                                    description: |-
-                                      Scheme is the scheme to be used in the value of the `Location` header in
-                                      the response. When empty, the scheme of the request is used.
-
-
-                                      Scheme redirects can affect the port of the redirect, for more information,
-                                      refer to the documentation for the port field of this filter.
-
-
-                                      Note that values may be added to this enum, implementations
-                                      must ensure that unknown values will not cause a crash.
-
-
-                                      Unknown values here must result in the implementation setting the
-                                      Accepted Condition for the Route to `status: False`, with a
-                                      Reason of `UnsupportedValue`.
-
-
-                                      Support: Extended
-                                    enum:
-                                    - http
-                                    - https
-                                    type: string
-                                  statusCode:
-                                    default: 302
-                                    description: |-
-                                      StatusCode is the HTTP status code to be used in response.
-
-
-                                      Note that values may be added to this enum, implementations
-                                      must ensure that unknown values will not cause a crash.
-
-
-                                      Unknown values here must result in the implementation setting the
-                                      Accepted Condition for the Route to `status: False`, with a
-                                      Reason of `UnsupportedValue`.
-
-
-                                      Support: Core
-                                    enum:
-                                    - 301
-                                    - 302
-                                    type: integer
-                                type: object
                               responseHeaderModifier:
                                 description: |-
                                   ResponseHeaderModifier defines a schema for a filter that modifies response
@@ -1177,14 +1006,14 @@ spec:
                                     x-kubernetes-list-type: map
                                 type: object
                               type:
-                                description: |-
+                                description: |+
                                   Type identifies the type of filter to apply. As with other API fields,
                                   types are classified into three conformance levels:
 
 
                                   - Core: Filter types and their corresponding configuration defined by
                                     "Support: Core" in this package, e.g. "RequestHeaderModifier". All
-                                    implementations must support core filters.
+                                    implementations supporting GRPCRoute MUST support core filters.
 
 
                                   - Extended: Filter types and their corresponding configuration defined by
@@ -1192,12 +1021,11 @@ spec:
                                     are encouraged to support extended filters.
 
 
-                                  - Implementation-specific: Filters that are defined and supported by
-                                    specific vendors.
+                                  - Implementation-specific: Filters that are defined and supported by specific vendors.
                                     In the future, filters showing convergence in behavior across multiple
                                     implementations will be considered for inclusion in extended or core
                                     conformance levels. Filter-specific configuration for such filters
-                                    is specified using the ExtensionRef field. `Type` should be set to
+                                    is specified using the ExtensionRef field. `Type` MUST be set to
                                     "ExtensionRef" for custom filters.
 
 
@@ -1210,125 +1038,12 @@ spec:
                                   that filter MUST receive a HTTP error response.
 
 
-                                  Note that values may be added to this enum, implementations
-                                  must ensure that unknown values will not cause a crash.
-
-
-                                  Unknown values here must result in the implementation setting the
-                                  Accepted Condition for the Route to `status: False`, with a
-                                  Reason of `UnsupportedValue`.
                                 enum:
-                                - RequestHeaderModifier
                                 - ResponseHeaderModifier
+                                - RequestHeaderModifier
                                 - RequestMirror
-                                - RequestRedirect
-                                - URLRewrite
                                 - ExtensionRef
                                 type: string
-                              urlRewrite:
-                                description: |-
-                                  URLRewrite defines a schema for a filter that modifies a request during forwarding.
-
-
-                                  Support: Extended
-                                properties:
-                                  hostname:
-                                    description: |-
-                                      Hostname is the value to be used to replace the Host header value during
-                                      forwarding.
-
-
-                                      Support: Extended
-                                    maxLength: 253
-                                    minLength: 1
-                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                    type: string
-                                  path:
-                                    description: |-
-                                      Path defines a path rewrite.
-
-
-                                      Support: Extended
-                                    properties:
-                                      replaceFullPath:
-                                        description: |-
-                                          ReplaceFullPath specifies the value with which to replace the full path
-                                          of a request during a rewrite or redirect.
-                                        maxLength: 1024
-                                        type: string
-                                      replacePrefixMatch:
-                                        description: |-
-                                          ReplacePrefixMatch specifies the value with which to replace the prefix
-                                          match of a request during a rewrite or redirect. For example, a request
-                                          to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
-                                          of "/xyz" would be modified to "/xyz/bar".
-
-
-                                          Note that this matches the behavior of the PathPrefix match type. This
-                                          matches full path elements. A path element refers to the list of labels
-                                          in the path split by the `/` separator. When specified, a trailing `/` is
-                                          ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
-                                          match the prefix `/abc`, but the path `/abcd` would not.
-
-
-                                          ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
-                                          Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
-                                          the implementation setting the Accepted Condition for the Route to `status: False`.
-
-
-                                          Request Path | Prefix Match | Replace Prefix | Modified Path
-                                          -------------|--------------|----------------|----------
-                                          /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                          /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                          /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                          /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                          /foo         | /foo         | /xyz           | /xyz
-                                          /foo/        | /foo         | /xyz           | /xyz/
-                                          /foo/bar     | /foo         | <empty string> | /bar
-                                          /foo/        | /foo         | <empty string> | /
-                                          /foo         | /foo         | <empty string> | /
-                                          /foo/        | /foo         | /              | /
-                                          /foo         | /foo         | /              | /
-                                        maxLength: 1024
-                                        type: string
-                                      type:
-                                        description: |-
-                                          Type defines the type of path modifier. Additional types may be
-                                          added in a future release of the API.
-
-
-                                          Note that values may be added to this enum, implementations
-                                          must ensure that unknown values will not cause a crash.
-
-
-                                          Unknown values here must result in the implementation setting the
-                                          Accepted Condition for the Route to `status: False`, with a
-                                          Reason of `UnsupportedValue`.
-                                        enum:
-                                        - ReplaceFullPath
-                                        - ReplacePrefixMatch
-                                        type: string
-                                    required:
-                                    - type
-                                    type: object
-                                    x-kubernetes-validations:
-                                    - message: replaceFullPath must be specified when
-                                        type is set to 'ReplaceFullPath'
-                                      rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
-                                        : true'
-                                    - message: type must be 'ReplaceFullPath' when
-                                        replaceFullPath is set
-                                      rule: 'has(self.replaceFullPath) ? self.type
-                                        == ''ReplaceFullPath'' : true'
-                                    - message: replacePrefixMatch must be specified
-                                        when type is set to 'ReplacePrefixMatch'
-                                      rule: 'self.type == ''ReplacePrefixMatch'' ?
-                                        has(self.replacePrefixMatch) : true'
-                                    - message: type must be 'ReplacePrefixMatch' when
-                                        replacePrefixMatch is set
-                                      rule: 'has(self.replacePrefixMatch) ? self.type
-                                        == ''ReplacePrefixMatch'' : true'
-                                type: object
                             required:
                             - type
                             type: object
@@ -1355,19 +1070,6 @@ spec:
                             - message: filter.requestMirror must be specified for
                                 RequestMirror filter.type
                               rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
-                            - message: filter.requestRedirect must be nil if the filter.type
-                                is not RequestRedirect
-                              rule: '!(has(self.requestRedirect) && self.type != ''RequestRedirect'')'
-                            - message: filter.requestRedirect must be specified for
-                                RequestRedirect filter.type
-                              rule: '!(!has(self.requestRedirect) && self.type ==
-                                ''RequestRedirect'')'
-                            - message: filter.urlRewrite must be nil if the filter.type
-                                is not URLRewrite
-                              rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
-                            - message: filter.urlRewrite must be specified for URLRewrite
-                                filter.type
-                              rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
                             - message: filter.extensionRef must be nil if the filter.type
                                 is not ExtensionRef
                               rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
@@ -1377,26 +1079,12 @@ spec:
                           maxItems: 16
                           type: array
                           x-kubernetes-validations:
-                          - message: May specify either httpRouteFilterRequestRedirect
-                              or httpRouteFilterRequestRewrite, but not both
-                            rule: '!(self.exists(f, f.type == ''RequestRedirect'')
-                              && self.exists(f, f.type == ''URLRewrite''))'
-                          - message: May specify either httpRouteFilterRequestRedirect
-                              or httpRouteFilterRequestRewrite, but not both
-                            rule: '!(self.exists(f, f.type == ''RequestRedirect'')
-                              && self.exists(f, f.type == ''URLRewrite''))'
                           - message: RequestHeaderModifier filter cannot be repeated
                             rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
                               <= 1
                           - message: ResponseHeaderModifier filter cannot be repeated
                             rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
                               <= 1
-                          - message: RequestRedirect filter cannot be repeated
-                            rule: self.filter(f, f.type == 'RequestRedirect').size()
-                              <= 1
-                          - message: URLRewrite filter cannot be repeated
-                            rule: self.filter(f, f.type == 'URLRewrite').size() <=
-                              1
                         group:
                           default: ""
                           description: |-
@@ -1500,27 +1188,15 @@ spec:
                       this rule.
 
 
-                      Wherever possible, implementations SHOULD implement filters in the order
-                      they are specified.
-
-
-                      Implementations MAY choose to implement this ordering strictly, rejecting
-                      any combination or order of filters that can not be supported. If implementations
-                      choose a strict interpretation of filter ordering, they MUST clearly document
-                      that behavior.
-
-
-                      To reject an invalid combination or order of filters, implementations SHOULD
-                      consider the Route Rules with this configuration invalid. If all Route Rules
-                      in a Route are invalid, the entire Route would be considered invalid. If only
-                      a portion of Route Rules are invalid, implementations MUST set the
-                      "PartiallyInvalid" condition for the Route.
+                      The effects of ordering of multiple behaviors are currently unspecified.
+                      This can change in the future based on feedback during the alpha stage.
 
 
                       Conformance-levels at this level are defined based on the type of filter:
 
 
-                      - ALL core filters MUST be supported by all implementations.
+                      - ALL core filters MUST be supported by all implementations that support
+                        GRPCRoute.
                       - Implementers are encouraged to support extended filters.
                       - Implementation-specific custom filters have no API guarantees across
                         implementations.
@@ -1530,9 +1206,7 @@ spec:
                       indicated in the filter.
 
 
-                      All filters are expected to be compatible with each other except for the
-                      URLRewrite and RequestRedirect filters, which may not be combined. If an
-                      implementation can not support other combinations of filters, they must clearly
+                      If an implementation can not support a combination of filters, it must clearly
                       document that limitation. In cases where incompatible or unsupported
                       filters are specified and cause the `Accepted` condition to be set to status
                       `False`, implementations may use the `IncompatibleFilters` reason to specify
@@ -1542,8 +1216,8 @@ spec:
                       Support: Core
                     items:
                       description: |-
-                        HTTPRouteFilter defines processing steps that must be completed during the
-                        request or response lifecycle. HTTPRouteFilters are meant as an extension
+                        GRPCRouteFilter defines processing steps that must be completed during the
+                        request or response lifecycle. GRPCRouteFilters are meant as an extension
                         point to express processing that may be done in Gateway implementations. Some
                         examples include request or response modification, implementing
                         authentication strategies, rate-limiting, and traffic shaping. API
@@ -1557,10 +1231,10 @@ spec:
                             extended filters.
 
 
-                            This filter can be used multiple times within the same rule.
-
-
                             Support: Implementation-specific
+
+
+                            This filter can be used multiple times within the same rule.
                           properties:
                             group:
                               description: |-
@@ -1853,191 +1527,6 @@ spec:
                           required:
                           - backendRef
                           type: object
-                        requestRedirect:
-                          description: |-
-                            RequestRedirect defines a schema for a filter that responds to the
-                            request with an HTTP redirection.
-
-
-                            Support: Core
-                          properties:
-                            hostname:
-                              description: |-
-                                Hostname is the hostname to be used in the value of the `Location`
-                                header in the response.
-                                When empty, the hostname in the `Host` header of the request is used.
-
-
-                                Support: Core
-                              maxLength: 253
-                              minLength: 1
-                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                              type: string
-                            path:
-                              description: |-
-                                Path defines parameters used to modify the path of the incoming request.
-                                The modified path is then used to construct the `Location` header. When
-                                empty, the request path is used as-is.
-
-
-                                Support: Extended
-                              properties:
-                                replaceFullPath:
-                                  description: |-
-                                    ReplaceFullPath specifies the value with which to replace the full path
-                                    of a request during a rewrite or redirect.
-                                  maxLength: 1024
-                                  type: string
-                                replacePrefixMatch:
-                                  description: |-
-                                    ReplacePrefixMatch specifies the value with which to replace the prefix
-                                    match of a request during a rewrite or redirect. For example, a request
-                                    to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
-                                    of "/xyz" would be modified to "/xyz/bar".
-
-
-                                    Note that this matches the behavior of the PathPrefix match type. This
-                                    matches full path elements. A path element refers to the list of labels
-                                    in the path split by the `/` separator. When specified, a trailing `/` is
-                                    ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
-                                    match the prefix `/abc`, but the path `/abcd` would not.
-
-
-                                    ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
-                                    Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
-                                    the implementation setting the Accepted Condition for the Route to `status: False`.
-
-
-                                    Request Path | Prefix Match | Replace Prefix | Modified Path
-                                    -------------|--------------|----------------|----------
-                                    /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                    /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                    /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                    /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                    /foo         | /foo         | /xyz           | /xyz
-                                    /foo/        | /foo         | /xyz           | /xyz/
-                                    /foo/bar     | /foo         | <empty string> | /bar
-                                    /foo/        | /foo         | <empty string> | /
-                                    /foo         | /foo         | <empty string> | /
-                                    /foo/        | /foo         | /              | /
-                                    /foo         | /foo         | /              | /
-                                  maxLength: 1024
-                                  type: string
-                                type:
-                                  description: |-
-                                    Type defines the type of path modifier. Additional types may be
-                                    added in a future release of the API.
-
-
-                                    Note that values may be added to this enum, implementations
-                                    must ensure that unknown values will not cause a crash.
-
-
-                                    Unknown values here must result in the implementation setting the
-                                    Accepted Condition for the Route to `status: False`, with a
-                                    Reason of `UnsupportedValue`.
-                                  enum:
-                                  - ReplaceFullPath
-                                  - ReplacePrefixMatch
-                                  type: string
-                              required:
-                              - type
-                              type: object
-                              x-kubernetes-validations:
-                              - message: replaceFullPath must be specified when type
-                                  is set to 'ReplaceFullPath'
-                                rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
-                                  : true'
-                              - message: type must be 'ReplaceFullPath' when replaceFullPath
-                                  is set
-                                rule: 'has(self.replaceFullPath) ? self.type == ''ReplaceFullPath''
-                                  : true'
-                              - message: replacePrefixMatch must be specified when
-                                  type is set to 'ReplacePrefixMatch'
-                                rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
-                                  : true'
-                              - message: type must be 'ReplacePrefixMatch' when replacePrefixMatch
-                                  is set
-                                rule: 'has(self.replacePrefixMatch) ? self.type ==
-                                  ''ReplacePrefixMatch'' : true'
-                            port:
-                              description: |-
-                                Port is the port to be used in the value of the `Location`
-                                header in the response.
-
-
-                                If no port is specified, the redirect port MUST be derived using the
-                                following rules:
-
-
-                                * If redirect scheme is not-empty, the redirect port MUST be the well-known
-                                  port associated with the redirect scheme. Specifically "http" to port 80
-                                  and "https" to port 443. If the redirect scheme does not have a
-                                  well-known port, the listener port of the Gateway SHOULD be used.
-                                * If redirect scheme is empty, the redirect port MUST be the Gateway
-                                  Listener port.
-
-
-                                Implementations SHOULD NOT add the port number in the 'Location'
-                                header in the following cases:
-
-
-                                * A Location header that will use HTTP (whether that is determined via
-                                  the Listener protocol or the Scheme field) _and_ use port 80.
-                                * A Location header that will use HTTPS (whether that is determined via
-                                  the Listener protocol or the Scheme field) _and_ use port 443.
-
-
-                                Support: Extended
-                              format: int32
-                              maximum: 65535
-                              minimum: 1
-                              type: integer
-                            scheme:
-                              description: |-
-                                Scheme is the scheme to be used in the value of the `Location` header in
-                                the response. When empty, the scheme of the request is used.
-
-
-                                Scheme redirects can affect the port of the redirect, for more information,
-                                refer to the documentation for the port field of this filter.
-
-
-                                Note that values may be added to this enum, implementations
-                                must ensure that unknown values will not cause a crash.
-
-
-                                Unknown values here must result in the implementation setting the
-                                Accepted Condition for the Route to `status: False`, with a
-                                Reason of `UnsupportedValue`.
-
-
-                                Support: Extended
-                              enum:
-                              - http
-                              - https
-                              type: string
-                            statusCode:
-                              default: 302
-                              description: |-
-                                StatusCode is the HTTP status code to be used in response.
-
-
-                                Note that values may be added to this enum, implementations
-                                must ensure that unknown values will not cause a crash.
-
-
-                                Unknown values here must result in the implementation setting the
-                                Accepted Condition for the Route to `status: False`, with a
-                                Reason of `UnsupportedValue`.
-
-
-                                Support: Core
-                              enum:
-                              - 301
-                              - 302
-                              type: integer
-                          type: object
                         responseHeaderModifier:
                           description: |-
                             ResponseHeaderModifier defines a schema for a filter that modifies response
@@ -2184,14 +1673,14 @@ spec:
                               x-kubernetes-list-type: map
                           type: object
                         type:
-                          description: |-
+                          description: |+
                             Type identifies the type of filter to apply. As with other API fields,
                             types are classified into three conformance levels:
 
 
                             - Core: Filter types and their corresponding configuration defined by
                               "Support: Core" in this package, e.g. "RequestHeaderModifier". All
-                              implementations must support core filters.
+                              implementations supporting GRPCRoute MUST support core filters.
 
 
                             - Extended: Filter types and their corresponding configuration defined by
@@ -2199,12 +1688,11 @@ spec:
                               are encouraged to support extended filters.
 
 
-                            - Implementation-specific: Filters that are defined and supported by
-                              specific vendors.
+                            - Implementation-specific: Filters that are defined and supported by specific vendors.
                               In the future, filters showing convergence in behavior across multiple
                               implementations will be considered for inclusion in extended or core
                               conformance levels. Filter-specific configuration for such filters
-                              is specified using the ExtensionRef field. `Type` should be set to
+                              is specified using the ExtensionRef field. `Type` MUST be set to
                               "ExtensionRef" for custom filters.
 
 
@@ -2217,125 +1705,12 @@ spec:
                             that filter MUST receive a HTTP error response.
 
 
-                            Note that values may be added to this enum, implementations
-                            must ensure that unknown values will not cause a crash.
-
-
-                            Unknown values here must result in the implementation setting the
-                            Accepted Condition for the Route to `status: False`, with a
-                            Reason of `UnsupportedValue`.
                           enum:
-                          - RequestHeaderModifier
                           - ResponseHeaderModifier
+                          - RequestHeaderModifier
                           - RequestMirror
-                          - RequestRedirect
-                          - URLRewrite
                           - ExtensionRef
                           type: string
-                        urlRewrite:
-                          description: |-
-                            URLRewrite defines a schema for a filter that modifies a request during forwarding.
-
-
-                            Support: Extended
-                          properties:
-                            hostname:
-                              description: |-
-                                Hostname is the value to be used to replace the Host header value during
-                                forwarding.
-
-
-                                Support: Extended
-                              maxLength: 253
-                              minLength: 1
-                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                              type: string
-                            path:
-                              description: |-
-                                Path defines a path rewrite.
-
-
-                                Support: Extended
-                              properties:
-                                replaceFullPath:
-                                  description: |-
-                                    ReplaceFullPath specifies the value with which to replace the full path
-                                    of a request during a rewrite or redirect.
-                                  maxLength: 1024
-                                  type: string
-                                replacePrefixMatch:
-                                  description: |-
-                                    ReplacePrefixMatch specifies the value with which to replace the prefix
-                                    match of a request during a rewrite or redirect. For example, a request
-                                    to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
-                                    of "/xyz" would be modified to "/xyz/bar".
-
-
-                                    Note that this matches the behavior of the PathPrefix match type. This
-                                    matches full path elements. A path element refers to the list of labels
-                                    in the path split by the `/` separator. When specified, a trailing `/` is
-                                    ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
-                                    match the prefix `/abc`, but the path `/abcd` would not.
-
-
-                                    ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
-                                    Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
-                                    the implementation setting the Accepted Condition for the Route to `status: False`.
-
-
-                                    Request Path | Prefix Match | Replace Prefix | Modified Path
-                                    -------------|--------------|----------------|----------
-                                    /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                    /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                    /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                    /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                    /foo         | /foo         | /xyz           | /xyz
-                                    /foo/        | /foo         | /xyz           | /xyz/
-                                    /foo/bar     | /foo         | <empty string> | /bar
-                                    /foo/        | /foo         | <empty string> | /
-                                    /foo         | /foo         | <empty string> | /
-                                    /foo/        | /foo         | /              | /
-                                    /foo         | /foo         | /              | /
-                                  maxLength: 1024
-                                  type: string
-                                type:
-                                  description: |-
-                                    Type defines the type of path modifier. Additional types may be
-                                    added in a future release of the API.
-
-
-                                    Note that values may be added to this enum, implementations
-                                    must ensure that unknown values will not cause a crash.
-
-
-                                    Unknown values here must result in the implementation setting the
-                                    Accepted Condition for the Route to `status: False`, with a
-                                    Reason of `UnsupportedValue`.
-                                  enum:
-                                  - ReplaceFullPath
-                                  - ReplacePrefixMatch
-                                  type: string
-                              required:
-                              - type
-                              type: object
-                              x-kubernetes-validations:
-                              - message: replaceFullPath must be specified when type
-                                  is set to 'ReplaceFullPath'
-                                rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
-                                  : true'
-                              - message: type must be 'ReplaceFullPath' when replaceFullPath
-                                  is set
-                                rule: 'has(self.replaceFullPath) ? self.type == ''ReplaceFullPath''
-                                  : true'
-                              - message: replacePrefixMatch must be specified when
-                                  type is set to 'ReplacePrefixMatch'
-                                rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
-                                  : true'
-                              - message: type must be 'ReplacePrefixMatch' when replacePrefixMatch
-                                  is set
-                                rule: 'has(self.replacePrefixMatch) ? self.type ==
-                                  ''ReplacePrefixMatch'' : true'
-                          type: object
                       required:
                       - type
                       type: object
@@ -2361,18 +1736,6 @@ spec:
                       - message: filter.requestMirror must be specified for RequestMirror
                           filter.type
                         rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
-                      - message: filter.requestRedirect must be nil if the filter.type
-                          is not RequestRedirect
-                        rule: '!(has(self.requestRedirect) && self.type != ''RequestRedirect'')'
-                      - message: filter.requestRedirect must be specified for RequestRedirect
-                          filter.type
-                        rule: '!(!has(self.requestRedirect) && self.type == ''RequestRedirect'')'
-                      - message: filter.urlRewrite must be nil if the filter.type
-                          is not URLRewrite
-                        rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
-                      - message: filter.urlRewrite must be specified for URLRewrite
-                          filter.type
-                        rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
                       - message: filter.extensionRef must be nil if the filter.type
                           is not ExtensionRef
                         rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
@@ -2382,29 +1745,16 @@ spec:
                     maxItems: 16
                     type: array
                     x-kubernetes-validations:
-                    - message: May specify either httpRouteFilterRequestRedirect or
-                        httpRouteFilterRequestRewrite, but not both
-                      rule: '!(self.exists(f, f.type == ''RequestRedirect'') && self.exists(f,
-                        f.type == ''URLRewrite''))'
                     - message: RequestHeaderModifier filter cannot be repeated
                       rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
                         <= 1
                     - message: ResponseHeaderModifier filter cannot be repeated
                       rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
                         <= 1
-                    - message: RequestRedirect filter cannot be repeated
-                      rule: self.filter(f, f.type == 'RequestRedirect').size() <=
-                        1
-                    - message: URLRewrite filter cannot be repeated
-                      rule: self.filter(f, f.type == 'URLRewrite').size() <= 1
                   matches:
-                    default:
-                    - path:
-                        type: PathPrefix
-                        value: /
                     description: |-
                       Matches define conditions used for matching the rule against incoming
-                      HTTP requests. Each match is independent, i.e. this rule will be matched
+                      gRPC requests. Each match is independent, i.e. this rule will be matched
                       if **any** one of the matches is satisfied.
 
 
@@ -2413,47 +1763,42 @@ spec:
 
                       ```
                       matches:
-                      - path:
-                          value: "/foo"
+                      - method:
+                          service: foo.bar
                         headers:
-                        - name: "version"
-                          value: "v2"
-                      - path:
-                          value: "/v2/foo"
+                          values:
+                            version: 2
+                      - method:
+                          service: foo.bar.v2
                       ```
 
 
-                      For a request to match against this rule, a request must satisfy
+                      For a request to match against this rule, it MUST satisfy
                       EITHER of the two conditions:
 
 
-                      - path prefixed with `/foo` AND contains the header `version: v2`
-                      - path prefix of `/v2/foo`
+                      - service of foo.bar AND contains the header `version: 2`
+                      - service of foo.bar.v2
 
 
-                      See the documentation for HTTPRouteMatch on how to specify multiple
-                      match conditions that should be ANDed together.
+                      See the documentation for GRPCRouteMatch on how to specify multiple
+                      match conditions to be ANDed together.
 
 
-                      If no matches are specified, the default is a prefix
-                      path match on "/", which has the effect of matching every
-                      HTTP request.
+                      If no matches are specified, the implementation MUST match every gRPC request.
 
 
-                      Proxy or Load Balancer routing configuration generated from HTTPRoutes
-                      MUST prioritize matches based on the following criteria, continuing on
-                      ties. Across all rules specified on applicable Routes, precedence must be
-                      given to the match having:
+                      Proxy or Load Balancer routing configuration generated from GRPCRoutes
+                      MUST prioritize rules based on the following criteria, continuing on
+                      ties. Merging MUST not be done between GRPCRoutes and HTTPRoutes.
+                      Precedence MUST be given to the rule with the largest number of:
 
 
-                      * "Exact" path match.
-                      * "Prefix" path match with largest number of characters.
-                      * Method match.
-                      * Largest number of header matches.
-                      * Largest number of query param matches.
-
-
-                      Note: The precedence of RegularExpression path matches are implementation-specific.
+                      * Characters in a matching non-wildcard hostname.
+                      * Characters in a matching hostname.
+                      * Characters in a matching service.
+                      * Characters in a matching method.
+                      * Header matches.
 
 
                       If ties still exist across multiple Routes, matching precedence MUST be
@@ -2465,37 +1810,45 @@ spec:
                         "{namespace}/{name}".
 
 
-                      If ties still exist within an HTTPRoute, matching precedence MUST be granted
-                      to the FIRST matching rule (in list order) with a match meeting the above
-                      criteria.
-
-
-                      When no rules matching a request have been successfully attached to the
-                      parent a request is coming from, a HTTP 404 status code MUST be returned.
+                      If ties still exist within the Route that has been given precedence,
+                      matching precedence MUST be granted to the first matching rule meeting
+                      the above criteria.
                     items:
-                      description: "HTTPRouteMatch defines the predicate used to match
-                        requests to a given\naction. Multiple match types are ANDed
-                        together, i.e. the match will\nevaluate to true only if all
-                        conditions are satisfied.\n\n\nFor example, the match below
-                        will match a HTTP request only if its path\nstarts with `/foo`
-                        AND it contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
-                        \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t  value
-                        \"v1\"\n\n\n```"
+                      description: |-
+                        GRPCRouteMatch defines the predicate used to match requests to a given
+                        action. Multiple match types are ANDed together, i.e. the match will
+                        evaluate to true only if all conditions are satisfied.
+
+
+                        For example, the match below will match a gRPC request only if its service
+                        is `foo` AND it contains the `version: v1` header:
+
+
+                        ```
+                        matches:
+                          - method:
+                            type: Exact
+                            service: "foo"
+                            headers:
+                          - name: "version"
+                            value "v1"
+
+
+                        ```
                       properties:
                         headers:
                           description: |-
-                            Headers specifies HTTP request header matchers. Multiple match values are
-                            ANDed together, meaning, a request must match all the specified headers
+                            Headers specifies gRPC request header matchers. Multiple match values are
+                            ANDed together, meaning, a request MUST match all the specified headers
                             to select the route.
                           items:
                             description: |-
-                              HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                              GRPCHeaderMatch describes how to select a gRPC route by matching gRPC request
                               headers.
                             properties:
                               name:
                                 description: |-
-                                  Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                  case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                  Name is the name of the gRPC Header to be matched.
 
 
                                   If multiple entries specify equivalent header names, only the first
@@ -2503,40 +1856,21 @@ spec:
                                   entries with an equivalent header name MUST be ignored. Due to the
                                   case-insensitivity of header names, "foo" and "Foo" are considered
                                   equivalent.
-
-
-                                  When a header is repeated in an HTTP request, it is
-                                  implementation-specific behavior as to how this is represented.
-                                  Generally, proxies should follow the guidance from the RFC:
-                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                  processing a repeated header, with special handling for "Set-Cookie".
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                 type: string
                               type:
                                 default: Exact
-                                description: |-
-                                  Type specifies how to match against the value of the header.
-
-
-                                  Support: Core (Exact)
-
-
-                                  Support: Implementation-specific (RegularExpression)
-
-
-                                  Since RegularExpression HeaderMatchType has implementation-specific
-                                  conformance, implementations can support POSIX, PCRE or any other dialects
-                                  of regular expressions. Please read the implementation's documentation to
-                                  determine the supported dialect.
+                                description: Type specifies how to match against the
+                                  value of the header.
                                 enum:
                                 - Exact
                                 - RegularExpression
                                 type: string
                               value:
-                                description: Value is the value of HTTP Header to
-                                  be matched.
+                                description: Value is the value of the gRPC Header
+                                  to be matched.
                                 maxLength: 4096
                                 minLength: 1
                                 type: string
@@ -2551,171 +1885,58 @@ spec:
                           x-kubernetes-list-type: map
                         method:
                           description: |-
-                            Method specifies HTTP method matcher.
-                            When specified, this route will be matched only if the request has the
-                            specified method.
-
-
-                            Support: Extended
-                          enum:
-                          - GET
-                          - HEAD
-                          - POST
-                          - PUT
-                          - DELETE
-                          - CONNECT
-                          - OPTIONS
-                          - TRACE
-                          - PATCH
-                          type: string
-                        path:
-                          default:
-                            type: PathPrefix
-                            value: /
-                          description: |-
-                            Path specifies a HTTP request path matcher. If this field is not
-                            specified, a default prefix match on the "/" path is provided.
+                            Method specifies a gRPC request service/method matcher. If this field is
+                            not specified, all services and methods will match.
                           properties:
-                            type:
-                              default: PathPrefix
+                            method:
                               description: |-
-                                Type specifies how to match against the path Value.
+                                Value of the method to match against. If left empty or omitted, will
+                                match all services.
 
 
-                                Support: Core (Exact, PathPrefix)
+                                At least one of Service and Method MUST be a non-empty string.
+                              maxLength: 1024
+                              type: string
+                            service:
+                              description: |-
+                                Value of the service to match against. If left empty or omitted, will
+                                match any service.
+
+
+                                At least one of Service and Method MUST be a non-empty string.
+                              maxLength: 1024
+                              type: string
+                            type:
+                              default: Exact
+                              description: |-
+                                Type specifies how to match against the service and/or method.
+                                Support: Core (Exact with service and method specified)
+
+
+                                Support: Implementation-specific (Exact with method specified but no service specified)
 
 
                                 Support: Implementation-specific (RegularExpression)
                               enum:
                               - Exact
-                              - PathPrefix
                               - RegularExpression
-                              type: string
-                            value:
-                              default: /
-                              description: Value of the HTTP path to match against.
-                              maxLength: 1024
                               type: string
                           type: object
                           x-kubernetes-validations:
-                          - message: value must be an absolute path and start with
-                              '/' when type one of ['Exact', 'PathPrefix']
-                            rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.startsWith(''/'')
+                          - message: One or both of 'service' or 'method' must be
+                              specified
+                            rule: 'has(self.type) ? has(self.service) || has(self.method)
                               : true'
-                          - message: must not contain '//' when type one of ['Exact',
-                              'PathPrefix']
-                            rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''//'')
-                              : true'
-                          - message: must not contain '/./' when type one of ['Exact',
-                              'PathPrefix']
-                            rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/./'')
-                              : true'
-                          - message: must not contain '/../' when type one of ['Exact',
-                              'PathPrefix']
-                            rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/../'')
-                              : true'
-                          - message: must not contain '%2f' when type one of ['Exact',
-                              'PathPrefix']
-                            rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2f'')
-                              : true'
-                          - message: must not contain '%2F' when type one of ['Exact',
-                              'PathPrefix']
-                            rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2F'')
-                              : true'
-                          - message: must not contain '#' when type one of ['Exact',
-                              'PathPrefix']
-                            rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''#'')
-                              : true'
-                          - message: must not end with '/..' when type one of ['Exact',
-                              'PathPrefix']
-                            rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/..'')
-                              : true'
-                          - message: must not end with '/.' when type one of ['Exact',
-                              'PathPrefix']
-                            rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/.'')
-                              : true'
-                          - message: type must be one of ['Exact', 'PathPrefix', 'RegularExpression']
-                            rule: self.type in ['Exact','PathPrefix'] || self.type
-                              == 'RegularExpression'
-                          - message: must only contain valid characters (matching
-                              ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
-                              for types ['Exact', 'PathPrefix']
-                            rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
-                              : true'
-                        queryParams:
-                          description: |-
-                            QueryParams specifies HTTP query parameter matchers. Multiple match
-                            values are ANDed together, meaning, a request must match all the
-                            specified query parameters to select the route.
-
-
-                            Support: Extended
-                          items:
-                            description: |-
-                              HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
-                              query parameters.
-                            properties:
-                              name:
-                                description: |-
-                                  Name is the name of the HTTP query param to be matched. This must be an
-                                  exact string match. (See
-                                  https://tools.ietf.org/html/rfc7230#section-2.7.3).
-
-
-                                  If multiple entries specify equivalent query param names, only the first
-                                  entry with an equivalent name MUST be considered for a match. Subsequent
-                                  entries with an equivalent query param name MUST be ignored.
-
-
-                                  If a query param is repeated in an HTTP request, the behavior is
-                                  purposely left undefined, since different data planes have different
-                                  capabilities. However, it is *recommended* that implementations should
-                                  match against the first value of the param if the data plane supports it,
-                                  as this behavior is expected in other load balancing contexts outside of
-                                  the Gateway API.
-
-
-                                  Users SHOULD NOT route traffic based on repeated query params to guard
-                                  themselves against potential differences in the implementations.
-                                maxLength: 256
-                                minLength: 1
-                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                type: string
-                              type:
-                                default: Exact
-                                description: |-
-                                  Type specifies how to match against the value of the query parameter.
-
-
-                                  Support: Extended (Exact)
-
-
-                                  Support: Implementation-specific (RegularExpression)
-
-
-                                  Since RegularExpression QueryParamMatchType has Implementation-specific
-                                  conformance, implementations can support POSIX, PCRE or any other
-                                  dialects of regular expressions. Please read the implementation's
-                                  documentation to determine the supported dialect.
-                                enum:
-                                - Exact
-                                - RegularExpression
-                                type: string
-                              value:
-                                description: Value is the value of HTTP query param
-                                  to be matched.
-                                maxLength: 1024
-                                minLength: 1
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          maxItems: 16
-                          type: array
-                          x-kubernetes-list-map-keys:
-                          - name
-                          x-kubernetes-list-type: map
+                          - message: service must only contain valid characters (matching
+                              ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$)
+                            rule: '(!has(self.type) || self.type == ''Exact'') &&
+                              has(self.service) ? self.service.matches(r"""^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$"""):
+                              true'
+                          - message: method must only contain valid characters (matching
+                              ^[A-Za-z_][A-Za-z_0-9]*$)
+                            rule: '(!has(self.type) || self.type == ''Exact'') &&
+                              has(self.method) ? self.method.matches(r"""^[A-Za-z_][A-Za-z_0-9]*$"""):
+                              true'
                       type: object
                     maxItems: 8
                     type: array
@@ -2819,116 +2040,8 @@ spec:
                         is Permanent
                       rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
                         != ''Permanent'' || has(self.absoluteTimeout)'
-                  timeouts:
-                    description: |+
-                      Timeouts defines the timeouts that can be configured for an HTTP request.
-
-
-                      Support: Extended
-
-
-                    properties:
-                      backendRequest:
-                        description: |-
-                          BackendRequest specifies a timeout for an individual request from the gateway
-                          to a backend. This covers the time from when the request first starts being
-                          sent from the gateway to when the full response has been received from the backend.
-
-
-                          Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
-                          completely. Implementations that cannot completely disable the timeout MUST
-                          instead interpret the zero duration as the longest possible value to which
-                          the timeout can be set.
-
-
-                          An entire client HTTP transaction with a gateway, covered by the Request timeout,
-                          may result in more than one call from the gateway to the destination backend,
-                          for example, if automatic retries are supported.
-
-
-                          Because the Request timeout encompasses the BackendRequest timeout, the value of
-                          BackendRequest must be <= the value of Request timeout.
-
-
-                          Support: Extended
-                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                        type: string
-                      request:
-                        description: |-
-                          Request specifies the maximum duration for a gateway to respond to an HTTP request.
-                          If the gateway has not been able to respond before this deadline is met, the gateway
-                          MUST return a timeout error.
-
-
-                          For example, setting the `rules.timeouts.request` field to the value `10s` in an
-                          `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
-                          to complete.
-
-
-                          Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
-                          completely. Implementations that cannot completely disable the timeout MUST
-                          instead interpret the zero duration as the longest possible value to which
-                          the timeout can be set.
-
-
-                          This timeout is intended to cover as close to the whole request-response transaction
-                          as possible although an implementation MAY choose to start the timeout after the entire
-                          request stream has been received instead of immediately after the transaction is
-                          initiated by the client.
-
-
-                          When this field is unspecified, request timeout behavior is implementation-specific.
-
-
-                          Support: Extended
-                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                        type: string
-                    type: object
-                    x-kubernetes-validations:
-                    - message: backendRequest timeout cannot be longer than request
-                        timeout
-                      rule: '!(has(self.request) && has(self.backendRequest) && duration(self.request)
-                        != duration(''0s'') && duration(self.backendRequest) > duration(self.request))'
                 type: object
-                x-kubernetes-validations:
-                - message: RequestRedirect filter must not be used together with backendRefs
-                  rule: '(has(self.backendRefs) && size(self.backendRefs) > 0) ? (!has(self.filters)
-                    || self.filters.all(f, !has(f.requestRedirect))): true'
-                - message: When using RequestRedirect filter with path.replacePrefixMatch,
-                    exactly one PathPrefix match must be specified
-                  rule: '(has(self.filters) && self.filters.exists_one(f, has(f.requestRedirect)
-                    && has(f.requestRedirect.path) && f.requestRedirect.path.type
-                    == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
-                    ? ((size(self.matches) != 1 || !has(self.matches[0].path) || self.matches[0].path.type
-                    != ''PathPrefix'') ? false : true) : true'
-                - message: When using URLRewrite filter with path.replacePrefixMatch,
-                    exactly one PathPrefix match must be specified
-                  rule: '(has(self.filters) && self.filters.exists_one(f, has(f.urlRewrite)
-                    && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
-                    && has(f.urlRewrite.path.replacePrefixMatch))) ? ((size(self.matches)
-                    != 1 || !has(self.matches[0].path) || self.matches[0].path.type
-                    != ''PathPrefix'') ? false : true) : true'
-                - message: Within backendRefs, when using RequestRedirect filter with
-                    path.replacePrefixMatch, exactly one PathPrefix match must be
-                    specified
-                  rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
-                    (has(b.filters) && b.filters.exists_one(f, has(f.requestRedirect)
-                    && has(f.requestRedirect.path) && f.requestRedirect.path.type
-                    == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
-                    )) ? ((size(self.matches) != 1 || !has(self.matches[0].path) ||
-                    self.matches[0].path.type != ''PathPrefix'') ? false : true) :
-                    true'
-                - message: Within backendRefs, When using URLRewrite filter with path.replacePrefixMatch,
-                    exactly one PathPrefix match must be specified
-                  rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
-                    (has(b.filters) && b.filters.exists_one(f, has(f.urlRewrite) &&
-                    has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
-                    && has(f.urlRewrite.path.replacePrefixMatch))) )) ? ((size(self.matches)
-                    != 1 || !has(self.matches[0].path) || self.matches[0].path.type
-                    != ''PathPrefix'') ? false : true) : true'
               maxItems: 16
               type: array
           type: object
-      required:
-      - spec
       type: object

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
@@ -1,0 +1,221 @@
+apiVersion: meta.k8s.appscode.com/v1alpha1
+kind: ResourceDescriptor
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.networking.k8s.io
+    k8s.io/kind: BackendLBPolicy
+    k8s.io/resource: backendlbpolicies
+    k8s.io/version: v1alpha2
+  name: gateway.networking.k8s.io-v1alpha2-backendlbpolicies
+spec:
+  resource:
+    group: gateway.networking.k8s.io
+    kind: BackendLBPolicy
+    name: backendlbpolicies
+    scope: Namespaced
+    version: v1alpha2
+  validation:
+    openAPIV3Schema:
+      description: |-
+        BackendLBPolicy provides a way to define load balancing rules
+        for a backend.
+      properties:
+        apiVersion:
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          type: string
+        kind:
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          properties:
+            name:
+              description: 'Name must be unique within a namespace. Is required when
+                creating resources, although some resources may allow a client to
+                request the generation of an appropriate name automatically. Name
+                is primarily intended for creation idempotence and configuration definition.
+                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: "Namespace defines the space within which each name must
+                be unique. An empty namespace is equivalent to the \"default\" namespace,
+                but \"default\" is the canonical representation. Not all objects are
+                required to be scoped to a namespace - the value of this field for
+                those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                More info: http://kubernetes.io/docs/user-guide/namespaces"
+              type: string
+            labels:
+              additionalProperties:
+                type: string
+              description: 'Map of string keys and values that can be used to organize
+                and categorize (scope and select) objects. May match selectors of
+                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            annotations:
+              additionalProperties:
+                type: string
+              description: 'Annotations is an unstructured key value map stored with
+                a resource that may be set by external tools to store and retrieve
+                arbitrary metadata. They are not queryable and should be preserved
+                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+          type: object
+        spec:
+          description: Spec defines the desired state of BackendLBPolicy.
+          properties:
+            sessionPersistence:
+              description: |-
+                SessionPersistence defines and configures session persistence
+                for the backend.
+
+
+                Support: Extended
+              properties:
+                absoluteTimeout:
+                  description: |-
+                    AbsoluteTimeout defines the absolute timeout of the persistent
+                    session. Once the AbsoluteTimeout duration has elapsed, the
+                    session becomes invalid.
+
+
+                    Support: Extended
+                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                  type: string
+                cookieConfig:
+                  description: |-
+                    CookieConfig provides configuration settings that are specific
+                    to cookie-based session persistence.
+
+
+                    Support: Core
+                  properties:
+                    lifetimeType:
+                      default: Session
+                      description: |-
+                        LifetimeType specifies whether the cookie has a permanent or
+                        session-based lifetime. A permanent cookie persists until its
+                        specified expiry time, defined by the Expires or Max-Age cookie
+                        attributes, while a session cookie is deleted when the current
+                        session ends.
+
+
+                        When set to "Permanent", AbsoluteTimeout indicates the
+                        cookie's lifetime via the Expires or Max-Age cookie attributes
+                        and is required.
+
+
+                        When set to "Session", AbsoluteTimeout indicates the
+                        absolute lifetime of the cookie tracked by the gateway and
+                        is optional.
+
+
+                        Support: Core for "Session" type
+
+
+                        Support: Extended for "Permanent" type
+                      enum:
+                      - Permanent
+                      - Session
+                      type: string
+                  type: object
+                idleTimeout:
+                  description: |-
+                    IdleTimeout defines the idle timeout of the persistent session.
+                    Once the session has been idle for more than the specified
+                    IdleTimeout duration, the session becomes invalid.
+
+
+                    Support: Extended
+                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                  type: string
+                sessionName:
+                  description: |-
+                    SessionName defines the name of the persistent session token
+                    which may be reflected in the cookie or the header. Users
+                    should avoid reusing session names to prevent unintended
+                    consequences, such as rejection or unpredictable behavior.
+
+
+                    Support: Implementation-specific
+                  maxLength: 128
+                  type: string
+                type:
+                  default: Cookie
+                  description: |-
+                    Type defines the type of session persistence such as through
+                    the use a header or cookie. Defaults to cookie based session
+                    persistence.
+
+
+                    Support: Core for "Cookie" type
+
+
+                    Support: Extended for "Header" type
+                  enum:
+                  - Cookie
+                  - Header
+                  type: string
+              type: object
+              x-kubernetes-validations:
+              - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                  is Permanent
+                rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                  != ''Permanent'' || has(self.absoluteTimeout)'
+            targetRefs:
+              description: |-
+                TargetRef identifies an API object to apply policy to.
+                Currently, Backends (i.e. Service, ServiceImport, or any
+                implementation-specific backendRef) are the only valid API
+                target references.
+              items:
+                description: |-
+                  LocalPolicyTargetReference identifies an API object to apply a direct or
+                  inherited policy to. This should be used as part of Policy resources
+                  that can target Gateway API resources. For more information on how this
+                  policy attachment model works, and a sample Policy resource, refer to
+                  the policy attachment documentation for Gateway API.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              maxItems: 16
+              minItems: 1
+              type: array
+              x-kubernetes-list-map-keys:
+              - group
+              - kind
+              - name
+              x-kubernetes-list-type: map
+          required:
+          - targetRefs
+          type: object
+      required:
+      - spec
+      type: object

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/grpcroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/grpcroutes.yaml
@@ -17,36 +17,52 @@ spec:
     version: v1alpha2
   validation:
     openAPIV3Schema:
-      description: "GRPCRoute provides a way to route gRPC requests. This includes
-        the capability to match requests by hostname, gRPC service, gRPC method, or
-        HTTP/2 header. Filters can be used to specify additional processing steps.
-        Backends specify where matching requests will be routed. \n GRPCRoute falls
-        under extended support within the Gateway API. Within the following specification,
-        the word \"MUST\" indicates that an implementation supporting GRPCRoute must
-        conform to the indicated requirement, but an implementation not supporting
-        this route type need not follow the requirement unless explicitly indicated.
-        \n Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType`
-        MUST accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e.
-        via ALPN. If the implementation does not support this, then it MUST set the
-        \"Accepted\" condition to \"False\" for the affected listener with a reason
-        of \"UnsupportedProtocol\".  Implementations MAY also accept HTTP/2 connections
-        with an upgrade from HTTP/1. \n Implementations supporting `GRPCRoute` with
-        the `HTTP` `ProtocolType` MUST support HTTP/2 over cleartext TCP (h2c, https://www.rfc-editor.org/rfc/rfc7540#section-3.1)
-        without an initial upgrade from HTTP/1.1, i.e. with prior knowledge (https://www.rfc-editor.org/rfc/rfc7540#section-3.4).
-        If the implementation does not support this, then it MUST set the \"Accepted\"
-        condition to \"False\" for the affected listener with a reason of \"UnsupportedProtocol\".
-        Implementations MAY also accept HTTP/2 connections with an upgrade from HTTP/1,
-        i.e. without prior knowledge."
+      description: |-
+        GRPCRoute provides a way to route gRPC requests. This includes the capability
+        to match requests by hostname, gRPC service, gRPC method, or HTTP/2 header.
+        Filters can be used to specify additional processing steps. Backends specify
+        where matching requests will be routed.
+
+
+        GRPCRoute falls under extended support within the Gateway API. Within the
+        following specification, the word "MUST" indicates that an implementation
+        supporting GRPCRoute must conform to the indicated requirement, but an
+        implementation not supporting this route type need not follow the requirement
+        unless explicitly indicated.
+
+
+        Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST
+        accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via
+        ALPN. If the implementation does not support this, then it MUST set the
+        "Accepted" condition to "False" for the affected listener with a reason of
+        "UnsupportedProtocol".  Implementations MAY also accept HTTP/2 connections
+        with an upgrade from HTTP/1.
+
+
+        Implementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST
+        support HTTP/2 over cleartext TCP (h2c,
+        https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial
+        upgrade from HTTP/1.1, i.e. with prior knowledge
+        (https://www.rfc-editor.org/rfc/rfc7540#section-3.4). If the implementation
+        does not support this, then it MUST set the "Accepted" condition to "False"
+        for the affected listener with a reason of "UnsupportedProtocol".
+        Implementations MAY also accept HTTP/2 connections with an upgrade from
+        HTTP/1, i.e. without prior knowledge.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -85,55 +101,86 @@ spec:
           description: Spec defines the desired state of GRPCRoute.
           properties:
             hostnames:
-              description: "Hostnames defines a set of hostnames to match against
-                the GRPC Host header to select a GRPCRoute to process the request.
-                This matches the RFC 1123 definition of a hostname with 2 notable
-                exceptions: \n 1. IPs are not allowed. 2. A hostname may be prefixed
-                with a wildcard label (`*.`). The wildcard label MUST appear by itself
-                as the first label. \n If a hostname is specified by both the Listener
-                and GRPCRoute, there MUST be at least one intersecting hostname for
-                the GRPCRoute to be attached to the Listener. For example: \n * A
-                Listener with `test.example.com` as the hostname matches GRPCRoutes
-                that have either not specified any hostnames, or have specified at
-                least one of `test.example.com` or `*.example.com`. * A Listener with
-                `*.example.com` as the hostname matches GRPCRoutes that have either
-                not specified any hostnames or have specified at least one hostname
-                that matches the Listener hostname. For example, `test.example.com`
-                and `*.example.com` would both match. On the other hand, `example.com`
-                and `test.example.net` would not match. \n Hostnames that are prefixed
-                with a wildcard label (`*.`) are interpreted as a suffix match. That
-                means that a match for `*.example.com` would match both `test.example.com`,
-                and `foo.test.example.com`, but not `example.com`. \n If both the
-                Listener and GRPCRoute have specified hostnames, any GRPCRoute hostnames
-                that do not match the Listener hostname MUST be ignored. For example,
-                if a Listener specified `*.example.com`, and the GRPCRoute specified
-                `test.example.com` and `test.example.net`, `test.example.net` MUST
-                NOT be considered for a match. \n If both the Listener and GRPCRoute
-                have specified hostnames, and none match with the criteria above,
-                then the GRPCRoute MUST NOT be accepted by the implementation. The
-                implementation MUST raise an 'Accepted' Condition with a status of
-                `False` in the corresponding RouteParentStatus. \n If a Route (A)
-                of type HTTPRoute or GRPCRoute is attached to a Listener and that
-                listener already has another Route (B) of the other type attached
-                and the intersection of the hostnames of A and B is non-empty, then
-                the implementation MUST accept exactly one of these two routes, determined
-                by the following criteria, in order: \n * The oldest Route based on
-                creation timestamp. * The Route appearing first in alphabetical order
-                by \"{namespace}/{name}\". \n The rejected Route MUST raise an 'Accepted'
-                condition with a status of 'False' in the corresponding RouteParentStatus.
-                \n Support: Core"
+              description: |-
+                Hostnames defines a set of hostnames to match against the GRPC
+                Host header to select a GRPCRoute to process the request. This matches
+                the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                1. IPs are not allowed.
+                2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                   label MUST appear by itself as the first label.
+
+
+                If a hostname is specified by both the Listener and GRPCRoute, there
+                MUST be at least one intersecting hostname for the GRPCRoute to be
+                attached to the Listener. For example:
+
+
+                * A Listener with `test.example.com` as the hostname matches GRPCRoutes
+                  that have either not specified any hostnames, or have specified at
+                  least one of `test.example.com` or `*.example.com`.
+                * A Listener with `*.example.com` as the hostname matches GRPCRoutes
+                  that have either not specified any hostnames or have specified at least
+                  one hostname that matches the Listener hostname. For example,
+                  `test.example.com` and `*.example.com` would both match. On the other
+                  hand, `example.com` and `test.example.net` would not match.
+
+
+                Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                as a suffix match. That means that a match for `*.example.com` would match
+                both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+
+                If both the Listener and GRPCRoute have specified hostnames, any
+                GRPCRoute hostnames that do not match the Listener hostname MUST be
+                ignored. For example, if a Listener specified `*.example.com`, and the
+                GRPCRoute specified `test.example.com` and `test.example.net`,
+                `test.example.net` MUST NOT be considered for a match.
+
+
+                If both the Listener and GRPCRoute have specified hostnames, and none
+                match with the criteria above, then the GRPCRoute MUST NOT be accepted by
+                the implementation. The implementation MUST raise an 'Accepted' Condition
+                with a status of `False` in the corresponding RouteParentStatus.
+
+
+                If a Route (A) of type HTTPRoute or GRPCRoute is attached to a
+                Listener and that listener already has another Route (B) of the other
+                type attached and the intersection of the hostnames of A and B is
+                non-empty, then the implementation MUST accept exactly one of these two
+                routes, determined by the following criteria, in order:
+
+
+                * The oldest Route based on creation timestamp.
+                * The Route appearing first in alphabetical order by
+                  "{namespace}/{name}".
+
+
+                The rejected Route MUST raise an 'Accepted' condition with a status of
+                'False' in the corresponding RouteParentStatus.
+
+
+                Support: Core
               items:
-                description: "Hostname is the fully qualified domain name of a network
-                  host. This matches the RFC 1123 definition of a hostname with 2
-                  notable exceptions: \n 1. IPs are not allowed. 2. A hostname may
-                  be prefixed with a wildcard label (`*.`). The wildcard label must
-                  appear by itself as the first label. \n Hostname can be \"precise\"
-                  which is a domain name without the terminating dot of a network
-                  host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
-                  name prefixed with a single wildcard label (e.g. `*.example.com`).
-                  \n Note that as per RFC1035 and RFC1123, a *label* must consist
-                  of lower case alphanumeric characters or '-', and must start and
-                  end with an alphanumeric character. No other punctuation is allowed."
+                description: |-
+                  Hostname is the fully qualified domain name of a network host. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                   1. IPs are not allowed.
+                   2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                      label must appear by itself as the first label.
+
+
+                  Hostname can be "precise" which is a domain name without the terminating
+                  dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                  domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                  Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                  alphanumeric characters or '-', and must start and end with an alphanumeric
+                  character. No other punctuation is allowed.
                 maxLength: 253
                 minLength: 1
                 pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -141,159 +188,246 @@ spec:
               maxItems: 16
               type: array
             parentRefs:
-              description: "ParentRefs references the resources (usually Gateways)
-                that a Route wants to be attached to. Note that the referenced parent
-                resource needs to allow this for the attachment to be complete. For
-                Gateways, that means the Gateway needs to allow attachment from Routes
-                of this kind and namespace. For Services, that means the Service must
-                either be in the same namespace for a \"producer\" route, or the mesh
-                implementation must support and allow \"consumer\" routes for the
-                referenced Service. ReferenceGrant is not applicable for governing
-                ParentRefs to Services - it is not possible to create a \"producer\"
-                route for a Service in a different namespace from the Route. \n There
-                are two kinds of parent resources with \"Core\" support: \n * Gateway
-                (Gateway conformance profile)  * Service (Mesh conformance profile,
-                experimental, ClusterIP Services only)  This API may be extended in
-                the future to support additional kinds of parent resources. \n ParentRefs
-                must be _distinct_. This means either that: \n * They select different
-                objects.  If this is the case, then parentRef entries are distinct.
-                In terms of fields, this means that the multi-part key defined by
-                `group`, `kind`, `namespace`, and `name` must be unique across all
-                parentRef entries in the Route. * They do not select different objects,
-                but for each optional field used, each ParentRef that selects the
-                same object must set the same set of optional fields to different
-                values. If one ParentRef sets a combination of optional fields, all
-                must set the same combination. \n Some examples: \n * If one ParentRef
-                sets `sectionName`, all ParentRefs referencing the same object must
-                also set `sectionName`. * If one ParentRef sets `port`, all ParentRefs
-                referencing the same object must also set `port`. * If one ParentRef
-                sets `sectionName` and `port`, all ParentRefs referencing the same
-                object must also set `sectionName` and `port`. \n It is possible to
-                separately reference multiple distinct objects that may be collapsed
-                by an implementation. For example, some implementations may choose
-                to merge compatible Gateway Listeners together. If that is the case,
-                the list of routes attached to those resources should also be merged.
-                \n Note that for ParentRefs that cross namespace boundaries, there
-                are specific rules. Cross-namespace references are only valid if they
-                are explicitly allowed by something in the namespace they are referring
-                to. For example, Gateway has the AllowedRoutes field, and ReferenceGrant
-                provides a generic way to enable other kinds of cross-namespace reference.
-                \n  ParentRefs from a Route to a Service in the same namespace are
-                \"producer\" routes, which apply default routing rules to inbound
-                connections from any namespace to the Service. \n ParentRefs from
-                a Route to a Service in a different namespace are \"consumer\" routes,
-                and these routing rules are only applied to outbound connections originating
-                from the same namespace as the Route, for which the intended destination
-                of the connections are a Service targeted as a ParentRef of the Route.
-                \ \n "
+              description: |+
+                ParentRefs references the resources (usually Gateways) that a Route wants
+                to be attached to. Note that the referenced parent resource needs to
+                allow this for the attachment to be complete. For Gateways, that means
+                the Gateway needs to allow attachment from Routes of this kind and
+                namespace. For Services, that means the Service must either be in the same
+                namespace for a "producer" route, or the mesh implementation must support
+                and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                not applicable for governing ParentRefs to Services - it is not possible to
+                create a "producer" route for a Service in a different namespace from the
+                Route.
+
+
+                There are two kinds of parent resources with "Core" support:
+
+
+                * Gateway (Gateway conformance profile)
+                * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                This API may be extended in the future to support additional kinds of parent
+                resources.
+
+
+                ParentRefs must be _distinct_. This means either that:
+
+
+                * They select different objects.  If this is the case, then parentRef
+                  entries are distinct. In terms of fields, this means that the
+                  multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                  be unique across all parentRef entries in the Route.
+                * They do not select different objects, but for each optional field used,
+                  each ParentRef that selects the same object must set the same set of
+                  optional fields to different values. If one ParentRef sets a
+                  combination of optional fields, all must set the same combination.
+
+
+                Some examples:
+
+
+                * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                  same object must also set `sectionName`.
+                * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`.
+                * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                  referencing the same object must also set `sectionName` and `port`.
+
+
+                It is possible to separately reference multiple distinct objects that may
+                be collapsed by an implementation. For example, some implementations may
+                choose to merge compatible Gateway Listeners together. If that is the
+                case, the list of routes attached to those resources should also be
+                merged.
+
+
+                Note that for ParentRefs that cross namespace boundaries, there are specific
+                rules. Cross-namespace references are only valid if they are explicitly
+                allowed by something in the namespace they are referring to. For example,
+                Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                generic way to enable other kinds of cross-namespace reference.
+
+
+
+                ParentRefs from a Route to a Service in the same namespace are "producer"
+                routes, which apply default routing rules to inbound connections from
+                any namespace to the Service.
+
+
+                ParentRefs from a Route to a Service in a different namespace are
+                "consumer" routes, and these routing rules are only applied to outbound
+                connections originating from the same namespace as the Route, for which
+                the intended destination of the connections are a Service targeted as a
+                ParentRef of the Route.
+
+
+
+
+
+
               items:
-                description: "ParentReference identifies an API object (usually a
-                  Gateway) that can be considered a parent of this resource (usually
-                  a route). There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
-                  API may be extended in the future to support additional kinds of
-                  parent resources. \n The API object must be valid in the cluster;
-                  the Group and Kind must be registered in the cluster for this reference
-                  to be valid."
+                description: |-
+                  ParentReference identifies an API object (usually a Gateway) that can be considered
+                  a parent of this resource (usually a route). There are two kinds of parent resources
+                  with "Core" support:
+
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+
+                  The API object must be valid in the cluster; the Group and Kind must
+                  be registered in the cluster for this reference to be valid.
                 properties:
                   group:
                     default: gateway.networking.k8s.io
-                    description: "Group is the group of the referent. When unspecified,
-                      \"gateway.networking.k8s.io\" is inferred. To set the core API
-                      group (such as for a \"Service\" kind referent), Group must
-                      be explicitly set to \"\" (empty string). \n Support: Core"
+                    description: |-
+                      Group is the group of the referent.
+                      When unspecified, "gateway.networking.k8s.io" is inferred.
+                      To set the core API group (such as for a "Service" kind referent),
+                      Group must be explicitly set to "" (empty string).
+
+
+                      Support: Core
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
                     default: Gateway
-                    description: "Kind is kind of the referent. \n There are two kinds
-                      of parent resources with \"Core\" support: \n * Gateway (Gateway
-                      conformance profile) * Service (Mesh conformance profile, experimental,
-                      ClusterIP Services only) \n Support for other resources is Implementation-Specific."
+                    description: |-
+                      Kind is kind of the referent.
+
+
+                      There are two kinds of parent resources with "Core" support:
+
+
+                      * Gateway (Gateway conformance profile)
+                      * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                      Support for other resources is Implementation-Specific.
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
-                    description: "Name is the name of the referent. \n Support: Core"
+                    description: |-
+                      Name is the name of the referent.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     type: string
                   namespace:
-                    description: "Namespace is the namespace of the referent. When
-                      unspecified, this refers to the local namespace of the Route.
-                      \n Note that there are specific rules for ParentRefs which cross
-                      namespace boundaries. Cross-namespace references are only valid
-                      if they are explicitly allowed by something in the namespace
-                      they are referring to. For example: Gateway has the AllowedRoutes
-                      field, and ReferenceGrant provides a generic way to enable any
-                      other kind of cross-namespace reference. \n  ParentRefs from
-                      a Route to a Service in the same namespace are \"producer\"
-                      routes, which apply default routing rules to inbound connections
-                      from any namespace to the Service. \n ParentRefs from a Route
-                      to a Service in a different namespace are \"consumer\" routes,
-                      and these routing rules are only applied to outbound connections
-                      originating from the same namespace as the Route, for which
-                      the intended destination of the connections are a Service targeted
-                      as a ParentRef of the Route.  \n Support: Core"
+                    description: |-
+                      Namespace is the namespace of the referent. When unspecified, this refers
+                      to the local namespace of the Route.
+
+
+                      Note that there are specific rules for ParentRefs which cross namespace
+                      boundaries. Cross-namespace references are only valid if they are explicitly
+                      allowed by something in the namespace they are referring to. For example:
+                      Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                      generic way to enable any other kind of cross-namespace reference.
+
+
+
+                      ParentRefs from a Route to a Service in the same namespace are "producer"
+                      routes, which apply default routing rules to inbound connections from
+                      any namespace to the Service.
+
+
+                      ParentRefs from a Route to a Service in a different namespace are
+                      "consumer" routes, and these routing rules are only applied to outbound
+                      connections originating from the same namespace as the Route, for which
+                      the intended destination of the connections are a Service targeted as a
+                      ParentRef of the Route.
+
+
+
+                      Support: Core
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   port:
-                    description: "Port is the network port this Route targets. It
-                      can be interpreted differently based on the type of parent resource.
-                      \n When the parent resource is a Gateway, this targets all listeners
-                      listening on the specified port that also support this kind
-                      of Route(and select this Route). It's not recommended to set
-                      `Port` unless the networking behaviors specified in a Route
-                      must apply to a specific port as opposed to a listener(s) whose
-                      port(s) may be changed. When both Port and SectionName are specified,
-                      the name and port of the selected listener must match both specified
-                      values. \n  When the parent resource is a Service, this targets
-                      a specific port in the Service spec. When both Port (experimental)
-                      and SectionName are specified, the name and port of the selected
-                      port must match both specified values.  \n Implementations MAY
-                      choose to support other parent resources. Implementations supporting
-                      other types of parent resources MUST clearly document how/if
-                      Port is interpreted. \n For the purpose of status, an attachment
-                      is considered successful as long as the parent resource accepts
-                      it partially. For example, Gateway listeners can restrict which
-                      Routes can attach to them by Route kind, namespace, or hostname.
-                      If 1 of 2 Gateway listeners accept attachment from the referencing
-                      Route, the Route MUST be considered successfully attached. If
-                      no Gateway listeners accept attachment from this Route, the
-                      Route MUST be considered detached from the Gateway. \n Support:
-                      Extended \n "
+                    description: |-
+                      Port is the network port this Route targets. It can be interpreted
+                      differently based on the type of parent resource.
+
+
+                      When the parent resource is a Gateway, this targets all listeners
+                      listening on the specified port that also support this kind of Route(and
+                      select this Route). It's not recommended to set `Port` unless the
+                      networking behaviors specified in a Route must apply to a specific port
+                      as opposed to a listener(s) whose port(s) may be changed. When both Port
+                      and SectionName are specified, the name and port of the selected listener
+                      must match both specified values.
+
+
+
+                      When the parent resource is a Service, this targets a specific port in the
+                      Service spec. When both Port (experimental) and SectionName are specified,
+                      the name and port of the selected port must match both specified values.
+
+
+
+                      Implementations MAY choose to support other parent resources.
+                      Implementations supporting other types of parent resources MUST clearly
+                      document how/if Port is interpreted.
+
+
+                      For the purpose of status, an attachment is considered successful as
+                      long as the parent resource accepts it partially. For example, Gateway
+                      listeners can restrict which Routes can attach to them by Route kind,
+                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                      from the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this Route,
+                      the Route MUST be considered detached from the Gateway.
+
+
+                      Support: Extended
                     format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer
                   sectionName:
-                    description: "SectionName is the name of a section within the
-                      target resource. In the following resources, SectionName is
-                      interpreted as the following: \n * Gateway: Listener Name. When
-                      both Port (experimental) and SectionName are specified, the
-                      name and port of the selected listener must match both specified
-                      values. * Service: Port Name. When both Port (experimental)
-                      and SectionName are specified, the name and port of the selected
-                      listener must match both specified values. Note that attaching
-                      Routes to Services as Parents is part of experimental Mesh support
-                      and is not supported for any other purpose. \n Implementations
-                      MAY choose to support attaching Routes to other resources. If
-                      that is the case, they MUST clearly document how SectionName
-                      is interpreted. \n When unspecified (empty string), this will
-                      reference the entire resource. For the purpose of status, an
-                      attachment is considered successful if at least one section
-                      in the parent resource accepts it. For example, Gateway listeners
-                      can restrict which Routes can attach to them by Route kind,
-                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
-                      from the referencing Route, the Route MUST be considered successfully
-                      attached. If no Gateway listeners accept attachment from this
-                      Route, the Route MUST be considered detached from the Gateway.
-                      \n Support: Core"
+                    description: |-
+                      SectionName is the name of a section within the target resource. In the
+                      following resources, SectionName is interpreted as the following:
+
+
+                      * Gateway: Listener name. When both Port (experimental) and SectionName
+                      are specified, the name and port of the selected listener must match
+                      both specified values.
+                      * Service: Port name. When both Port (experimental) and SectionName
+                      are specified, the name and port of the selected listener must match
+                      both specified values.
+
+
+                      Implementations MAY choose to support attaching Routes to other resources.
+                      If that is the case, they MUST clearly document how SectionName is
+                      interpreted.
+
+
+                      When unspecified (empty string), this will reference the entire resource.
+                      For the purpose of status, an attachment is considered successful if at
+                      least one section in the parent resource accepts it. For example, Gateway
+                      listeners can restrict which Routes can attach to them by Route kind,
+                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                      the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this Route, the
+                      Route MUST be considered detached from the Gateway.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -328,78 +462,117 @@ spec:
             rules:
               description: Rules are a list of GRPC matchers, filters and actions.
               items:
-                description: GRPCRouteRule defines the semantics for matching a gRPC
-                  request based on conditions (matches), processing it (filters),
-                  and forwarding the request to an API object (backendRefs).
+                description: |-
+                  GRPCRouteRule defines the semantics for matching a gRPC request based on
+                  conditions (matches), processing it (filters), and forwarding the request to
+                  an API object (backendRefs).
                 properties:
                   backendRefs:
-                    description: "BackendRefs defines the backend(s) where matching
-                      requests should be sent. \n Failure behavior here depends on
-                      how many BackendRefs are specified and how many are invalid.
-                      \n If *all* entries in BackendRefs are invalid, and there are
-                      also no filters specified in this route rule, *all* traffic
-                      which matches this rule MUST receive an `UNAVAILABLE` status.
-                      \n See the GRPCBackendRef definition for the rules about what
-                      makes a single GRPCBackendRef invalid. \n When a GRPCBackendRef
-                      is invalid, `UNAVAILABLE` statuses MUST be returned for requests
-                      that would have otherwise been routed to an invalid backend.
-                      If multiple backends are specified, and some are invalid, the
-                      proportion of requests that would otherwise have been routed
-                      to an invalid backend MUST receive an `UNAVAILABLE` status.
-                      \n For example, if two backends are specified with equal weights,
-                      and one is invalid, 50 percent of traffic MUST receive an `UNAVAILABLE`
-                      status. Implementations may choose how that 50 percent is determined.
-                      \n Support: Core for Kubernetes Service \n Support: Implementation-specific
-                      for any other resource \n Support for weight: Core"
+                    description: |-
+                      BackendRefs defines the backend(s) where matching requests should be
+                      sent.
+
+
+                      Failure behavior here depends on how many BackendRefs are specified and
+                      how many are invalid.
+
+
+                      If *all* entries in BackendRefs are invalid, and there are also no filters
+                      specified in this route rule, *all* traffic which matches this rule MUST
+                      receive an `UNAVAILABLE` status.
+
+
+                      See the GRPCBackendRef definition for the rules about what makes a single
+                      GRPCBackendRef invalid.
+
+
+                      When a GRPCBackendRef is invalid, `UNAVAILABLE` statuses MUST be returned for
+                      requests that would have otherwise been routed to an invalid backend. If
+                      multiple backends are specified, and some are invalid, the proportion of
+                      requests that would otherwise have been routed to an invalid backend
+                      MUST receive an `UNAVAILABLE` status.
+
+
+                      For example, if two backends are specified with equal weights, and one is
+                      invalid, 50 percent of traffic MUST receive an `UNAVAILABLE` status.
+                      Implementations may choose how that 50 percent is determined.
+
+
+                      Support: Core for Kubernetes Service
+
+
+                      Support: Implementation-specific for any other resource
+
+
+                      Support for weight: Core
                     items:
-                      description: "GRPCBackendRef defines how a GRPCRoute forwards
-                        a gRPC request. \n Note that when a namespace different than
-                        the local namespace is specified, a ReferenceGrant object
-                        is required in the referent namespace to allow that namespace's
-                        owner to accept the reference. See the ReferenceGrant documentation
-                        for details. \n <gateway:experimental:description> \n When
-                        the BackendRef points to a Kubernetes Service, implementations
-                        SHOULD honor the appProtocol field if it is set for the target
-                        Service Port. \n Implementations supporting appProtocol SHOULD
-                        recognize the Kubernetes Standard Application Protocols defined
-                        in KEP-3726. \n If a Service appProtocol isn't specified,
-                        an implementation MAY infer the backend protocol through its
-                        own means. Implementations MAY infer the protocol from the
-                        Route type referring to the backend Service. \n If a Route
-                        is not able to send traffic to the backend using the specified
-                        protocol then the backend is considered invalid. Implementations
-                        MUST set the \"ResolvedRefs\" condition to \"False\" with
-                        the \"UnsupportedProtocol\" reason. \n </gateway:experimental:description>"
+                      description: |-
+                        GRPCBackendRef defines how a GRPCRoute forwards a gRPC request.
+
+
+                        Note that when a namespace different than the local namespace is specified, a
+                        ReferenceGrant object is required in the referent namespace to allow that
+                        namespace's owner to accept the reference. See the ReferenceGrant
+                        documentation for details.
+
+
+                        <gateway:experimental:description>
+
+
+                        When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                        honor the appProtocol field if it is set for the target Service Port.
+
+
+                        Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                        Standard Application Protocols defined in KEP-3726.
+
+
+                        If a Service appProtocol isn't specified, an implementation MAY infer the
+                        backend protocol through its own means. Implementations MAY infer the
+                        protocol from the Route type referring to the backend Service.
+
+
+                        If a Route is not able to send traffic to the backend using the specified
+                        protocol then the backend is considered invalid. Implementations MUST set the
+                        "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                        </gateway:experimental:description>
                       properties:
                         filters:
-                          description: "Filters defined at this level MUST be executed
-                            if and only if the request is being forwarded to the backend
-                            defined here. \n Support: Implementation-specific (For
-                            broader support of filters, use the Filters field in GRPCRouteRule.)"
+                          description: |-
+                            Filters defined at this level MUST be executed if and only if the
+                            request is being forwarded to the backend defined here.
+
+
+                            Support: Implementation-specific (For broader support of filters, use the
+                            Filters field in GRPCRouteRule.)
                           items:
-                            description: GRPCRouteFilter defines processing steps
-                              that must be completed during the request or response
-                              lifecycle. GRPCRouteFilters are meant as an extension
-                              point to express processing that may be done in Gateway
-                              implementations. Some examples include request or response
-                              modification, implementing authentication strategies,
-                              rate-limiting, and traffic shaping. API guarantee/conformance
-                              is defined based on the type of the filter.
+                            description: |-
+                              GRPCRouteFilter defines processing steps that must be completed during the
+                              request or response lifecycle. GRPCRouteFilters are meant as an extension
+                              point to express processing that may be done in Gateway implementations. Some
+                              examples include request or response modification, implementing
+                              authentication strategies, rate-limiting, and traffic shaping. API
+                              guarantee/conformance is defined based on the type of the filter.
                             properties:
                               extensionRef:
-                                description: "ExtensionRef is an optional, implementation-specific
-                                  extension to the \"filter\" behavior.  For example,
-                                  resource \"myroutefilter\" in group \"networking.example.net\").
-                                  ExtensionRef MUST NOT be used for core and extended
-                                  filters. \n Support: Implementation-specific \n
-                                  This filter can be used multiple times within the
-                                  same rule."
+                                description: |-
+                                  ExtensionRef is an optional, implementation-specific extension to the
+                                  "filter" behavior.  For example, resource "myroutefilter" in group
+                                  "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                                  extended filters.
+
+
+                                  Support: Implementation-specific
+
+
+                                  This filter can be used multiple times within the same rule.
                                 properties:
                                   group:
-                                    description: Group is the group of the referent.
-                                      For example, "gateway.networking.k8s.io". When
-                                      unspecified or empty string, core API group
-                                      is inferred.
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
@@ -421,33 +594,49 @@ spec:
                                 - name
                                 type: object
                               requestHeaderModifier:
-                                description: "RequestHeaderModifier defines a schema
-                                  for a filter that modifies request headers. \n Support:
-                                  Core"
+                                description: |-
+                                  RequestHeaderModifier defines a schema for a filter that modifies request
+                                  headers.
+
+
+                                  Support: Core
                                 properties:
                                   add:
-                                    description: "Add adds the given header(s) (name,
-                                      value) to the request before the action. It
-                                      appends to any existing values associated with
-                                      the header name. \n Input: GET /foo HTTP/1.1
-                                      my-header: foo \n Config: add: - name: \"my-header\"
-                                      value: \"bar,baz\" \n Output: GET /foo HTTP/1.1
-                                      my-header: foo,bar,baz"
+                                    description: |-
+                                      Add adds the given header(s) (name, value) to the request
+                                      before the action. It appends to any existing values associated
+                                      with the header name.
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo
+
+
+                                      Config:
+                                        add:
+                                        - name: "my-header"
+                                          value: "bar,baz"
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo,bar,baz
                                     items:
                                       description: HTTPHeader represents an HTTP Header
                                         name and value as defined by RFC 7230.
                                       properties:
                                         name:
-                                          description: "Name is the name of the HTTP
-                                            Header to be matched. Name matching MUST
-                                            be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                            \n If multiple entries specify equivalent
-                                            header names, the first entry with an
-                                            equivalent name MUST be considered for
-                                            a match. Subsequent entries with an equivalent
-                                            header name MUST be ignored. Due to the
-                                            case-insensitivity of header names, \"foo\"
-                                            and \"Foo\" are considered equivalent."
+                                          description: |-
+                                            Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                            case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                            If multiple entries specify equivalent header names, the first entry with
+                                            an equivalent name MUST be considered for a match. Subsequent entries
+                                            with an equivalent header name MUST be ignored. Due to the
+                                            case-insensitivity of header names, "foo" and "Foo" are considered
+                                            equivalent.
                                           maxLength: 256
                                           minLength: 1
                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -468,41 +657,67 @@ spec:
                                     - name
                                     x-kubernetes-list-type: map
                                   remove:
-                                    description: "Remove the given header(s) from
-                                      the HTTP request before the action. The value
-                                      of Remove is a list of HTTP header names. Note
-                                      that the header names are case-insensitive (see
+                                    description: |-
+                                      Remove the given header(s) from the HTTP request before the action. The
+                                      value of Remove is a list of HTTP header names. Note that the header
+                                      names are case-insensitive (see
                                       https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-                                      \n Input: GET /foo HTTP/1.1 my-header1: foo
-                                      my-header2: bar my-header3: baz \n Config: remove:
-                                      [\"my-header1\", \"my-header3\"] \n Output:
-                                      GET /foo HTTP/1.1 my-header2: bar"
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header1: foo
+                                        my-header2: bar
+                                        my-header3: baz
+
+
+                                      Config:
+                                        remove: ["my-header1", "my-header3"]
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header2: bar
                                     items:
                                       type: string
                                     maxItems: 16
                                     type: array
                                     x-kubernetes-list-type: set
                                   set:
-                                    description: "Set overwrites the request with
-                                      the given header (name, value) before the action.
-                                      \n Input: GET /foo HTTP/1.1 my-header: foo \n
-                                      Config: set: - name: \"my-header\" value: \"bar\"
-                                      \n Output: GET /foo HTTP/1.1 my-header: bar"
+                                    description: |-
+                                      Set overwrites the request with the given header (name, value)
+                                      before the action.
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo
+
+
+                                      Config:
+                                        set:
+                                        - name: "my-header"
+                                          value: "bar"
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header: bar
                                     items:
                                       description: HTTPHeader represents an HTTP Header
                                         name and value as defined by RFC 7230.
                                       properties:
                                         name:
-                                          description: "Name is the name of the HTTP
-                                            Header to be matched. Name matching MUST
-                                            be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                            \n If multiple entries specify equivalent
-                                            header names, the first entry with an
-                                            equivalent name MUST be considered for
-                                            a match. Subsequent entries with an equivalent
-                                            header name MUST be ignored. Due to the
-                                            case-insensitivity of header names, \"foo\"
-                                            and \"Foo\" are considered equivalent."
+                                          description: |-
+                                            Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                            case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                            If multiple entries specify equivalent header names, the first entry with
+                                            an equivalent name MUST be considered for a match. Subsequent entries
+                                            with an equivalent header name MUST be ignored. Due to the
+                                            case-insensitivity of header names, "foo" and "Foo" are considered
+                                            equivalent.
                                           maxLength: 256
                                           minLength: 1
                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -524,63 +739,80 @@ spec:
                                     x-kubernetes-list-type: map
                                 type: object
                               requestMirror:
-                                description: "RequestMirror defines a schema for a
-                                  filter that mirrors requests. Requests are sent
-                                  to the specified destination, but responses from
-                                  that destination are ignored. \n This filter can
-                                  be used multiple times within the same rule. Note
-                                  that not all implementations will be able to support
-                                  mirroring to multiple backends. \n Support: Extended"
+                                description: |-
+                                  RequestMirror defines a schema for a filter that mirrors requests.
+                                  Requests are sent to the specified destination, but responses from
+                                  that destination are ignored.
+
+
+                                  This filter can be used multiple times within the same rule. Note that
+                                  not all implementations will be able to support mirroring to multiple
+                                  backends.
+
+
+                                  Support: Extended
                                 properties:
                                   backendRef:
-                                    description: "BackendRef references a resource
-                                      where mirrored requests are sent. \n Mirrored
-                                      requests must be sent only to a single destination
-                                      endpoint within this BackendRef, irrespective
-                                      of how many endpoints are present within this
-                                      BackendRef. \n If the referent cannot be found,
-                                      this BackendRef is invalid and must be dropped
-                                      from the Gateway. The controller must ensure
-                                      the \"ResolvedRefs\" condition on the Route
-                                      status is set to `status: False` and not configure
+                                    description: |-
+                                      BackendRef references a resource where mirrored requests are sent.
+
+
+                                      Mirrored requests must be sent only to a single destination endpoint
+                                      within this BackendRef, irrespective of how many endpoints are present
+                                      within this BackendRef.
+
+
+                                      If the referent cannot be found, this BackendRef is invalid and must be
+                                      dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                      condition on the Route status is set to `status: False` and not configure
                                       this backend in the underlying implementation.
-                                      \n If there is a cross-namespace reference to
-                                      an *existing* object that is not allowed by
-                                      a ReferenceGrant, the controller must ensure
-                                      the \"ResolvedRefs\"  condition on the Route
-                                      is set to `status: False`, with the \"RefNotPermitted\"
-                                      reason and not configure this backend in the
-                                      underlying implementation. \n In either error
-                                      case, the Message of the `ResolvedRefs` Condition
-                                      should be used to provide more detail about
-                                      the problem. \n Support: Extended for Kubernetes
-                                      Service \n Support: Implementation-specific
-                                      for any other resource"
+
+
+                                      If there is a cross-namespace reference to an *existing* object
+                                      that is not allowed by a ReferenceGrant, the controller must ensure the
+                                      "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                      with the "RefNotPermitted" reason and not configure this backend in the
+                                      underlying implementation.
+
+
+                                      In either error case, the Message of the `ResolvedRefs` Condition
+                                      should be used to provide more detail about the problem.
+
+
+                                      Support: Extended for Kubernetes Service
+
+
+                                      Support: Implementation-specific for any other resource
                                     properties:
                                       group:
                                         default: ""
-                                        description: Group is the group of the referent.
-                                          For example, "gateway.networking.k8s.io".
-                                          When unspecified or empty string, core API
-                                          group is inferred.
+                                        description: |-
+                                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                          When unspecified or empty string, core API group is inferred.
                                         maxLength: 253
                                         pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                         type: string
                                       kind:
                                         default: Service
-                                        description: "Kind is the Kubernetes resource
-                                          kind of the referent. For example \"Service\".
-                                          \n Defaults to \"Service\" when not specified.
-                                          \n ExternalName services can refer to CNAME
-                                          DNS records that may live outside of the
-                                          cluster and as such are difficult to reason
-                                          about in terms of conformance. They also
-                                          may not be safe to forward to (see CVE-2021-25740
-                                          for more information). Implementations SHOULD
-                                          NOT support ExternalName Services. \n Support:
-                                          Core (Services with a type other than ExternalName)
-                                          \n Support: Implementation-specific (Services
-                                          with type ExternalName)"
+                                        description: |-
+                                          Kind is the Kubernetes resource kind of the referent. For example
+                                          "Service".
+
+
+                                          Defaults to "Service" when not specified.
+
+
+                                          ExternalName services can refer to CNAME DNS records that may live
+                                          outside of the cluster and as such are difficult to reason about in
+                                          terms of conformance. They also may not be safe to forward to (see
+                                          CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                          support ExternalName Services.
+
+
+                                          Support: Core (Services with a type other than ExternalName)
+
+
+                                          Support: Implementation-specific (Services with type ExternalName)
                                         maxLength: 63
                                         minLength: 1
                                         pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -591,28 +823,29 @@ spec:
                                         minLength: 1
                                         type: string
                                       namespace:
-                                        description: "Namespace is the namespace of
-                                          the backend. When unspecified, the local
-                                          namespace is inferred. \n Note that when
-                                          a namespace different than the local namespace
-                                          is specified, a ReferenceGrant object is
-                                          required in the referent namespace to allow
-                                          that namespace's owner to accept the reference.
-                                          See the ReferenceGrant documentation for
-                                          details. \n Support: Core"
+                                        description: |-
+                                          Namespace is the namespace of the backend. When unspecified, the local
+                                          namespace is inferred.
+
+
+                                          Note that when a namespace different than the local namespace is specified,
+                                          a ReferenceGrant object is required in the referent namespace to allow that
+                                          namespace's owner to accept the reference. See the ReferenceGrant
+                                          documentation for details.
+
+
+                                          Support: Core
                                         maxLength: 63
                                         minLength: 1
                                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       port:
-                                        description: Port specifies the destination
-                                          port number to use for this resource. Port
-                                          is required when the referent is a Kubernetes
-                                          Service. In this case, the port number is
-                                          the service port number, not the target
-                                          port. For other resources, destination port
-                                          might be derived from the referent resource
-                                          or this field.
+                                        description: |-
+                                          Port specifies the destination port number to use for this resource.
+                                          Port is required when the referent is a Kubernetes Service. In this
+                                          case, the port number is the service port number, not the target port.
+                                          For other resources, destination port might be derived from the referent
+                                          resource or this field.
                                         format: int32
                                         maximum: 65535
                                         minimum: 1
@@ -628,33 +861,49 @@ spec:
                                 - backendRef
                                 type: object
                               responseHeaderModifier:
-                                description: "ResponseHeaderModifier defines a schema
-                                  for a filter that modifies response headers. \n
-                                  Support: Extended"
+                                description: |-
+                                  ResponseHeaderModifier defines a schema for a filter that modifies response
+                                  headers.
+
+
+                                  Support: Extended
                                 properties:
                                   add:
-                                    description: "Add adds the given header(s) (name,
-                                      value) to the request before the action. It
-                                      appends to any existing values associated with
-                                      the header name. \n Input: GET /foo HTTP/1.1
-                                      my-header: foo \n Config: add: - name: \"my-header\"
-                                      value: \"bar,baz\" \n Output: GET /foo HTTP/1.1
-                                      my-header: foo,bar,baz"
+                                    description: |-
+                                      Add adds the given header(s) (name, value) to the request
+                                      before the action. It appends to any existing values associated
+                                      with the header name.
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo
+
+
+                                      Config:
+                                        add:
+                                        - name: "my-header"
+                                          value: "bar,baz"
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo,bar,baz
                                     items:
                                       description: HTTPHeader represents an HTTP Header
                                         name and value as defined by RFC 7230.
                                       properties:
                                         name:
-                                          description: "Name is the name of the HTTP
-                                            Header to be matched. Name matching MUST
-                                            be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                            \n If multiple entries specify equivalent
-                                            header names, the first entry with an
-                                            equivalent name MUST be considered for
-                                            a match. Subsequent entries with an equivalent
-                                            header name MUST be ignored. Due to the
-                                            case-insensitivity of header names, \"foo\"
-                                            and \"Foo\" are considered equivalent."
+                                          description: |-
+                                            Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                            case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                            If multiple entries specify equivalent header names, the first entry with
+                                            an equivalent name MUST be considered for a match. Subsequent entries
+                                            with an equivalent header name MUST be ignored. Due to the
+                                            case-insensitivity of header names, "foo" and "Foo" are considered
+                                            equivalent.
                                           maxLength: 256
                                           minLength: 1
                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -675,41 +924,67 @@ spec:
                                     - name
                                     x-kubernetes-list-type: map
                                   remove:
-                                    description: "Remove the given header(s) from
-                                      the HTTP request before the action. The value
-                                      of Remove is a list of HTTP header names. Note
-                                      that the header names are case-insensitive (see
+                                    description: |-
+                                      Remove the given header(s) from the HTTP request before the action. The
+                                      value of Remove is a list of HTTP header names. Note that the header
+                                      names are case-insensitive (see
                                       https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-                                      \n Input: GET /foo HTTP/1.1 my-header1: foo
-                                      my-header2: bar my-header3: baz \n Config: remove:
-                                      [\"my-header1\", \"my-header3\"] \n Output:
-                                      GET /foo HTTP/1.1 my-header2: bar"
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header1: foo
+                                        my-header2: bar
+                                        my-header3: baz
+
+
+                                      Config:
+                                        remove: ["my-header1", "my-header3"]
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header2: bar
                                     items:
                                       type: string
                                     maxItems: 16
                                     type: array
                                     x-kubernetes-list-type: set
                                   set:
-                                    description: "Set overwrites the request with
-                                      the given header (name, value) before the action.
-                                      \n Input: GET /foo HTTP/1.1 my-header: foo \n
-                                      Config: set: - name: \"my-header\" value: \"bar\"
-                                      \n Output: GET /foo HTTP/1.1 my-header: bar"
+                                    description: |-
+                                      Set overwrites the request with the given header (name, value)
+                                      before the action.
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo
+
+
+                                      Config:
+                                        set:
+                                        - name: "my-header"
+                                          value: "bar"
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header: bar
                                     items:
                                       description: HTTPHeader represents an HTTP Header
                                         name and value as defined by RFC 7230.
                                       properties:
                                         name:
-                                          description: "Name is the name of the HTTP
-                                            Header to be matched. Name matching MUST
-                                            be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                            \n If multiple entries specify equivalent
-                                            header names, the first entry with an
-                                            equivalent name MUST be considered for
-                                            a match. Subsequent entries with an equivalent
-                                            header name MUST be ignored. Due to the
-                                            case-insensitivity of header names, \"foo\"
-                                            and \"Foo\" are considered equivalent."
+                                          description: |-
+                                            Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                            case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                            If multiple entries specify equivalent header names, the first entry with
+                                            an equivalent name MUST be considered for a match. Subsequent entries
+                                            with an equivalent header name MUST be ignored. Due to the
+                                            case-insensitivity of header names, "foo" and "Foo" are considered
+                                            equivalent.
                                           maxLength: 256
                                           minLength: 1
                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -731,31 +1006,38 @@ spec:
                                     x-kubernetes-list-type: map
                                 type: object
                               type:
-                                description: "Type identifies the type of filter to
-                                  apply. As with other API fields, types are classified
-                                  into three conformance levels: \n - Core: Filter
-                                  types and their corresponding configuration defined
-                                  by \"Support: Core\" in this package, e.g. \"RequestHeaderModifier\".
-                                  All implementations supporting GRPCRoute MUST support
-                                  core filters. \n - Extended: Filter types and their
-                                  corresponding configuration defined by \"Support:
-                                  Extended\" in this package, e.g. \"RequestMirror\".
-                                  Implementers are encouraged to support extended
-                                  filters. \n - Implementation-specific: Filters that
-                                  are defined and supported by specific vendors. In
-                                  the future, filters showing convergence in behavior
-                                  across multiple implementations will be considered
-                                  for inclusion in extended or core conformance levels.
-                                  Filter-specific configuration for such filters is
-                                  specified using the ExtensionRef field. `Type` MUST
-                                  be set to \"ExtensionRef\" for custom filters. \n
-                                  Implementers are encouraged to define custom implementation
-                                  types to extend the core API with implementation-specific
-                                  behavior. \n If a reference to a custom filter type
-                                  cannot be resolved, the filter MUST NOT be skipped.
-                                  Instead, requests that would have been processed
-                                  by that filter MUST receive a HTTP error response.
-                                  \n "
+                                description: |+
+                                  Type identifies the type of filter to apply. As with other API fields,
+                                  types are classified into three conformance levels:
+
+
+                                  - Core: Filter types and their corresponding configuration defined by
+                                    "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                    implementations supporting GRPCRoute MUST support core filters.
+
+
+                                  - Extended: Filter types and their corresponding configuration defined by
+                                    "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                    are encouraged to support extended filters.
+
+
+                                  - Implementation-specific: Filters that are defined and supported by specific vendors.
+                                    In the future, filters showing convergence in behavior across multiple
+                                    implementations will be considered for inclusion in extended or core
+                                    conformance levels. Filter-specific configuration for such filters
+                                    is specified using the ExtensionRef field. `Type` MUST be set to
+                                    "ExtensionRef" for custom filters.
+
+
+                                  Implementers are encouraged to define custom implementation types to
+                                  extend the core API with implementation-specific behavior.
+
+
+                                  If a reference to a custom filter type cannot be resolved, the filter
+                                  MUST NOT be skipped. Instead, requests that would have been processed by
+                                  that filter MUST receive a HTTP error response.
+
+
                                 enum:
                                 - ResponseHeaderModifier
                                 - RequestHeaderModifier
@@ -805,24 +1087,33 @@ spec:
                               <= 1
                         group:
                           default: ""
-                          description: Group is the group of the referent. For example,
-                            "gateway.networking.k8s.io". When unspecified or empty
-                            string, core API group is inferred.
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Service
-                          description: "Kind is the Kubernetes resource kind of the
-                            referent. For example \"Service\". \n Defaults to \"Service\"
-                            when not specified. \n ExternalName services can refer
-                            to CNAME DNS records that may live outside of the cluster
-                            and as such are difficult to reason about in terms of
-                            conformance. They also may not be safe to forward to (see
-                            CVE-2021-25740 for more information). Implementations
-                            SHOULD NOT support ExternalName Services. \n Support:
-                            Core (Services with a type other than ExternalName) \n
-                            Support: Implementation-specific (Services with type ExternalName)"
+                          description: |-
+                            Kind is the Kubernetes resource kind of the referent. For example
+                            "Service".
+
+
+                            Defaults to "Service" when not specified.
+
+
+                            ExternalName services can refer to CNAME DNS records that may live
+                            outside of the cluster and as such are difficult to reason about in
+                            terms of conformance. They also may not be safe to forward to (see
+                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                            support ExternalName Services.
+
+
+                            Support: Core (Services with a type other than ExternalName)
+
+
+                            Support: Implementation-specific (Services with type ExternalName)
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -833,43 +1124,51 @@ spec:
                           minLength: 1
                           type: string
                         namespace:
-                          description: "Namespace is the namespace of the backend.
-                            When unspecified, the local namespace is inferred. \n
-                            Note that when a namespace different than the local namespace
-                            is specified, a ReferenceGrant object is required in the
-                            referent namespace to allow that namespace's owner to
-                            accept the reference. See the ReferenceGrant documentation
-                            for details. \n Support: Core"
+                          description: |-
+                            Namespace is the namespace of the backend. When unspecified, the local
+                            namespace is inferred.
+
+
+                            Note that when a namespace different than the local namespace is specified,
+                            a ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            Support: Core
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: Port specifies the destination port number
-                            to use for this resource. Port is required when the referent
-                            is a Kubernetes Service. In this case, the port number
-                            is the service port number, not the target port. For other
-                            resources, destination port might be derived from the
-                            referent resource or this field.
+                          description: |-
+                            Port specifies the destination port number to use for this resource.
+                            Port is required when the referent is a Kubernetes Service. In this
+                            case, the port number is the service port number, not the target port.
+                            For other resources, destination port might be derived from the referent
+                            resource or this field.
                           format: int32
                           maximum: 65535
                           minimum: 1
                           type: integer
                         weight:
                           default: 1
-                          description: "Weight specifies the proportion of requests
-                            forwarded to the referenced backend. This is computed
-                            as weight/(sum of all weights in this BackendRefs list).
-                            For non-zero values, there may be some epsilon from the
-                            exact proportion defined here depending on the precision
-                            an implementation supports. Weight is not a percentage
-                            and the sum of weights does not need to equal 100. \n
-                            If only one backend is specified and it has a weight greater
-                            than 0, 100% of the traffic is forwarded to that backend.
-                            If weight is set to 0, no traffic should be forwarded
-                            for this entry. If unspecified, weight defaults to 1.
-                            \n Support for this field varies based on the context
-                            where used."
+                          description: |-
+                            Weight specifies the proportion of requests forwarded to the referenced
+                            backend. This is computed as weight/(sum of all weights in this
+                            BackendRefs list). For non-zero values, there may be some epsilon from
+                            the exact proportion defined here depending on the precision an
+                            implementation supports. Weight is not a percentage and the sum of
+                            weights does not need to equal 100.
+
+
+                            If only one backend is specified and it has a weight greater than 0, 100%
+                            of the traffic is forwarded to that backend. If weight is set to 0, no
+                            traffic should be forwarded for this entry. If unspecified, weight
+                            defaults to 1.
+
+
+                            Support for this field varies based on the context where used.
                           format: int32
                           maximum: 1000000
                           minimum: 0
@@ -884,43 +1183,63 @@ spec:
                     maxItems: 16
                     type: array
                   filters:
-                    description: "Filters define the filters that are applied to requests
-                      that match this rule. \n The effects of ordering of multiple
-                      behaviors are currently unspecified. This can change in the
-                      future based on feedback during the alpha stage. \n Conformance-levels
-                      at this level are defined based on the type of filter: \n -
-                      ALL core filters MUST be supported by all implementations that
-                      support GRPCRoute. - Implementers are encouraged to support
-                      extended filters. - Implementation-specific custom filters have
-                      no API guarantees across implementations. \n Specifying the
-                      same filter multiple times is not supported unless explicitly
-                      indicated in the filter. \n If an implementation can not support
-                      a combination of filters, it must clearly document that limitation.
-                      In cases where incompatible or unsupported filters are specified
-                      and cause the `Accepted` condition to be set to status `False`,
-                      implementations may use the `IncompatibleFilters` reason to
-                      specify this configuration error. \n Support: Core"
+                    description: |-
+                      Filters define the filters that are applied to requests that match
+                      this rule.
+
+
+                      The effects of ordering of multiple behaviors are currently unspecified.
+                      This can change in the future based on feedback during the alpha stage.
+
+
+                      Conformance-levels at this level are defined based on the type of filter:
+
+
+                      - ALL core filters MUST be supported by all implementations that support
+                        GRPCRoute.
+                      - Implementers are encouraged to support extended filters.
+                      - Implementation-specific custom filters have no API guarantees across
+                        implementations.
+
+
+                      Specifying the same filter multiple times is not supported unless explicitly
+                      indicated in the filter.
+
+
+                      If an implementation can not support a combination of filters, it must clearly
+                      document that limitation. In cases where incompatible or unsupported
+                      filters are specified and cause the `Accepted` condition to be set to status
+                      `False`, implementations may use the `IncompatibleFilters` reason to specify
+                      this configuration error.
+
+
+                      Support: Core
                     items:
-                      description: GRPCRouteFilter defines processing steps that must
-                        be completed during the request or response lifecycle. GRPCRouteFilters
-                        are meant as an extension point to express processing that
-                        may be done in Gateway implementations. Some examples include
-                        request or response modification, implementing authentication
-                        strategies, rate-limiting, and traffic shaping. API guarantee/conformance
-                        is defined based on the type of the filter.
+                      description: |-
+                        GRPCRouteFilter defines processing steps that must be completed during the
+                        request or response lifecycle. GRPCRouteFilters are meant as an extension
+                        point to express processing that may be done in Gateway implementations. Some
+                        examples include request or response modification, implementing
+                        authentication strategies, rate-limiting, and traffic shaping. API
+                        guarantee/conformance is defined based on the type of the filter.
                       properties:
                         extensionRef:
-                          description: "ExtensionRef is an optional, implementation-specific
-                            extension to the \"filter\" behavior.  For example, resource
-                            \"myroutefilter\" in group \"networking.example.net\").
-                            ExtensionRef MUST NOT be used for core and extended filters.
-                            \n Support: Implementation-specific \n This filter can
-                            be used multiple times within the same rule."
+                          description: |-
+                            ExtensionRef is an optional, implementation-specific extension to the
+                            "filter" behavior.  For example, resource "myroutefilter" in group
+                            "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                            extended filters.
+
+
+                            Support: Implementation-specific
+
+
+                            This filter can be used multiple times within the same rule.
                           properties:
                             group:
-                              description: Group is the group of the referent. For
-                                example, "gateway.networking.k8s.io". When unspecified
-                                or empty string, core API group is inferred.
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
                               maxLength: 253
                               pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
@@ -942,30 +1261,49 @@ spec:
                           - name
                           type: object
                         requestHeaderModifier:
-                          description: "RequestHeaderModifier defines a schema for
-                            a filter that modifies request headers. \n Support: Core"
+                          description: |-
+                            RequestHeaderModifier defines a schema for a filter that modifies request
+                            headers.
+
+
+                            Support: Core
                           properties:
                             add:
-                              description: "Add adds the given header(s) (name, value)
-                                to the request before the action. It appends to any
-                                existing values associated with the header name. \n
-                                Input: GET /foo HTTP/1.1 my-header: foo \n Config:
-                                add: - name: \"my-header\" value: \"bar,baz\" \n Output:
-                                GET /foo HTTP/1.1 my-header: foo,bar,baz"
+                              description: |-
+                                Add adds the given header(s) (name, value) to the request
+                                before the action. It appends to any existing values associated
+                                with the header name.
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo
+
+
+                                Config:
+                                  add:
+                                  - name: "my-header"
+                                    value: "bar,baz"
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo,bar,baz
                               items:
                                 description: HTTPHeader represents an HTTP Header
                                   name and value as defined by RFC 7230.
                                 properties:
                                   name:
-                                    description: "Name is the name of the HTTP Header
-                                      to be matched. Name matching MUST be case insensitive.
-                                      (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                      \n If multiple entries specify equivalent header
-                                      names, the first entry with an equivalent name
-                                      MUST be considered for a match. Subsequent entries
-                                      with an equivalent header name MUST be ignored.
-                                      Due to the case-insensitivity of header names,
-                                      \"foo\" and \"Foo\" are considered equivalent."
+                                    description: |-
+                                      Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                      case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                      If multiple entries specify equivalent header names, the first entry with
+                                      an equivalent name MUST be considered for a match. Subsequent entries
+                                      with an equivalent header name MUST be ignored. Due to the
+                                      case-insensitivity of header names, "foo" and "Foo" are considered
+                                      equivalent.
                                     maxLength: 256
                                     minLength: 1
                                     pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -986,39 +1324,67 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             remove:
-                              description: "Remove the given header(s) from the HTTP
-                                request before the action. The value of Remove is
-                                a list of HTTP header names. Note that the header
-                                names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-                                \n Input: GET /foo HTTP/1.1 my-header1: foo my-header2:
-                                bar my-header3: baz \n Config: remove: [\"my-header1\",
-                                \"my-header3\"] \n Output: GET /foo HTTP/1.1 my-header2:
-                                bar"
+                              description: |-
+                                Remove the given header(s) from the HTTP request before the action. The
+                                value of Remove is a list of HTTP header names. Note that the header
+                                names are case-insensitive (see
+                                https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header1: foo
+                                  my-header2: bar
+                                  my-header3: baz
+
+
+                                Config:
+                                  remove: ["my-header1", "my-header3"]
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header2: bar
                               items:
                                 type: string
                               maxItems: 16
                               type: array
                               x-kubernetes-list-type: set
                             set:
-                              description: "Set overwrites the request with the given
-                                header (name, value) before the action. \n Input:
-                                GET /foo HTTP/1.1 my-header: foo \n Config: set: -
-                                name: \"my-header\" value: \"bar\" \n Output: GET
-                                /foo HTTP/1.1 my-header: bar"
+                              description: |-
+                                Set overwrites the request with the given header (name, value)
+                                before the action.
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo
+
+
+                                Config:
+                                  set:
+                                  - name: "my-header"
+                                    value: "bar"
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header: bar
                               items:
                                 description: HTTPHeader represents an HTTP Header
                                   name and value as defined by RFC 7230.
                                 properties:
                                   name:
-                                    description: "Name is the name of the HTTP Header
-                                      to be matched. Name matching MUST be case insensitive.
-                                      (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                      \n If multiple entries specify equivalent header
-                                      names, the first entry with an equivalent name
-                                      MUST be considered for a match. Subsequent entries
-                                      with an equivalent header name MUST be ignored.
-                                      Due to the case-insensitivity of header names,
-                                      \"foo\" and \"Foo\" are considered equivalent."
+                                    description: |-
+                                      Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                      case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                      If multiple entries specify equivalent header names, the first entry with
+                                      an equivalent name MUST be considered for a match. Subsequent entries
+                                      with an equivalent header name MUST be ignored. Due to the
+                                      case-insensitivity of header names, "foo" and "Foo" are considered
+                                      equivalent.
                                     maxLength: 256
                                     minLength: 1
                                     pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1040,58 +1406,80 @@ spec:
                               x-kubernetes-list-type: map
                           type: object
                         requestMirror:
-                          description: "RequestMirror defines a schema for a filter
-                            that mirrors requests. Requests are sent to the specified
-                            destination, but responses from that destination are ignored.
-                            \n This filter can be used multiple times within the same
-                            rule. Note that not all implementations will be able to
-                            support mirroring to multiple backends. \n Support: Extended"
+                          description: |-
+                            RequestMirror defines a schema for a filter that mirrors requests.
+                            Requests are sent to the specified destination, but responses from
+                            that destination are ignored.
+
+
+                            This filter can be used multiple times within the same rule. Note that
+                            not all implementations will be able to support mirroring to multiple
+                            backends.
+
+
+                            Support: Extended
                           properties:
                             backendRef:
-                              description: "BackendRef references a resource where
-                                mirrored requests are sent. \n Mirrored requests must
-                                be sent only to a single destination endpoint within
-                                this BackendRef, irrespective of how many endpoints
-                                are present within this BackendRef. \n If the referent
-                                cannot be found, this BackendRef is invalid and must
-                                be dropped from the Gateway. The controller must ensure
-                                the \"ResolvedRefs\" condition on the Route status
-                                is set to `status: False` and not configure this backend
-                                in the underlying implementation. \n If there is a
-                                cross-namespace reference to an *existing* object
-                                that is not allowed by a ReferenceGrant, the controller
-                                must ensure the \"ResolvedRefs\"  condition on the
-                                Route is set to `status: False`, with the \"RefNotPermitted\"
-                                reason and not configure this backend in the underlying
-                                implementation. \n In either error case, the Message
-                                of the `ResolvedRefs` Condition should be used to
-                                provide more detail about the problem. \n Support:
-                                Extended for Kubernetes Service \n Support: Implementation-specific
-                                for any other resource"
+                              description: |-
+                                BackendRef references a resource where mirrored requests are sent.
+
+
+                                Mirrored requests must be sent only to a single destination endpoint
+                                within this BackendRef, irrespective of how many endpoints are present
+                                within this BackendRef.
+
+
+                                If the referent cannot be found, this BackendRef is invalid and must be
+                                dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                condition on the Route status is set to `status: False` and not configure
+                                this backend in the underlying implementation.
+
+
+                                If there is a cross-namespace reference to an *existing* object
+                                that is not allowed by a ReferenceGrant, the controller must ensure the
+                                "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                with the "RefNotPermitted" reason and not configure this backend in the
+                                underlying implementation.
+
+
+                                In either error case, the Message of the `ResolvedRefs` Condition
+                                should be used to provide more detail about the problem.
+
+
+                                Support: Extended for Kubernetes Service
+
+
+                                Support: Implementation-specific for any other resource
                               properties:
                                 group:
                                   default: ""
-                                  description: Group is the group of the referent.
-                                    For example, "gateway.networking.k8s.io". When
-                                    unspecified or empty string, core API group is
-                                    inferred.
+                                  description: |-
+                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                    When unspecified or empty string, core API group is inferred.
                                   maxLength: 253
                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                   type: string
                                 kind:
                                   default: Service
-                                  description: "Kind is the Kubernetes resource kind
-                                    of the referent. For example \"Service\". \n Defaults
-                                    to \"Service\" when not specified. \n ExternalName
-                                    services can refer to CNAME DNS records that may
-                                    live outside of the cluster and as such are difficult
-                                    to reason about in terms of conformance. They
-                                    also may not be safe to forward to (see CVE-2021-25740
-                                    for more information). Implementations SHOULD
-                                    NOT support ExternalName Services. \n Support:
-                                    Core (Services with a type other than ExternalName)
-                                    \n Support: Implementation-specific (Services
-                                    with type ExternalName)"
+                                  description: |-
+                                    Kind is the Kubernetes resource kind of the referent. For example
+                                    "Service".
+
+
+                                    Defaults to "Service" when not specified.
+
+
+                                    ExternalName services can refer to CNAME DNS records that may live
+                                    outside of the cluster and as such are difficult to reason about in
+                                    terms of conformance. They also may not be safe to forward to (see
+                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                    support ExternalName Services.
+
+
+                                    Support: Core (Services with a type other than ExternalName)
+
+
+                                    Support: Implementation-specific (Services with type ExternalName)
                                   maxLength: 63
                                   minLength: 1
                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1102,25 +1490,28 @@ spec:
                                   minLength: 1
                                   type: string
                                 namespace:
-                                  description: "Namespace is the namespace of the
-                                    backend. When unspecified, the local namespace
-                                    is inferred. \n Note that when a namespace different
-                                    than the local namespace is specified, a ReferenceGrant
-                                    object is required in the referent namespace to
-                                    allow that namespace's owner to accept the reference.
-                                    See the ReferenceGrant documentation for details.
-                                    \n Support: Core"
+                                  description: |-
+                                    Namespace is the namespace of the backend. When unspecified, the local
+                                    namespace is inferred.
+
+
+                                    Note that when a namespace different than the local namespace is specified,
+                                    a ReferenceGrant object is required in the referent namespace to allow that
+                                    namespace's owner to accept the reference. See the ReferenceGrant
+                                    documentation for details.
+
+
+                                    Support: Core
                                   maxLength: 63
                                   minLength: 1
                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                   type: string
                                 port:
-                                  description: Port specifies the destination port
-                                    number to use for this resource. Port is required
-                                    when the referent is a Kubernetes Service. In
-                                    this case, the port number is the service port
-                                    number, not the target port. For other resources,
-                                    destination port might be derived from the referent
+                                  description: |-
+                                    Port specifies the destination port number to use for this resource.
+                                    Port is required when the referent is a Kubernetes Service. In this
+                                    case, the port number is the service port number, not the target port.
+                                    For other resources, destination port might be derived from the referent
                                     resource or this field.
                                   format: int32
                                   maximum: 65535
@@ -1137,30 +1528,49 @@ spec:
                           - backendRef
                           type: object
                         responseHeaderModifier:
-                          description: "ResponseHeaderModifier defines a schema for
-                            a filter that modifies response headers. \n Support: Extended"
+                          description: |-
+                            ResponseHeaderModifier defines a schema for a filter that modifies response
+                            headers.
+
+
+                            Support: Extended
                           properties:
                             add:
-                              description: "Add adds the given header(s) (name, value)
-                                to the request before the action. It appends to any
-                                existing values associated with the header name. \n
-                                Input: GET /foo HTTP/1.1 my-header: foo \n Config:
-                                add: - name: \"my-header\" value: \"bar,baz\" \n Output:
-                                GET /foo HTTP/1.1 my-header: foo,bar,baz"
+                              description: |-
+                                Add adds the given header(s) (name, value) to the request
+                                before the action. It appends to any existing values associated
+                                with the header name.
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo
+
+
+                                Config:
+                                  add:
+                                  - name: "my-header"
+                                    value: "bar,baz"
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo,bar,baz
                               items:
                                 description: HTTPHeader represents an HTTP Header
                                   name and value as defined by RFC 7230.
                                 properties:
                                   name:
-                                    description: "Name is the name of the HTTP Header
-                                      to be matched. Name matching MUST be case insensitive.
-                                      (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                      \n If multiple entries specify equivalent header
-                                      names, the first entry with an equivalent name
-                                      MUST be considered for a match. Subsequent entries
-                                      with an equivalent header name MUST be ignored.
-                                      Due to the case-insensitivity of header names,
-                                      \"foo\" and \"Foo\" are considered equivalent."
+                                    description: |-
+                                      Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                      case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                      If multiple entries specify equivalent header names, the first entry with
+                                      an equivalent name MUST be considered for a match. Subsequent entries
+                                      with an equivalent header name MUST be ignored. Due to the
+                                      case-insensitivity of header names, "foo" and "Foo" are considered
+                                      equivalent.
                                     maxLength: 256
                                     minLength: 1
                                     pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1181,39 +1591,67 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             remove:
-                              description: "Remove the given header(s) from the HTTP
-                                request before the action. The value of Remove is
-                                a list of HTTP header names. Note that the header
-                                names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-                                \n Input: GET /foo HTTP/1.1 my-header1: foo my-header2:
-                                bar my-header3: baz \n Config: remove: [\"my-header1\",
-                                \"my-header3\"] \n Output: GET /foo HTTP/1.1 my-header2:
-                                bar"
+                              description: |-
+                                Remove the given header(s) from the HTTP request before the action. The
+                                value of Remove is a list of HTTP header names. Note that the header
+                                names are case-insensitive (see
+                                https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header1: foo
+                                  my-header2: bar
+                                  my-header3: baz
+
+
+                                Config:
+                                  remove: ["my-header1", "my-header3"]
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header2: bar
                               items:
                                 type: string
                               maxItems: 16
                               type: array
                               x-kubernetes-list-type: set
                             set:
-                              description: "Set overwrites the request with the given
-                                header (name, value) before the action. \n Input:
-                                GET /foo HTTP/1.1 my-header: foo \n Config: set: -
-                                name: \"my-header\" value: \"bar\" \n Output: GET
-                                /foo HTTP/1.1 my-header: bar"
+                              description: |-
+                                Set overwrites the request with the given header (name, value)
+                                before the action.
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo
+
+
+                                Config:
+                                  set:
+                                  - name: "my-header"
+                                    value: "bar"
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header: bar
                               items:
                                 description: HTTPHeader represents an HTTP Header
                                   name and value as defined by RFC 7230.
                                 properties:
                                   name:
-                                    description: "Name is the name of the HTTP Header
-                                      to be matched. Name matching MUST be case insensitive.
-                                      (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                      \n If multiple entries specify equivalent header
-                                      names, the first entry with an equivalent name
-                                      MUST be considered for a match. Subsequent entries
-                                      with an equivalent header name MUST be ignored.
-                                      Due to the case-insensitivity of header names,
-                                      \"foo\" and \"Foo\" are considered equivalent."
+                                    description: |-
+                                      Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                      case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                      If multiple entries specify equivalent header names, the first entry with
+                                      an equivalent name MUST be considered for a match. Subsequent entries
+                                      with an equivalent header name MUST be ignored. Due to the
+                                      case-insensitivity of header names, "foo" and "Foo" are considered
+                                      equivalent.
                                     maxLength: 256
                                     minLength: 1
                                     pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1235,28 +1673,38 @@ spec:
                               x-kubernetes-list-type: map
                           type: object
                         type:
-                          description: "Type identifies the type of filter to apply.
-                            As with other API fields, types are classified into three
-                            conformance levels: \n - Core: Filter types and their
-                            corresponding configuration defined by \"Support: Core\"
-                            in this package, e.g. \"RequestHeaderModifier\". All implementations
-                            supporting GRPCRoute MUST support core filters. \n - Extended:
-                            Filter types and their corresponding configuration defined
-                            by \"Support: Extended\" in this package, e.g. \"RequestMirror\".
-                            Implementers are encouraged to support extended filters.
-                            \n - Implementation-specific: Filters that are defined
-                            and supported by specific vendors. In the future, filters
-                            showing convergence in behavior across multiple implementations
-                            will be considered for inclusion in extended or core conformance
-                            levels. Filter-specific configuration for such filters
-                            is specified using the ExtensionRef field. `Type` MUST
-                            be set to \"ExtensionRef\" for custom filters. \n Implementers
-                            are encouraged to define custom implementation types to
+                          description: |+
+                            Type identifies the type of filter to apply. As with other API fields,
+                            types are classified into three conformance levels:
+
+
+                            - Core: Filter types and their corresponding configuration defined by
+                              "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                              implementations supporting GRPCRoute MUST support core filters.
+
+
+                            - Extended: Filter types and their corresponding configuration defined by
+                              "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                              are encouraged to support extended filters.
+
+
+                            - Implementation-specific: Filters that are defined and supported by specific vendors.
+                              In the future, filters showing convergence in behavior across multiple
+                              implementations will be considered for inclusion in extended or core
+                              conformance levels. Filter-specific configuration for such filters
+                              is specified using the ExtensionRef field. `Type` MUST be set to
+                              "ExtensionRef" for custom filters.
+
+
+                            Implementers are encouraged to define custom implementation types to
                             extend the core API with implementation-specific behavior.
-                            \n If a reference to a custom filter type cannot be resolved,
-                            the filter MUST NOT be skipped. Instead, requests that
-                            would have been processed by that filter MUST receive
-                            a HTTP error response. \n "
+
+
+                            If a reference to a custom filter type cannot be resolved, the filter
+                            MUST NOT be skipped. Instead, requests that would have been processed by
+                            that filter MUST receive a HTTP error response.
+
+
                           enum:
                           - ResponseHeaderModifier
                           - RequestHeaderModifier
@@ -1304,58 +1752,110 @@ spec:
                       rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
                         <= 1
                   matches:
-                    description: "Matches define conditions used for matching the
-                      rule against incoming gRPC requests. Each match is independent,
-                      i.e. this rule will be matched if **any** one of the matches
-                      is satisfied. \n For example, take the following matches configuration:
-                      \n ``` matches: - method: service: foo.bar headers: values:
-                      version: 2 - method: service: foo.bar.v2 ``` \n For a request
-                      to match against this rule, it MUST satisfy EITHER of the two
-                      conditions: \n - service of foo.bar AND contains the header
-                      `version: 2` - service of foo.bar.v2 \n See the documentation
-                      for GRPCRouteMatch on how to specify multiple match conditions
-                      to be ANDed together. \n If no matches are specified, the implementation
-                      MUST match every gRPC request. \n Proxy or Load Balancer routing
-                      configuration generated from GRPCRoutes MUST prioritize rules
-                      based on the following criteria, continuing on ties. Merging
-                      MUST not be done between GRPCRoutes and HTTPRoutes. Precedence
-                      MUST be given to the rule with the largest number of: \n * Characters
-                      in a matching non-wildcard hostname. * Characters in a matching
-                      hostname. * Characters in a matching service. * Characters in
-                      a matching method. * Header matches. \n If ties still exist
-                      across multiple Routes, matching precedence MUST be determined
-                      in order of the following criteria, continuing on ties: \n *
-                      The oldest Route based on creation timestamp. * The Route appearing
-                      first in alphabetical order by \"{namespace}/{name}\". \n If
-                      ties still exist within the Route that has been given precedence,
-                      matching precedence MUST be granted to the first matching rule
-                      meeting the above criteria."
+                    description: |-
+                      Matches define conditions used for matching the rule against incoming
+                      gRPC requests. Each match is independent, i.e. this rule will be matched
+                      if **any** one of the matches is satisfied.
+
+
+                      For example, take the following matches configuration:
+
+
+                      ```
+                      matches:
+                      - method:
+                          service: foo.bar
+                        headers:
+                          values:
+                            version: 2
+                      - method:
+                          service: foo.bar.v2
+                      ```
+
+
+                      For a request to match against this rule, it MUST satisfy
+                      EITHER of the two conditions:
+
+
+                      - service of foo.bar AND contains the header `version: 2`
+                      - service of foo.bar.v2
+
+
+                      See the documentation for GRPCRouteMatch on how to specify multiple
+                      match conditions to be ANDed together.
+
+
+                      If no matches are specified, the implementation MUST match every gRPC request.
+
+
+                      Proxy or Load Balancer routing configuration generated from GRPCRoutes
+                      MUST prioritize rules based on the following criteria, continuing on
+                      ties. Merging MUST not be done between GRPCRoutes and HTTPRoutes.
+                      Precedence MUST be given to the rule with the largest number of:
+
+
+                      * Characters in a matching non-wildcard hostname.
+                      * Characters in a matching hostname.
+                      * Characters in a matching service.
+                      * Characters in a matching method.
+                      * Header matches.
+
+
+                      If ties still exist across multiple Routes, matching precedence MUST be
+                      determined in order of the following criteria, continuing on ties:
+
+
+                      * The oldest Route based on creation timestamp.
+                      * The Route appearing first in alphabetical order by
+                        "{namespace}/{name}".
+
+
+                      If ties still exist within the Route that has been given precedence,
+                      matching precedence MUST be granted to the first matching rule meeting
+                      the above criteria.
                     items:
-                      description: "GRPCRouteMatch defines the predicate used to match
-                        requests to a given action. Multiple match types are ANDed
-                        together, i.e. the match will evaluate to true only if all
-                        conditions are satisfied. \n For example, the match below
-                        will match a gRPC request only if its service is `foo` AND
-                        it contains the `version: v1` header: \n ``` matches: - method:
-                        type: Exact service: \"foo\" headers: - name: \"version\"
-                        value \"v1\" \n ```"
+                      description: |-
+                        GRPCRouteMatch defines the predicate used to match requests to a given
+                        action. Multiple match types are ANDed together, i.e. the match will
+                        evaluate to true only if all conditions are satisfied.
+
+
+                        For example, the match below will match a gRPC request only if its service
+                        is `foo` AND it contains the `version: v1` header:
+
+
+                        ```
+                        matches:
+                          - method:
+                            type: Exact
+                            service: "foo"
+                            headers:
+                          - name: "version"
+                            value "v1"
+
+
+                        ```
                       properties:
                         headers:
-                          description: Headers specifies gRPC request header matchers.
-                            Multiple match values are ANDed together, meaning, a request
-                            MUST match all the specified headers to select the route.
+                          description: |-
+                            Headers specifies gRPC request header matchers. Multiple match values are
+                            ANDed together, meaning, a request MUST match all the specified headers
+                            to select the route.
                           items:
-                            description: GRPCHeaderMatch describes how to select a
-                              gRPC route by matching gRPC request headers.
+                            description: |-
+                              GRPCHeaderMatch describes how to select a gRPC route by matching gRPC request
+                              headers.
                             properties:
                               name:
-                                description: "Name is the name of the gRPC Header
-                                  to be matched. \n If multiple entries specify equivalent
-                                  header names, only the first entry with an equivalent
-                                  name MUST be considered for a match. Subsequent
-                                  entries with an equivalent header name MUST be ignored.
-                                  Due to the case-insensitivity of header names, \"foo\"
-                                  and \"Foo\" are considered equivalent."
+                                description: |-
+                                  Name is the name of the gRPC Header to be matched.
+
+
+                                  If multiple entries specify equivalent header names, only the first
+                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                  entries with an equivalent header name MUST be ignored. Due to the
+                                  case-insensitivity of header names, "foo" and "Foo" are considered
+                                  equivalent.
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1384,31 +1884,39 @@ spec:
                           - name
                           x-kubernetes-list-type: map
                         method:
-                          description: Method specifies a gRPC request service/method
-                            matcher. If this field is not specified, all services
-                            and methods will match.
+                          description: |-
+                            Method specifies a gRPC request service/method matcher. If this field is
+                            not specified, all services and methods will match.
                           properties:
                             method:
-                              description: "Value of the method to match against.
-                                If left empty or omitted, will match all services.
-                                \n At least one of Service and Method MUST be a non-empty
-                                string."
+                              description: |-
+                                Value of the method to match against. If left empty or omitted, will
+                                match all services.
+
+
+                                At least one of Service and Method MUST be a non-empty string.
                               maxLength: 1024
                               type: string
                             service:
-                              description: "Value of the service to match against.
-                                If left empty or omitted, will match any service.
-                                \n At least one of Service and Method MUST be a non-empty
-                                string."
+                              description: |-
+                                Value of the service to match against. If left empty or omitted, will
+                                match any service.
+
+
+                                At least one of Service and Method MUST be a non-empty string.
                               maxLength: 1024
                               type: string
                             type:
                               default: Exact
-                              description: "Type specifies how to match against the
-                                service and/or method. Support: Core (Exact with service
-                                and method specified) \n Support: Implementation-specific
-                                (Exact with method specified but no service specified)
-                                \n Support: Implementation-specific (RegularExpression)"
+                              description: |-
+                                Type specifies how to match against the service and/or method.
+                                Support: Core (Exact with service and method specified)
+
+
+                                Support: Implementation-specific (Exact with method specified but no service specified)
+
+
+                                Support: Implementation-specific (RegularExpression)
                               enum:
                               - Exact
                               - RegularExpression
@@ -1432,6 +1940,106 @@ spec:
                       type: object
                     maxItems: 8
                     type: array
+                  sessionPersistence:
+                    description: |+
+                      SessionPersistence defines and configures session persistence
+                      for the route rule.
+
+
+                      Support: Extended
+
+
+                    properties:
+                      absoluteTimeout:
+                        description: |-
+                          AbsoluteTimeout defines the absolute timeout of the persistent
+                          session. Once the AbsoluteTimeout duration has elapsed, the
+                          session becomes invalid.
+
+
+                          Support: Extended
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                      cookieConfig:
+                        description: |-
+                          CookieConfig provides configuration settings that are specific
+                          to cookie-based session persistence.
+
+
+                          Support: Core
+                        properties:
+                          lifetimeType:
+                            default: Session
+                            description: |-
+                              LifetimeType specifies whether the cookie has a permanent or
+                              session-based lifetime. A permanent cookie persists until its
+                              specified expiry time, defined by the Expires or Max-Age cookie
+                              attributes, while a session cookie is deleted when the current
+                              session ends.
+
+
+                              When set to "Permanent", AbsoluteTimeout indicates the
+                              cookie's lifetime via the Expires or Max-Age cookie attributes
+                              and is required.
+
+
+                              When set to "Session", AbsoluteTimeout indicates the
+                              absolute lifetime of the cookie tracked by the gateway and
+                              is optional.
+
+
+                              Support: Core for "Session" type
+
+
+                              Support: Extended for "Permanent" type
+                            enum:
+                            - Permanent
+                            - Session
+                            type: string
+                        type: object
+                      idleTimeout:
+                        description: |-
+                          IdleTimeout defines the idle timeout of the persistent session.
+                          Once the session has been idle for more than the specified
+                          IdleTimeout duration, the session becomes invalid.
+
+
+                          Support: Extended
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                      sessionName:
+                        description: |-
+                          SessionName defines the name of the persistent session token
+                          which may be reflected in the cookie or the header. Users
+                          should avoid reusing session names to prevent unintended
+                          consequences, such as rejection or unpredictable behavior.
+
+
+                          Support: Implementation-specific
+                        maxLength: 128
+                        type: string
+                      type:
+                        default: Cookie
+                        description: |-
+                          Type defines the type of session persistence such as through
+                          the use a header or cookie. Defaults to cookie based session
+                          persistence.
+
+
+                          Support: Core for "Cookie" type
+
+
+                          Support: Extended for "Header" type
+                        enum:
+                        - Cookie
+                        - Header
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                        is Permanent
+                      rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                        != ''Permanent'' || has(self.absoluteTimeout)'
                 type: object
               maxItems: 16
               type: array

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/referencegrants.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/referencegrants.yaml
@@ -17,32 +17,45 @@ spec:
     version: v1alpha2
   validation:
     openAPIV3Schema:
-      description: "ReferenceGrant identifies kinds of resources in other namespaces
-        that are trusted to reference the specified kinds of resources in the same
-        namespace as the policy. \n Each ReferenceGrant can be used to represent a
-        unique trust relationship. Additional Reference Grants can be used to add
-        to the set of trusted sources of inbound references for the namespace they
-        are defined within. \n A ReferenceGrant is required for all cross-namespace
-        references in Gateway API (with the exception of cross-namespace Route-Gateway
-        attachment, which is governed by the AllowedRoutes configuration on the Gateway,
-        and cross-namespace Service ParentRefs on a \"consumer\" mesh Route, which
-        defines routing rules applicable only to workloads in the Route namespace).
-        ReferenceGrants allowing a reference from a Route to a Service are only applicable
-        to BackendRefs. \n ReferenceGrant is a form of runtime verification allowing
-        users to assert which cross-namespace object references are permitted. Implementations
-        that support ReferenceGrant MUST NOT permit cross-namespace references which
-        have no grant, and MUST respond to the removal of a grant by revoking the
-        access that the grant allowed."
+      description: |-
+        ReferenceGrant identifies kinds of resources in other namespaces that are
+        trusted to reference the specified kinds of resources in the same namespace
+        as the policy.
+
+
+        Each ReferenceGrant can be used to represent a unique trust relationship.
+        Additional Reference Grants can be used to add to the set of trusted
+        sources of inbound references for the namespace they are defined within.
+
+
+        A ReferenceGrant is required for all cross-namespace references in Gateway API
+        (with the exception of cross-namespace Route-Gateway attachment, which is
+        governed by the AllowedRoutes configuration on the Gateway, and cross-namespace
+        Service ParentRefs on a "consumer" mesh Route, which defines routing rules
+        applicable only to workloads in the Route namespace). ReferenceGrants allowing
+        a reference from a Route to a Service are only applicable to BackendRefs.
+
+
+        ReferenceGrant is a form of runtime verification allowing users to assert
+        which cross-namespace object references are permitted. Implementations that
+        support ReferenceGrant MUST NOT permit cross-namespace references which have
+        no grant, and MUST respond to the removal of a grant by revoking the access
+        that the grant allowed.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -81,34 +94,58 @@ spec:
           description: Spec defines the desired state of ReferenceGrant.
           properties:
             from:
-              description: "From describes the trusted namespaces and kinds that can
-                reference the resources described in \"To\". Each entry in this list
-                MUST be considered to be an additional place that references can be
-                valid from, or to put this another way, entries MUST be combined using
-                OR. \n Support: Core"
+              description: |-
+                From describes the trusted namespaces and kinds that can reference the
+                resources described in "To". Each entry in this list MUST be considered
+                to be an additional place that references can be valid from, or to put
+                this another way, entries MUST be combined using OR.
+
+
+                Support: Core
               items:
                 description: ReferenceGrantFrom describes trusted namespaces and kinds.
                 properties:
                   group:
-                    description: "Group is the group of the referent. When empty,
-                      the Kubernetes core API group is inferred. \n Support: Core"
+                    description: |-
+                      Group is the group of the referent.
+                      When empty, the Kubernetes core API group is inferred.
+
+
+                      Support: Core
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
-                    description: "Kind is the kind of the referent. Although implementations
-                      may support additional resources, the following types are part
-                      of the \"Core\" support level for this field. \n When used to
-                      permit a SecretObjectReference: \n * Gateway \n When used to
-                      permit a BackendObjectReference: \n * GRPCRoute * HTTPRoute
-                      * TCPRoute * TLSRoute * UDPRoute"
+                    description: |-
+                      Kind is the kind of the referent. Although implementations may support
+                      additional resources, the following types are part of the "Core"
+                      support level for this field.
+
+
+                      When used to permit a SecretObjectReference:
+
+
+                      * Gateway
+
+
+                      When used to permit a BackendObjectReference:
+
+
+                      * GRPCRoute
+                      * HTTPRoute
+                      * TCPRoute
+                      * TLSRoute
+                      * UDPRoute
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   namespace:
-                    description: "Namespace is the namespace of the referent. \n Support:
-                      Core"
+                    description: |-
+                      Namespace is the namespace of the referent.
+
+
+                      Support: Core
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -122,34 +159,47 @@ spec:
               minItems: 1
               type: array
             to:
-              description: "To describes the resources that may be referenced by the
-                resources described in \"From\". Each entry in this list MUST be considered
-                to be an additional place that references can be valid to, or to put
-                this another way, entries MUST be combined using OR. \n Support: Core"
+              description: |-
+                To describes the resources that may be referenced by the resources
+                described in "From". Each entry in this list MUST be considered to be an
+                additional place that references can be valid to, or to put this another
+                way, entries MUST be combined using OR.
+
+
+                Support: Core
               items:
-                description: ReferenceGrantTo describes what Kinds are allowed as
-                  targets of the references.
+                description: |-
+                  ReferenceGrantTo describes what Kinds are allowed as targets of the
+                  references.
                 properties:
                   group:
-                    description: "Group is the group of the referent. When empty,
-                      the Kubernetes core API group is inferred. \n Support: Core"
+                    description: |-
+                      Group is the group of the referent.
+                      When empty, the Kubernetes core API group is inferred.
+
+
+                      Support: Core
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
-                    description: "Kind is the kind of the referent. Although implementations
-                      may support additional resources, the following types are part
-                      of the \"Core\" support level for this field: \n * Secret when
-                      used to permit a SecretObjectReference * Service when used to
-                      permit a BackendObjectReference"
+                    description: |-
+                      Kind is the kind of the referent. Although implementations may support
+                      additional resources, the following types are part of the "Core"
+                      support level for this field:
+
+
+                      * Secret when used to permit a SecretObjectReference
+                      * Service when used to permit a BackendObjectReference
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
-                    description: Name is the name of the referent. When unspecified,
-                      this policy refers to all resources of the specified Group and
-                      Kind in the local namespace.
+                    description: |-
+                      Name is the name of the referent. When unspecified, this policy
+                      refers to all resources of the specified Group and Kind in the local
+                      namespace.
                     maxLength: 253
                     minLength: 1
                     type: string

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/tcproutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/tcproutes.yaml
@@ -17,19 +17,25 @@ spec:
     version: v1alpha2
   validation:
     openAPIV3Schema:
-      description: TCPRoute provides a way to route TCP requests. When combined with
-        a Gateway listener, it can be used to forward connections on the port specified
-        by the listener to a set of backends specified by the TCPRoute.
+      description: |-
+        TCPRoute provides a way to route TCP requests. When combined with a Gateway
+        listener, it can be used to forward connections on the port specified by the
+        listener to a set of backends specified by the TCPRoute.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -68,159 +74,246 @@ spec:
           description: Spec defines the desired state of TCPRoute.
           properties:
             parentRefs:
-              description: "ParentRefs references the resources (usually Gateways)
-                that a Route wants to be attached to. Note that the referenced parent
-                resource needs to allow this for the attachment to be complete. For
-                Gateways, that means the Gateway needs to allow attachment from Routes
-                of this kind and namespace. For Services, that means the Service must
-                either be in the same namespace for a \"producer\" route, or the mesh
-                implementation must support and allow \"consumer\" routes for the
-                referenced Service. ReferenceGrant is not applicable for governing
-                ParentRefs to Services - it is not possible to create a \"producer\"
-                route for a Service in a different namespace from the Route. \n There
-                are two kinds of parent resources with \"Core\" support: \n * Gateway
-                (Gateway conformance profile)  * Service (Mesh conformance profile,
-                experimental, ClusterIP Services only)  This API may be extended in
-                the future to support additional kinds of parent resources. \n ParentRefs
-                must be _distinct_. This means either that: \n * They select different
-                objects.  If this is the case, then parentRef entries are distinct.
-                In terms of fields, this means that the multi-part key defined by
-                `group`, `kind`, `namespace`, and `name` must be unique across all
-                parentRef entries in the Route. * They do not select different objects,
-                but for each optional field used, each ParentRef that selects the
-                same object must set the same set of optional fields to different
-                values. If one ParentRef sets a combination of optional fields, all
-                must set the same combination. \n Some examples: \n * If one ParentRef
-                sets `sectionName`, all ParentRefs referencing the same object must
-                also set `sectionName`. * If one ParentRef sets `port`, all ParentRefs
-                referencing the same object must also set `port`. * If one ParentRef
-                sets `sectionName` and `port`, all ParentRefs referencing the same
-                object must also set `sectionName` and `port`. \n It is possible to
-                separately reference multiple distinct objects that may be collapsed
-                by an implementation. For example, some implementations may choose
-                to merge compatible Gateway Listeners together. If that is the case,
-                the list of routes attached to those resources should also be merged.
-                \n Note that for ParentRefs that cross namespace boundaries, there
-                are specific rules. Cross-namespace references are only valid if they
-                are explicitly allowed by something in the namespace they are referring
-                to. For example, Gateway has the AllowedRoutes field, and ReferenceGrant
-                provides a generic way to enable other kinds of cross-namespace reference.
-                \n  ParentRefs from a Route to a Service in the same namespace are
-                \"producer\" routes, which apply default routing rules to inbound
-                connections from any namespace to the Service. \n ParentRefs from
-                a Route to a Service in a different namespace are \"consumer\" routes,
-                and these routing rules are only applied to outbound connections originating
-                from the same namespace as the Route, for which the intended destination
-                of the connections are a Service targeted as a ParentRef of the Route.
-                \ \n "
+              description: |+
+                ParentRefs references the resources (usually Gateways) that a Route wants
+                to be attached to. Note that the referenced parent resource needs to
+                allow this for the attachment to be complete. For Gateways, that means
+                the Gateway needs to allow attachment from Routes of this kind and
+                namespace. For Services, that means the Service must either be in the same
+                namespace for a "producer" route, or the mesh implementation must support
+                and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                not applicable for governing ParentRefs to Services - it is not possible to
+                create a "producer" route for a Service in a different namespace from the
+                Route.
+
+
+                There are two kinds of parent resources with "Core" support:
+
+
+                * Gateway (Gateway conformance profile)
+                * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                This API may be extended in the future to support additional kinds of parent
+                resources.
+
+
+                ParentRefs must be _distinct_. This means either that:
+
+
+                * They select different objects.  If this is the case, then parentRef
+                  entries are distinct. In terms of fields, this means that the
+                  multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                  be unique across all parentRef entries in the Route.
+                * They do not select different objects, but for each optional field used,
+                  each ParentRef that selects the same object must set the same set of
+                  optional fields to different values. If one ParentRef sets a
+                  combination of optional fields, all must set the same combination.
+
+
+                Some examples:
+
+
+                * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                  same object must also set `sectionName`.
+                * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`.
+                * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                  referencing the same object must also set `sectionName` and `port`.
+
+
+                It is possible to separately reference multiple distinct objects that may
+                be collapsed by an implementation. For example, some implementations may
+                choose to merge compatible Gateway Listeners together. If that is the
+                case, the list of routes attached to those resources should also be
+                merged.
+
+
+                Note that for ParentRefs that cross namespace boundaries, there are specific
+                rules. Cross-namespace references are only valid if they are explicitly
+                allowed by something in the namespace they are referring to. For example,
+                Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                generic way to enable other kinds of cross-namespace reference.
+
+
+
+                ParentRefs from a Route to a Service in the same namespace are "producer"
+                routes, which apply default routing rules to inbound connections from
+                any namespace to the Service.
+
+
+                ParentRefs from a Route to a Service in a different namespace are
+                "consumer" routes, and these routing rules are only applied to outbound
+                connections originating from the same namespace as the Route, for which
+                the intended destination of the connections are a Service targeted as a
+                ParentRef of the Route.
+
+
+
+
+
+
               items:
-                description: "ParentReference identifies an API object (usually a
-                  Gateway) that can be considered a parent of this resource (usually
-                  a route). There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
-                  API may be extended in the future to support additional kinds of
-                  parent resources. \n The API object must be valid in the cluster;
-                  the Group and Kind must be registered in the cluster for this reference
-                  to be valid."
+                description: |-
+                  ParentReference identifies an API object (usually a Gateway) that can be considered
+                  a parent of this resource (usually a route). There are two kinds of parent resources
+                  with "Core" support:
+
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+
+                  The API object must be valid in the cluster; the Group and Kind must
+                  be registered in the cluster for this reference to be valid.
                 properties:
                   group:
                     default: gateway.networking.k8s.io
-                    description: "Group is the group of the referent. When unspecified,
-                      \"gateway.networking.k8s.io\" is inferred. To set the core API
-                      group (such as for a \"Service\" kind referent), Group must
-                      be explicitly set to \"\" (empty string). \n Support: Core"
+                    description: |-
+                      Group is the group of the referent.
+                      When unspecified, "gateway.networking.k8s.io" is inferred.
+                      To set the core API group (such as for a "Service" kind referent),
+                      Group must be explicitly set to "" (empty string).
+
+
+                      Support: Core
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
                     default: Gateway
-                    description: "Kind is kind of the referent. \n There are two kinds
-                      of parent resources with \"Core\" support: \n * Gateway (Gateway
-                      conformance profile) * Service (Mesh conformance profile, experimental,
-                      ClusterIP Services only) \n Support for other resources is Implementation-Specific."
+                    description: |-
+                      Kind is kind of the referent.
+
+
+                      There are two kinds of parent resources with "Core" support:
+
+
+                      * Gateway (Gateway conformance profile)
+                      * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                      Support for other resources is Implementation-Specific.
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
-                    description: "Name is the name of the referent. \n Support: Core"
+                    description: |-
+                      Name is the name of the referent.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     type: string
                   namespace:
-                    description: "Namespace is the namespace of the referent. When
-                      unspecified, this refers to the local namespace of the Route.
-                      \n Note that there are specific rules for ParentRefs which cross
-                      namespace boundaries. Cross-namespace references are only valid
-                      if they are explicitly allowed by something in the namespace
-                      they are referring to. For example: Gateway has the AllowedRoutes
-                      field, and ReferenceGrant provides a generic way to enable any
-                      other kind of cross-namespace reference. \n  ParentRefs from
-                      a Route to a Service in the same namespace are \"producer\"
-                      routes, which apply default routing rules to inbound connections
-                      from any namespace to the Service. \n ParentRefs from a Route
-                      to a Service in a different namespace are \"consumer\" routes,
-                      and these routing rules are only applied to outbound connections
-                      originating from the same namespace as the Route, for which
-                      the intended destination of the connections are a Service targeted
-                      as a ParentRef of the Route.  \n Support: Core"
+                    description: |-
+                      Namespace is the namespace of the referent. When unspecified, this refers
+                      to the local namespace of the Route.
+
+
+                      Note that there are specific rules for ParentRefs which cross namespace
+                      boundaries. Cross-namespace references are only valid if they are explicitly
+                      allowed by something in the namespace they are referring to. For example:
+                      Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                      generic way to enable any other kind of cross-namespace reference.
+
+
+
+                      ParentRefs from a Route to a Service in the same namespace are "producer"
+                      routes, which apply default routing rules to inbound connections from
+                      any namespace to the Service.
+
+
+                      ParentRefs from a Route to a Service in a different namespace are
+                      "consumer" routes, and these routing rules are only applied to outbound
+                      connections originating from the same namespace as the Route, for which
+                      the intended destination of the connections are a Service targeted as a
+                      ParentRef of the Route.
+
+
+
+                      Support: Core
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   port:
-                    description: "Port is the network port this Route targets. It
-                      can be interpreted differently based on the type of parent resource.
-                      \n When the parent resource is a Gateway, this targets all listeners
-                      listening on the specified port that also support this kind
-                      of Route(and select this Route). It's not recommended to set
-                      `Port` unless the networking behaviors specified in a Route
-                      must apply to a specific port as opposed to a listener(s) whose
-                      port(s) may be changed. When both Port and SectionName are specified,
-                      the name and port of the selected listener must match both specified
-                      values. \n  When the parent resource is a Service, this targets
-                      a specific port in the Service spec. When both Port (experimental)
-                      and SectionName are specified, the name and port of the selected
-                      port must match both specified values.  \n Implementations MAY
-                      choose to support other parent resources. Implementations supporting
-                      other types of parent resources MUST clearly document how/if
-                      Port is interpreted. \n For the purpose of status, an attachment
-                      is considered successful as long as the parent resource accepts
-                      it partially. For example, Gateway listeners can restrict which
-                      Routes can attach to them by Route kind, namespace, or hostname.
-                      If 1 of 2 Gateway listeners accept attachment from the referencing
-                      Route, the Route MUST be considered successfully attached. If
-                      no Gateway listeners accept attachment from this Route, the
-                      Route MUST be considered detached from the Gateway. \n Support:
-                      Extended \n "
+                    description: |-
+                      Port is the network port this Route targets. It can be interpreted
+                      differently based on the type of parent resource.
+
+
+                      When the parent resource is a Gateway, this targets all listeners
+                      listening on the specified port that also support this kind of Route(and
+                      select this Route). It's not recommended to set `Port` unless the
+                      networking behaviors specified in a Route must apply to a specific port
+                      as opposed to a listener(s) whose port(s) may be changed. When both Port
+                      and SectionName are specified, the name and port of the selected listener
+                      must match both specified values.
+
+
+
+                      When the parent resource is a Service, this targets a specific port in the
+                      Service spec. When both Port (experimental) and SectionName are specified,
+                      the name and port of the selected port must match both specified values.
+
+
+
+                      Implementations MAY choose to support other parent resources.
+                      Implementations supporting other types of parent resources MUST clearly
+                      document how/if Port is interpreted.
+
+
+                      For the purpose of status, an attachment is considered successful as
+                      long as the parent resource accepts it partially. For example, Gateway
+                      listeners can restrict which Routes can attach to them by Route kind,
+                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                      from the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this Route,
+                      the Route MUST be considered detached from the Gateway.
+
+
+                      Support: Extended
                     format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer
                   sectionName:
-                    description: "SectionName is the name of a section within the
-                      target resource. In the following resources, SectionName is
-                      interpreted as the following: \n * Gateway: Listener Name. When
-                      both Port (experimental) and SectionName are specified, the
-                      name and port of the selected listener must match both specified
-                      values. * Service: Port Name. When both Port (experimental)
-                      and SectionName are specified, the name and port of the selected
-                      listener must match both specified values. Note that attaching
-                      Routes to Services as Parents is part of experimental Mesh support
-                      and is not supported for any other purpose. \n Implementations
-                      MAY choose to support attaching Routes to other resources. If
-                      that is the case, they MUST clearly document how SectionName
-                      is interpreted. \n When unspecified (empty string), this will
-                      reference the entire resource. For the purpose of status, an
-                      attachment is considered successful if at least one section
-                      in the parent resource accepts it. For example, Gateway listeners
-                      can restrict which Routes can attach to them by Route kind,
-                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
-                      from the referencing Route, the Route MUST be considered successfully
-                      attached. If no Gateway listeners accept attachment from this
-                      Route, the Route MUST be considered detached from the Gateway.
-                      \n Support: Core"
+                    description: |-
+                      SectionName is the name of a section within the target resource. In the
+                      following resources, SectionName is interpreted as the following:
+
+
+                      * Gateway: Listener name. When both Port (experimental) and SectionName
+                      are specified, the name and port of the selected listener must match
+                      both specified values.
+                      * Service: Port name. When both Port (experimental) and SectionName
+                      are specified, the name and port of the selected listener must match
+                      both specified values.
+
+
+                      Implementations MAY choose to support attaching Routes to other resources.
+                      If that is the case, they MUST clearly document how SectionName is
+                      interpreted.
+
+
+                      When unspecified (empty string), this will reference the entire resource.
+                      For the purpose of status, an attachment is considered successful if at
+                      least one section in the parent resource accepts it. For example, Gateway
+                      listeners can restrict which Routes can attach to them by Route kind,
+                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                      the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this Route, the
+                      Route MUST be considered detached from the Gateway.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -258,60 +351,94 @@ spec:
                 description: TCPRouteRule is the configuration for a given rule.
                 properties:
                   backendRefs:
-                    description: "BackendRefs defines the backend(s) where matching
-                      requests should be sent. If unspecified or invalid (refers to
-                      a non-existent resource or a Service with no endpoints), the
-                      underlying implementation MUST actively reject connection attempts
-                      to this backend. Connection rejections must respect weight;
-                      if an invalid backend is requested to have 80% of connections,
-                      then 80% of connections must be rejected instead. \n Support:
-                      Core for Kubernetes Service \n Support: Extended for Kubernetes
-                      ServiceImport \n Support: Implementation-specific for any other
-                      resource \n Support for weight: Extended"
+                    description: |-
+                      BackendRefs defines the backend(s) where matching requests should be
+                      sent. If unspecified or invalid (refers to a non-existent resource or a
+                      Service with no endpoints), the underlying implementation MUST actively
+                      reject connection attempts to this backend. Connection rejections must
+                      respect weight; if an invalid backend is requested to have 80% of
+                      connections, then 80% of connections must be rejected instead.
+
+
+                      Support: Core for Kubernetes Service
+
+
+                      Support: Extended for Kubernetes ServiceImport
+
+
+                      Support: Implementation-specific for any other resource
+
+
+                      Support for weight: Extended
                     items:
-                      description: "BackendRef defines how a Route should forward
-                        a request to a Kubernetes resource. \n Note that when a namespace
-                        different than the local namespace is specified, a ReferenceGrant
-                        object is required in the referent namespace to allow that
+                      description: |-
+                        BackendRef defines how a Route should forward a request to a Kubernetes
+                        resource.
+
+
+                        Note that when a namespace different than the local namespace is specified, a
+                        ReferenceGrant object is required in the referent namespace to allow that
                         namespace's owner to accept the reference. See the ReferenceGrant
-                        documentation for details. \n <gateway:experimental:description>
-                        \n When the BackendRef points to a Kubernetes Service, implementations
-                        SHOULD honor the appProtocol field if it is set for the target
-                        Service Port. \n Implementations supporting appProtocol SHOULD
-                        recognize the Kubernetes Standard Application Protocols defined
-                        in KEP-3726. \n If a Service appProtocol isn't specified,
-                        an implementation MAY infer the backend protocol through its
-                        own means. Implementations MAY infer the protocol from the
-                        Route type referring to the backend Service. \n If a Route
-                        is not able to send traffic to the backend using the specified
-                        protocol then the backend is considered invalid. Implementations
-                        MUST set the \"ResolvedRefs\" condition to \"False\" with
-                        the \"UnsupportedProtocol\" reason. \n </gateway:experimental:description>
-                        \n Note that when the BackendTLSPolicy object is enabled by
-                        the implementation, there are some extra rules about validity
-                        to consider here. See the fields where this struct is used
-                        for more information about the exact behavior."
+                        documentation for details.
+
+
+                        <gateway:experimental:description>
+
+
+                        When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                        honor the appProtocol field if it is set for the target Service Port.
+
+
+                        Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                        Standard Application Protocols defined in KEP-3726.
+
+
+                        If a Service appProtocol isn't specified, an implementation MAY infer the
+                        backend protocol through its own means. Implementations MAY infer the
+                        protocol from the Route type referring to the backend Service.
+
+
+                        If a Route is not able to send traffic to the backend using the specified
+                        protocol then the backend is considered invalid. Implementations MUST set the
+                        "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                        </gateway:experimental:description>
+
+
+                        Note that when the BackendTLSPolicy object is enabled by the implementation,
+                        there are some extra rules about validity to consider here. See the fields
+                        where this struct is used for more information about the exact behavior.
                       properties:
                         group:
                           default: ""
-                          description: Group is the group of the referent. For example,
-                            "gateway.networking.k8s.io". When unspecified or empty
-                            string, core API group is inferred.
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Service
-                          description: "Kind is the Kubernetes resource kind of the
-                            referent. For example \"Service\". \n Defaults to \"Service\"
-                            when not specified. \n ExternalName services can refer
-                            to CNAME DNS records that may live outside of the cluster
-                            and as such are difficult to reason about in terms of
-                            conformance. They also may not be safe to forward to (see
-                            CVE-2021-25740 for more information). Implementations
-                            SHOULD NOT support ExternalName Services. \n Support:
-                            Core (Services with a type other than ExternalName) \n
-                            Support: Implementation-specific (Services with type ExternalName)"
+                          description: |-
+                            Kind is the Kubernetes resource kind of the referent. For example
+                            "Service".
+
+
+                            Defaults to "Service" when not specified.
+
+
+                            ExternalName services can refer to CNAME DNS records that may live
+                            outside of the cluster and as such are difficult to reason about in
+                            terms of conformance. They also may not be safe to forward to (see
+                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                            support ExternalName Services.
+
+
+                            Support: Core (Services with a type other than ExternalName)
+
+
+                            Support: Implementation-specific (Services with type ExternalName)
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -322,43 +449,51 @@ spec:
                           minLength: 1
                           type: string
                         namespace:
-                          description: "Namespace is the namespace of the backend.
-                            When unspecified, the local namespace is inferred. \n
-                            Note that when a namespace different than the local namespace
-                            is specified, a ReferenceGrant object is required in the
-                            referent namespace to allow that namespace's owner to
-                            accept the reference. See the ReferenceGrant documentation
-                            for details. \n Support: Core"
+                          description: |-
+                            Namespace is the namespace of the backend. When unspecified, the local
+                            namespace is inferred.
+
+
+                            Note that when a namespace different than the local namespace is specified,
+                            a ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            Support: Core
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: Port specifies the destination port number
-                            to use for this resource. Port is required when the referent
-                            is a Kubernetes Service. In this case, the port number
-                            is the service port number, not the target port. For other
-                            resources, destination port might be derived from the
-                            referent resource or this field.
+                          description: |-
+                            Port specifies the destination port number to use for this resource.
+                            Port is required when the referent is a Kubernetes Service. In this
+                            case, the port number is the service port number, not the target port.
+                            For other resources, destination port might be derived from the referent
+                            resource or this field.
                           format: int32
                           maximum: 65535
                           minimum: 1
                           type: integer
                         weight:
                           default: 1
-                          description: "Weight specifies the proportion of requests
-                            forwarded to the referenced backend. This is computed
-                            as weight/(sum of all weights in this BackendRefs list).
-                            For non-zero values, there may be some epsilon from the
-                            exact proportion defined here depending on the precision
-                            an implementation supports. Weight is not a percentage
-                            and the sum of weights does not need to equal 100. \n
-                            If only one backend is specified and it has a weight greater
-                            than 0, 100% of the traffic is forwarded to that backend.
-                            If weight is set to 0, no traffic should be forwarded
-                            for this entry. If unspecified, weight defaults to 1.
-                            \n Support for this field varies based on the context
-                            where used."
+                          description: |-
+                            Weight specifies the proportion of requests forwarded to the referenced
+                            backend. This is computed as weight/(sum of all weights in this
+                            BackendRefs list). For non-zero values, there may be some epsilon from
+                            the exact proportion defined here depending on the precision an
+                            implementation supports. Weight is not a percentage and the sum of
+                            weights does not need to equal 100.
+
+
+                            If only one backend is specified and it has a weight greater than 0, 100%
+                            of the traffic is forwarded to that backend. If weight is set to 0, no
+                            traffic should be forwarded for this entry. If unspecified, weight
+                            defaults to 1.
+
+
+                            Support for this field varies based on the context where used.
                           format: int32
                           maximum: 1000000
                           minimum: 0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/tlsroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/tlsroutes.yaml
@@ -17,20 +17,29 @@ spec:
     version: v1alpha2
   validation:
     openAPIV3Schema:
-      description: "The TLSRoute resource is similar to TCPRoute, but can be configured
-        to match against TLS-specific metadata. This allows more flexibility in matching
-        streams for a given TLS listener. \n If you need to forward traffic to a single
-        target for a TLS listener, you could choose to use a TCPRoute with a TLS listener."
+      description: |-
+        The TLSRoute resource is similar to TCPRoute, but can be configured
+        to match against TLS-specific metadata. This allows more flexibility
+        in matching streams for a given TLS listener.
+
+
+        If you need to forward traffic to a single target for a TLS listener, you
+        could choose to use a TCPRoute with a TLS listener.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -69,43 +78,65 @@ spec:
           description: Spec defines the desired state of TLSRoute.
           properties:
             hostnames:
-              description: "Hostnames defines a set of SNI names that should match
-                against the SNI attribute of TLS ClientHello message in TLS handshake.
-                This matches the RFC 1123 definition of a hostname with 2 notable
-                exceptions: \n 1. IPs are not allowed in SNI names per RFC 6066. 2.
-                A hostname may be prefixed with a wildcard label (`*.`). The wildcard
-                label must appear by itself as the first label. \n If a hostname is
-                specified by both the Listener and TLSRoute, there must be at least
-                one intersecting hostname for the TLSRoute to be attached to the Listener.
-                For example: \n * A Listener with `test.example.com` as the hostname
-                matches TLSRoutes that have either not specified any hostnames, or
-                have specified at least one of `test.example.com` or `*.example.com`.
+              description: |-
+                Hostnames defines a set of SNI names that should match against the
+                SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                1. IPs are not allowed in SNI names per RFC 6066.
+                2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                   label must appear by itself as the first label.
+
+
+                If a hostname is specified by both the Listener and TLSRoute, there
+                must be at least one intersecting hostname for the TLSRoute to be
+                attached to the Listener. For example:
+
+
+                * A Listener with `test.example.com` as the hostname matches TLSRoutes
+                  that have either not specified any hostnames, or have specified at
+                  least one of `test.example.com` or `*.example.com`.
                 * A Listener with `*.example.com` as the hostname matches TLSRoutes
-                that have either not specified any hostnames or have specified at
-                least one hostname that matches the Listener hostname. For example,
-                `test.example.com` and `*.example.com` would both match. On the other
-                hand, `example.com` and `test.example.net` would not match. \n If
-                both the Listener and TLSRoute have specified hostnames, any TLSRoute
-                hostnames that do not match the Listener hostname MUST be ignored.
-                For example, if a Listener specified `*.example.com`, and the TLSRoute
-                specified `test.example.com` and `test.example.net`, `test.example.net`
-                must not be considered for a match. \n If both the Listener and TLSRoute
-                have specified hostnames, and none match with the criteria above,
-                then the TLSRoute is not accepted. The implementation must raise an
-                'Accepted' Condition with a status of `False` in the corresponding
-                RouteParentStatus. \n Support: Core"
+                  that have either not specified any hostnames or have specified at least
+                  one hostname that matches the Listener hostname. For example,
+                  `test.example.com` and `*.example.com` would both match. On the other
+                  hand, `example.com` and `test.example.net` would not match.
+
+
+                If both the Listener and TLSRoute have specified hostnames, any
+                TLSRoute hostnames that do not match the Listener hostname MUST be
+                ignored. For example, if a Listener specified `*.example.com`, and the
+                TLSRoute specified `test.example.com` and `test.example.net`,
+                `test.example.net` must not be considered for a match.
+
+
+                If both the Listener and TLSRoute have specified hostnames, and none
+                match with the criteria above, then the TLSRoute is not accepted. The
+                implementation must raise an 'Accepted' Condition with a status of
+                `False` in the corresponding RouteParentStatus.
+
+
+                Support: Core
               items:
-                description: "Hostname is the fully qualified domain name of a network
-                  host. This matches the RFC 1123 definition of a hostname with 2
-                  notable exceptions: \n 1. IPs are not allowed. 2. A hostname may
-                  be prefixed with a wildcard label (`*.`). The wildcard label must
-                  appear by itself as the first label. \n Hostname can be \"precise\"
-                  which is a domain name without the terminating dot of a network
-                  host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
-                  name prefixed with a single wildcard label (e.g. `*.example.com`).
-                  \n Note that as per RFC1035 and RFC1123, a *label* must consist
-                  of lower case alphanumeric characters or '-', and must start and
-                  end with an alphanumeric character. No other punctuation is allowed."
+                description: |-
+                  Hostname is the fully qualified domain name of a network host. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                   1. IPs are not allowed.
+                   2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                      label must appear by itself as the first label.
+
+
+                  Hostname can be "precise" which is a domain name without the terminating
+                  dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                  domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                  Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                  alphanumeric characters or '-', and must start and end with an alphanumeric
+                  character. No other punctuation is allowed.
                 maxLength: 253
                 minLength: 1
                 pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -113,159 +144,246 @@ spec:
               maxItems: 16
               type: array
             parentRefs:
-              description: "ParentRefs references the resources (usually Gateways)
-                that a Route wants to be attached to. Note that the referenced parent
-                resource needs to allow this for the attachment to be complete. For
-                Gateways, that means the Gateway needs to allow attachment from Routes
-                of this kind and namespace. For Services, that means the Service must
-                either be in the same namespace for a \"producer\" route, or the mesh
-                implementation must support and allow \"consumer\" routes for the
-                referenced Service. ReferenceGrant is not applicable for governing
-                ParentRefs to Services - it is not possible to create a \"producer\"
-                route for a Service in a different namespace from the Route. \n There
-                are two kinds of parent resources with \"Core\" support: \n * Gateway
-                (Gateway conformance profile)  * Service (Mesh conformance profile,
-                experimental, ClusterIP Services only)  This API may be extended in
-                the future to support additional kinds of parent resources. \n ParentRefs
-                must be _distinct_. This means either that: \n * They select different
-                objects.  If this is the case, then parentRef entries are distinct.
-                In terms of fields, this means that the multi-part key defined by
-                `group`, `kind`, `namespace`, and `name` must be unique across all
-                parentRef entries in the Route. * They do not select different objects,
-                but for each optional field used, each ParentRef that selects the
-                same object must set the same set of optional fields to different
-                values. If one ParentRef sets a combination of optional fields, all
-                must set the same combination. \n Some examples: \n * If one ParentRef
-                sets `sectionName`, all ParentRefs referencing the same object must
-                also set `sectionName`. * If one ParentRef sets `port`, all ParentRefs
-                referencing the same object must also set `port`. * If one ParentRef
-                sets `sectionName` and `port`, all ParentRefs referencing the same
-                object must also set `sectionName` and `port`. \n It is possible to
-                separately reference multiple distinct objects that may be collapsed
-                by an implementation. For example, some implementations may choose
-                to merge compatible Gateway Listeners together. If that is the case,
-                the list of routes attached to those resources should also be merged.
-                \n Note that for ParentRefs that cross namespace boundaries, there
-                are specific rules. Cross-namespace references are only valid if they
-                are explicitly allowed by something in the namespace they are referring
-                to. For example, Gateway has the AllowedRoutes field, and ReferenceGrant
-                provides a generic way to enable other kinds of cross-namespace reference.
-                \n  ParentRefs from a Route to a Service in the same namespace are
-                \"producer\" routes, which apply default routing rules to inbound
-                connections from any namespace to the Service. \n ParentRefs from
-                a Route to a Service in a different namespace are \"consumer\" routes,
-                and these routing rules are only applied to outbound connections originating
-                from the same namespace as the Route, for which the intended destination
-                of the connections are a Service targeted as a ParentRef of the Route.
-                \ \n "
+              description: |+
+                ParentRefs references the resources (usually Gateways) that a Route wants
+                to be attached to. Note that the referenced parent resource needs to
+                allow this for the attachment to be complete. For Gateways, that means
+                the Gateway needs to allow attachment from Routes of this kind and
+                namespace. For Services, that means the Service must either be in the same
+                namespace for a "producer" route, or the mesh implementation must support
+                and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                not applicable for governing ParentRefs to Services - it is not possible to
+                create a "producer" route for a Service in a different namespace from the
+                Route.
+
+
+                There are two kinds of parent resources with "Core" support:
+
+
+                * Gateway (Gateway conformance profile)
+                * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                This API may be extended in the future to support additional kinds of parent
+                resources.
+
+
+                ParentRefs must be _distinct_. This means either that:
+
+
+                * They select different objects.  If this is the case, then parentRef
+                  entries are distinct. In terms of fields, this means that the
+                  multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                  be unique across all parentRef entries in the Route.
+                * They do not select different objects, but for each optional field used,
+                  each ParentRef that selects the same object must set the same set of
+                  optional fields to different values. If one ParentRef sets a
+                  combination of optional fields, all must set the same combination.
+
+
+                Some examples:
+
+
+                * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                  same object must also set `sectionName`.
+                * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`.
+                * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                  referencing the same object must also set `sectionName` and `port`.
+
+
+                It is possible to separately reference multiple distinct objects that may
+                be collapsed by an implementation. For example, some implementations may
+                choose to merge compatible Gateway Listeners together. If that is the
+                case, the list of routes attached to those resources should also be
+                merged.
+
+
+                Note that for ParentRefs that cross namespace boundaries, there are specific
+                rules. Cross-namespace references are only valid if they are explicitly
+                allowed by something in the namespace they are referring to. For example,
+                Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                generic way to enable other kinds of cross-namespace reference.
+
+
+
+                ParentRefs from a Route to a Service in the same namespace are "producer"
+                routes, which apply default routing rules to inbound connections from
+                any namespace to the Service.
+
+
+                ParentRefs from a Route to a Service in a different namespace are
+                "consumer" routes, and these routing rules are only applied to outbound
+                connections originating from the same namespace as the Route, for which
+                the intended destination of the connections are a Service targeted as a
+                ParentRef of the Route.
+
+
+
+
+
+
               items:
-                description: "ParentReference identifies an API object (usually a
-                  Gateway) that can be considered a parent of this resource (usually
-                  a route). There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
-                  API may be extended in the future to support additional kinds of
-                  parent resources. \n The API object must be valid in the cluster;
-                  the Group and Kind must be registered in the cluster for this reference
-                  to be valid."
+                description: |-
+                  ParentReference identifies an API object (usually a Gateway) that can be considered
+                  a parent of this resource (usually a route). There are two kinds of parent resources
+                  with "Core" support:
+
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+
+                  The API object must be valid in the cluster; the Group and Kind must
+                  be registered in the cluster for this reference to be valid.
                 properties:
                   group:
                     default: gateway.networking.k8s.io
-                    description: "Group is the group of the referent. When unspecified,
-                      \"gateway.networking.k8s.io\" is inferred. To set the core API
-                      group (such as for a \"Service\" kind referent), Group must
-                      be explicitly set to \"\" (empty string). \n Support: Core"
+                    description: |-
+                      Group is the group of the referent.
+                      When unspecified, "gateway.networking.k8s.io" is inferred.
+                      To set the core API group (such as for a "Service" kind referent),
+                      Group must be explicitly set to "" (empty string).
+
+
+                      Support: Core
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
                     default: Gateway
-                    description: "Kind is kind of the referent. \n There are two kinds
-                      of parent resources with \"Core\" support: \n * Gateway (Gateway
-                      conformance profile) * Service (Mesh conformance profile, experimental,
-                      ClusterIP Services only) \n Support for other resources is Implementation-Specific."
+                    description: |-
+                      Kind is kind of the referent.
+
+
+                      There are two kinds of parent resources with "Core" support:
+
+
+                      * Gateway (Gateway conformance profile)
+                      * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                      Support for other resources is Implementation-Specific.
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
-                    description: "Name is the name of the referent. \n Support: Core"
+                    description: |-
+                      Name is the name of the referent.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     type: string
                   namespace:
-                    description: "Namespace is the namespace of the referent. When
-                      unspecified, this refers to the local namespace of the Route.
-                      \n Note that there are specific rules for ParentRefs which cross
-                      namespace boundaries. Cross-namespace references are only valid
-                      if they are explicitly allowed by something in the namespace
-                      they are referring to. For example: Gateway has the AllowedRoutes
-                      field, and ReferenceGrant provides a generic way to enable any
-                      other kind of cross-namespace reference. \n  ParentRefs from
-                      a Route to a Service in the same namespace are \"producer\"
-                      routes, which apply default routing rules to inbound connections
-                      from any namespace to the Service. \n ParentRefs from a Route
-                      to a Service in a different namespace are \"consumer\" routes,
-                      and these routing rules are only applied to outbound connections
-                      originating from the same namespace as the Route, for which
-                      the intended destination of the connections are a Service targeted
-                      as a ParentRef of the Route.  \n Support: Core"
+                    description: |-
+                      Namespace is the namespace of the referent. When unspecified, this refers
+                      to the local namespace of the Route.
+
+
+                      Note that there are specific rules for ParentRefs which cross namespace
+                      boundaries. Cross-namespace references are only valid if they are explicitly
+                      allowed by something in the namespace they are referring to. For example:
+                      Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                      generic way to enable any other kind of cross-namespace reference.
+
+
+
+                      ParentRefs from a Route to a Service in the same namespace are "producer"
+                      routes, which apply default routing rules to inbound connections from
+                      any namespace to the Service.
+
+
+                      ParentRefs from a Route to a Service in a different namespace are
+                      "consumer" routes, and these routing rules are only applied to outbound
+                      connections originating from the same namespace as the Route, for which
+                      the intended destination of the connections are a Service targeted as a
+                      ParentRef of the Route.
+
+
+
+                      Support: Core
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   port:
-                    description: "Port is the network port this Route targets. It
-                      can be interpreted differently based on the type of parent resource.
-                      \n When the parent resource is a Gateway, this targets all listeners
-                      listening on the specified port that also support this kind
-                      of Route(and select this Route). It's not recommended to set
-                      `Port` unless the networking behaviors specified in a Route
-                      must apply to a specific port as opposed to a listener(s) whose
-                      port(s) may be changed. When both Port and SectionName are specified,
-                      the name and port of the selected listener must match both specified
-                      values. \n  When the parent resource is a Service, this targets
-                      a specific port in the Service spec. When both Port (experimental)
-                      and SectionName are specified, the name and port of the selected
-                      port must match both specified values.  \n Implementations MAY
-                      choose to support other parent resources. Implementations supporting
-                      other types of parent resources MUST clearly document how/if
-                      Port is interpreted. \n For the purpose of status, an attachment
-                      is considered successful as long as the parent resource accepts
-                      it partially. For example, Gateway listeners can restrict which
-                      Routes can attach to them by Route kind, namespace, or hostname.
-                      If 1 of 2 Gateway listeners accept attachment from the referencing
-                      Route, the Route MUST be considered successfully attached. If
-                      no Gateway listeners accept attachment from this Route, the
-                      Route MUST be considered detached from the Gateway. \n Support:
-                      Extended \n "
+                    description: |-
+                      Port is the network port this Route targets. It can be interpreted
+                      differently based on the type of parent resource.
+
+
+                      When the parent resource is a Gateway, this targets all listeners
+                      listening on the specified port that also support this kind of Route(and
+                      select this Route). It's not recommended to set `Port` unless the
+                      networking behaviors specified in a Route must apply to a specific port
+                      as opposed to a listener(s) whose port(s) may be changed. When both Port
+                      and SectionName are specified, the name and port of the selected listener
+                      must match both specified values.
+
+
+
+                      When the parent resource is a Service, this targets a specific port in the
+                      Service spec. When both Port (experimental) and SectionName are specified,
+                      the name and port of the selected port must match both specified values.
+
+
+
+                      Implementations MAY choose to support other parent resources.
+                      Implementations supporting other types of parent resources MUST clearly
+                      document how/if Port is interpreted.
+
+
+                      For the purpose of status, an attachment is considered successful as
+                      long as the parent resource accepts it partially. For example, Gateway
+                      listeners can restrict which Routes can attach to them by Route kind,
+                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                      from the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this Route,
+                      the Route MUST be considered detached from the Gateway.
+
+
+                      Support: Extended
                     format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer
                   sectionName:
-                    description: "SectionName is the name of a section within the
-                      target resource. In the following resources, SectionName is
-                      interpreted as the following: \n * Gateway: Listener Name. When
-                      both Port (experimental) and SectionName are specified, the
-                      name and port of the selected listener must match both specified
-                      values. * Service: Port Name. When both Port (experimental)
-                      and SectionName are specified, the name and port of the selected
-                      listener must match both specified values. Note that attaching
-                      Routes to Services as Parents is part of experimental Mesh support
-                      and is not supported for any other purpose. \n Implementations
-                      MAY choose to support attaching Routes to other resources. If
-                      that is the case, they MUST clearly document how SectionName
-                      is interpreted. \n When unspecified (empty string), this will
-                      reference the entire resource. For the purpose of status, an
-                      attachment is considered successful if at least one section
-                      in the parent resource accepts it. For example, Gateway listeners
-                      can restrict which Routes can attach to them by Route kind,
-                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
-                      from the referencing Route, the Route MUST be considered successfully
-                      attached. If no Gateway listeners accept attachment from this
-                      Route, the Route MUST be considered detached from the Gateway.
-                      \n Support: Core"
+                    description: |-
+                      SectionName is the name of a section within the target resource. In the
+                      following resources, SectionName is interpreted as the following:
+
+
+                      * Gateway: Listener name. When both Port (experimental) and SectionName
+                      are specified, the name and port of the selected listener must match
+                      both specified values.
+                      * Service: Port name. When both Port (experimental) and SectionName
+                      are specified, the name and port of the selected listener must match
+                      both specified values.
+
+
+                      Implementations MAY choose to support attaching Routes to other resources.
+                      If that is the case, they MUST clearly document how SectionName is
+                      interpreted.
+
+
+                      When unspecified (empty string), this will reference the entire resource.
+                      For the purpose of status, an attachment is considered successful if at
+                      least one section in the parent resource accepts it. For example, Gateway
+                      listeners can restrict which Routes can attach to them by Route kind,
+                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                      the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this Route, the
+                      Route MUST be considered detached from the Gateway.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -303,62 +421,97 @@ spec:
                 description: TLSRouteRule is the configuration for a given rule.
                 properties:
                   backendRefs:
-                    description: "BackendRefs defines the backend(s) where matching
-                      requests should be sent. If unspecified or invalid (refers to
-                      a non-existent resource or a Service with no endpoints), the
-                      rule performs no forwarding; if no filters are specified that
-                      would result in a response being sent, the underlying implementation
-                      must actively reject request attempts to this backend, by rejecting
-                      the connection or returning a 500 status code. Request rejections
-                      must respect weight; if an invalid backend is requested to have
-                      80% of requests, then 80% of requests must be rejected instead.
-                      \n Support: Core for Kubernetes Service \n Support: Extended
-                      for Kubernetes ServiceImport \n Support: Implementation-specific
-                      for any other resource \n Support for weight: Extended"
+                    description: |-
+                      BackendRefs defines the backend(s) where matching requests should be
+                      sent. If unspecified or invalid (refers to a non-existent resource or
+                      a Service with no endpoints), the rule performs no forwarding; if no
+                      filters are specified that would result in a response being sent, the
+                      underlying implementation must actively reject request attempts to this
+                      backend, by rejecting the connection or returning a 500 status code.
+                      Request rejections must respect weight; if an invalid backend is
+                      requested to have 80% of requests, then 80% of requests must be rejected
+                      instead.
+
+
+                      Support: Core for Kubernetes Service
+
+
+                      Support: Extended for Kubernetes ServiceImport
+
+
+                      Support: Implementation-specific for any other resource
+
+
+                      Support for weight: Extended
                     items:
-                      description: "BackendRef defines how a Route should forward
-                        a request to a Kubernetes resource. \n Note that when a namespace
-                        different than the local namespace is specified, a ReferenceGrant
-                        object is required in the referent namespace to allow that
+                      description: |-
+                        BackendRef defines how a Route should forward a request to a Kubernetes
+                        resource.
+
+
+                        Note that when a namespace different than the local namespace is specified, a
+                        ReferenceGrant object is required in the referent namespace to allow that
                         namespace's owner to accept the reference. See the ReferenceGrant
-                        documentation for details. \n <gateway:experimental:description>
-                        \n When the BackendRef points to a Kubernetes Service, implementations
-                        SHOULD honor the appProtocol field if it is set for the target
-                        Service Port. \n Implementations supporting appProtocol SHOULD
-                        recognize the Kubernetes Standard Application Protocols defined
-                        in KEP-3726. \n If a Service appProtocol isn't specified,
-                        an implementation MAY infer the backend protocol through its
-                        own means. Implementations MAY infer the protocol from the
-                        Route type referring to the backend Service. \n If a Route
-                        is not able to send traffic to the backend using the specified
-                        protocol then the backend is considered invalid. Implementations
-                        MUST set the \"ResolvedRefs\" condition to \"False\" with
-                        the \"UnsupportedProtocol\" reason. \n </gateway:experimental:description>
-                        \n Note that when the BackendTLSPolicy object is enabled by
-                        the implementation, there are some extra rules about validity
-                        to consider here. See the fields where this struct is used
-                        for more information about the exact behavior."
+                        documentation for details.
+
+
+                        <gateway:experimental:description>
+
+
+                        When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                        honor the appProtocol field if it is set for the target Service Port.
+
+
+                        Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                        Standard Application Protocols defined in KEP-3726.
+
+
+                        If a Service appProtocol isn't specified, an implementation MAY infer the
+                        backend protocol through its own means. Implementations MAY infer the
+                        protocol from the Route type referring to the backend Service.
+
+
+                        If a Route is not able to send traffic to the backend using the specified
+                        protocol then the backend is considered invalid. Implementations MUST set the
+                        "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                        </gateway:experimental:description>
+
+
+                        Note that when the BackendTLSPolicy object is enabled by the implementation,
+                        there are some extra rules about validity to consider here. See the fields
+                        where this struct is used for more information about the exact behavior.
                       properties:
                         group:
                           default: ""
-                          description: Group is the group of the referent. For example,
-                            "gateway.networking.k8s.io". When unspecified or empty
-                            string, core API group is inferred.
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Service
-                          description: "Kind is the Kubernetes resource kind of the
-                            referent. For example \"Service\". \n Defaults to \"Service\"
-                            when not specified. \n ExternalName services can refer
-                            to CNAME DNS records that may live outside of the cluster
-                            and as such are difficult to reason about in terms of
-                            conformance. They also may not be safe to forward to (see
-                            CVE-2021-25740 for more information). Implementations
-                            SHOULD NOT support ExternalName Services. \n Support:
-                            Core (Services with a type other than ExternalName) \n
-                            Support: Implementation-specific (Services with type ExternalName)"
+                          description: |-
+                            Kind is the Kubernetes resource kind of the referent. For example
+                            "Service".
+
+
+                            Defaults to "Service" when not specified.
+
+
+                            ExternalName services can refer to CNAME DNS records that may live
+                            outside of the cluster and as such are difficult to reason about in
+                            terms of conformance. They also may not be safe to forward to (see
+                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                            support ExternalName Services.
+
+
+                            Support: Core (Services with a type other than ExternalName)
+
+
+                            Support: Implementation-specific (Services with type ExternalName)
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -369,43 +522,51 @@ spec:
                           minLength: 1
                           type: string
                         namespace:
-                          description: "Namespace is the namespace of the backend.
-                            When unspecified, the local namespace is inferred. \n
-                            Note that when a namespace different than the local namespace
-                            is specified, a ReferenceGrant object is required in the
-                            referent namespace to allow that namespace's owner to
-                            accept the reference. See the ReferenceGrant documentation
-                            for details. \n Support: Core"
+                          description: |-
+                            Namespace is the namespace of the backend. When unspecified, the local
+                            namespace is inferred.
+
+
+                            Note that when a namespace different than the local namespace is specified,
+                            a ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            Support: Core
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: Port specifies the destination port number
-                            to use for this resource. Port is required when the referent
-                            is a Kubernetes Service. In this case, the port number
-                            is the service port number, not the target port. For other
-                            resources, destination port might be derived from the
-                            referent resource or this field.
+                          description: |-
+                            Port specifies the destination port number to use for this resource.
+                            Port is required when the referent is a Kubernetes Service. In this
+                            case, the port number is the service port number, not the target port.
+                            For other resources, destination port might be derived from the referent
+                            resource or this field.
                           format: int32
                           maximum: 65535
                           minimum: 1
                           type: integer
                         weight:
                           default: 1
-                          description: "Weight specifies the proportion of requests
-                            forwarded to the referenced backend. This is computed
-                            as weight/(sum of all weights in this BackendRefs list).
-                            For non-zero values, there may be some epsilon from the
-                            exact proportion defined here depending on the precision
-                            an implementation supports. Weight is not a percentage
-                            and the sum of weights does not need to equal 100. \n
-                            If only one backend is specified and it has a weight greater
-                            than 0, 100% of the traffic is forwarded to that backend.
-                            If weight is set to 0, no traffic should be forwarded
-                            for this entry. If unspecified, weight defaults to 1.
-                            \n Support for this field varies based on the context
-                            where used."
+                          description: |-
+                            Weight specifies the proportion of requests forwarded to the referenced
+                            backend. This is computed as weight/(sum of all weights in this
+                            BackendRefs list). For non-zero values, there may be some epsilon from
+                            the exact proportion defined here depending on the precision an
+                            implementation supports. Weight is not a percentage and the sum of
+                            weights does not need to equal 100.
+
+
+                            If only one backend is specified and it has a weight greater than 0, 100%
+                            of the traffic is forwarded to that backend. If weight is set to 0, no
+                            traffic should be forwarded for this entry. If unspecified, weight
+                            defaults to 1.
+
+
+                            Support for this field varies based on the context where used.
                           format: int32
                           maximum: 1000000
                           minimum: 0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/udproutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha2/udproutes.yaml
@@ -17,19 +17,25 @@ spec:
     version: v1alpha2
   validation:
     openAPIV3Schema:
-      description: UDPRoute provides a way to route UDP traffic. When combined with
-        a Gateway listener, it can be used to forward traffic on the port specified
-        by the listener to a set of backends specified by the UDPRoute.
+      description: |-
+        UDPRoute provides a way to route UDP traffic. When combined with a Gateway
+        listener, it can be used to forward traffic on the port specified by the
+        listener to a set of backends specified by the UDPRoute.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -68,159 +74,246 @@ spec:
           description: Spec defines the desired state of UDPRoute.
           properties:
             parentRefs:
-              description: "ParentRefs references the resources (usually Gateways)
-                that a Route wants to be attached to. Note that the referenced parent
-                resource needs to allow this for the attachment to be complete. For
-                Gateways, that means the Gateway needs to allow attachment from Routes
-                of this kind and namespace. For Services, that means the Service must
-                either be in the same namespace for a \"producer\" route, or the mesh
-                implementation must support and allow \"consumer\" routes for the
-                referenced Service. ReferenceGrant is not applicable for governing
-                ParentRefs to Services - it is not possible to create a \"producer\"
-                route for a Service in a different namespace from the Route. \n There
-                are two kinds of parent resources with \"Core\" support: \n * Gateway
-                (Gateway conformance profile)  * Service (Mesh conformance profile,
-                experimental, ClusterIP Services only)  This API may be extended in
-                the future to support additional kinds of parent resources. \n ParentRefs
-                must be _distinct_. This means either that: \n * They select different
-                objects.  If this is the case, then parentRef entries are distinct.
-                In terms of fields, this means that the multi-part key defined by
-                `group`, `kind`, `namespace`, and `name` must be unique across all
-                parentRef entries in the Route. * They do not select different objects,
-                but for each optional field used, each ParentRef that selects the
-                same object must set the same set of optional fields to different
-                values. If one ParentRef sets a combination of optional fields, all
-                must set the same combination. \n Some examples: \n * If one ParentRef
-                sets `sectionName`, all ParentRefs referencing the same object must
-                also set `sectionName`. * If one ParentRef sets `port`, all ParentRefs
-                referencing the same object must also set `port`. * If one ParentRef
-                sets `sectionName` and `port`, all ParentRefs referencing the same
-                object must also set `sectionName` and `port`. \n It is possible to
-                separately reference multiple distinct objects that may be collapsed
-                by an implementation. For example, some implementations may choose
-                to merge compatible Gateway Listeners together. If that is the case,
-                the list of routes attached to those resources should also be merged.
-                \n Note that for ParentRefs that cross namespace boundaries, there
-                are specific rules. Cross-namespace references are only valid if they
-                are explicitly allowed by something in the namespace they are referring
-                to. For example, Gateway has the AllowedRoutes field, and ReferenceGrant
-                provides a generic way to enable other kinds of cross-namespace reference.
-                \n  ParentRefs from a Route to a Service in the same namespace are
-                \"producer\" routes, which apply default routing rules to inbound
-                connections from any namespace to the Service. \n ParentRefs from
-                a Route to a Service in a different namespace are \"consumer\" routes,
-                and these routing rules are only applied to outbound connections originating
-                from the same namespace as the Route, for which the intended destination
-                of the connections are a Service targeted as a ParentRef of the Route.
-                \ \n "
+              description: |+
+                ParentRefs references the resources (usually Gateways) that a Route wants
+                to be attached to. Note that the referenced parent resource needs to
+                allow this for the attachment to be complete. For Gateways, that means
+                the Gateway needs to allow attachment from Routes of this kind and
+                namespace. For Services, that means the Service must either be in the same
+                namespace for a "producer" route, or the mesh implementation must support
+                and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                not applicable for governing ParentRefs to Services - it is not possible to
+                create a "producer" route for a Service in a different namespace from the
+                Route.
+
+
+                There are two kinds of parent resources with "Core" support:
+
+
+                * Gateway (Gateway conformance profile)
+                * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                This API may be extended in the future to support additional kinds of parent
+                resources.
+
+
+                ParentRefs must be _distinct_. This means either that:
+
+
+                * They select different objects.  If this is the case, then parentRef
+                  entries are distinct. In terms of fields, this means that the
+                  multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                  be unique across all parentRef entries in the Route.
+                * They do not select different objects, but for each optional field used,
+                  each ParentRef that selects the same object must set the same set of
+                  optional fields to different values. If one ParentRef sets a
+                  combination of optional fields, all must set the same combination.
+
+
+                Some examples:
+
+
+                * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                  same object must also set `sectionName`.
+                * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`.
+                * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                  referencing the same object must also set `sectionName` and `port`.
+
+
+                It is possible to separately reference multiple distinct objects that may
+                be collapsed by an implementation. For example, some implementations may
+                choose to merge compatible Gateway Listeners together. If that is the
+                case, the list of routes attached to those resources should also be
+                merged.
+
+
+                Note that for ParentRefs that cross namespace boundaries, there are specific
+                rules. Cross-namespace references are only valid if they are explicitly
+                allowed by something in the namespace they are referring to. For example,
+                Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                generic way to enable other kinds of cross-namespace reference.
+
+
+
+                ParentRefs from a Route to a Service in the same namespace are "producer"
+                routes, which apply default routing rules to inbound connections from
+                any namespace to the Service.
+
+
+                ParentRefs from a Route to a Service in a different namespace are
+                "consumer" routes, and these routing rules are only applied to outbound
+                connections originating from the same namespace as the Route, for which
+                the intended destination of the connections are a Service targeted as a
+                ParentRef of the Route.
+
+
+
+
+
+
               items:
-                description: "ParentReference identifies an API object (usually a
-                  Gateway) that can be considered a parent of this resource (usually
-                  a route). There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
-                  API may be extended in the future to support additional kinds of
-                  parent resources. \n The API object must be valid in the cluster;
-                  the Group and Kind must be registered in the cluster for this reference
-                  to be valid."
+                description: |-
+                  ParentReference identifies an API object (usually a Gateway) that can be considered
+                  a parent of this resource (usually a route). There are two kinds of parent resources
+                  with "Core" support:
+
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+
+                  The API object must be valid in the cluster; the Group and Kind must
+                  be registered in the cluster for this reference to be valid.
                 properties:
                   group:
                     default: gateway.networking.k8s.io
-                    description: "Group is the group of the referent. When unspecified,
-                      \"gateway.networking.k8s.io\" is inferred. To set the core API
-                      group (such as for a \"Service\" kind referent), Group must
-                      be explicitly set to \"\" (empty string). \n Support: Core"
+                    description: |-
+                      Group is the group of the referent.
+                      When unspecified, "gateway.networking.k8s.io" is inferred.
+                      To set the core API group (such as for a "Service" kind referent),
+                      Group must be explicitly set to "" (empty string).
+
+
+                      Support: Core
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
                     default: Gateway
-                    description: "Kind is kind of the referent. \n There are two kinds
-                      of parent resources with \"Core\" support: \n * Gateway (Gateway
-                      conformance profile) * Service (Mesh conformance profile, experimental,
-                      ClusterIP Services only) \n Support for other resources is Implementation-Specific."
+                    description: |-
+                      Kind is kind of the referent.
+
+
+                      There are two kinds of parent resources with "Core" support:
+
+
+                      * Gateway (Gateway conformance profile)
+                      * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                      Support for other resources is Implementation-Specific.
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
-                    description: "Name is the name of the referent. \n Support: Core"
+                    description: |-
+                      Name is the name of the referent.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     type: string
                   namespace:
-                    description: "Namespace is the namespace of the referent. When
-                      unspecified, this refers to the local namespace of the Route.
-                      \n Note that there are specific rules for ParentRefs which cross
-                      namespace boundaries. Cross-namespace references are only valid
-                      if they are explicitly allowed by something in the namespace
-                      they are referring to. For example: Gateway has the AllowedRoutes
-                      field, and ReferenceGrant provides a generic way to enable any
-                      other kind of cross-namespace reference. \n  ParentRefs from
-                      a Route to a Service in the same namespace are \"producer\"
-                      routes, which apply default routing rules to inbound connections
-                      from any namespace to the Service. \n ParentRefs from a Route
-                      to a Service in a different namespace are \"consumer\" routes,
-                      and these routing rules are only applied to outbound connections
-                      originating from the same namespace as the Route, for which
-                      the intended destination of the connections are a Service targeted
-                      as a ParentRef of the Route.  \n Support: Core"
+                    description: |-
+                      Namespace is the namespace of the referent. When unspecified, this refers
+                      to the local namespace of the Route.
+
+
+                      Note that there are specific rules for ParentRefs which cross namespace
+                      boundaries. Cross-namespace references are only valid if they are explicitly
+                      allowed by something in the namespace they are referring to. For example:
+                      Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                      generic way to enable any other kind of cross-namespace reference.
+
+
+
+                      ParentRefs from a Route to a Service in the same namespace are "producer"
+                      routes, which apply default routing rules to inbound connections from
+                      any namespace to the Service.
+
+
+                      ParentRefs from a Route to a Service in a different namespace are
+                      "consumer" routes, and these routing rules are only applied to outbound
+                      connections originating from the same namespace as the Route, for which
+                      the intended destination of the connections are a Service targeted as a
+                      ParentRef of the Route.
+
+
+
+                      Support: Core
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   port:
-                    description: "Port is the network port this Route targets. It
-                      can be interpreted differently based on the type of parent resource.
-                      \n When the parent resource is a Gateway, this targets all listeners
-                      listening on the specified port that also support this kind
-                      of Route(and select this Route). It's not recommended to set
-                      `Port` unless the networking behaviors specified in a Route
-                      must apply to a specific port as opposed to a listener(s) whose
-                      port(s) may be changed. When both Port and SectionName are specified,
-                      the name and port of the selected listener must match both specified
-                      values. \n  When the parent resource is a Service, this targets
-                      a specific port in the Service spec. When both Port (experimental)
-                      and SectionName are specified, the name and port of the selected
-                      port must match both specified values.  \n Implementations MAY
-                      choose to support other parent resources. Implementations supporting
-                      other types of parent resources MUST clearly document how/if
-                      Port is interpreted. \n For the purpose of status, an attachment
-                      is considered successful as long as the parent resource accepts
-                      it partially. For example, Gateway listeners can restrict which
-                      Routes can attach to them by Route kind, namespace, or hostname.
-                      If 1 of 2 Gateway listeners accept attachment from the referencing
-                      Route, the Route MUST be considered successfully attached. If
-                      no Gateway listeners accept attachment from this Route, the
-                      Route MUST be considered detached from the Gateway. \n Support:
-                      Extended \n "
+                    description: |-
+                      Port is the network port this Route targets. It can be interpreted
+                      differently based on the type of parent resource.
+
+
+                      When the parent resource is a Gateway, this targets all listeners
+                      listening on the specified port that also support this kind of Route(and
+                      select this Route). It's not recommended to set `Port` unless the
+                      networking behaviors specified in a Route must apply to a specific port
+                      as opposed to a listener(s) whose port(s) may be changed. When both Port
+                      and SectionName are specified, the name and port of the selected listener
+                      must match both specified values.
+
+
+
+                      When the parent resource is a Service, this targets a specific port in the
+                      Service spec. When both Port (experimental) and SectionName are specified,
+                      the name and port of the selected port must match both specified values.
+
+
+
+                      Implementations MAY choose to support other parent resources.
+                      Implementations supporting other types of parent resources MUST clearly
+                      document how/if Port is interpreted.
+
+
+                      For the purpose of status, an attachment is considered successful as
+                      long as the parent resource accepts it partially. For example, Gateway
+                      listeners can restrict which Routes can attach to them by Route kind,
+                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                      from the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this Route,
+                      the Route MUST be considered detached from the Gateway.
+
+
+                      Support: Extended
                     format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer
                   sectionName:
-                    description: "SectionName is the name of a section within the
-                      target resource. In the following resources, SectionName is
-                      interpreted as the following: \n * Gateway: Listener Name. When
-                      both Port (experimental) and SectionName are specified, the
-                      name and port of the selected listener must match both specified
-                      values. * Service: Port Name. When both Port (experimental)
-                      and SectionName are specified, the name and port of the selected
-                      listener must match both specified values. Note that attaching
-                      Routes to Services as Parents is part of experimental Mesh support
-                      and is not supported for any other purpose. \n Implementations
-                      MAY choose to support attaching Routes to other resources. If
-                      that is the case, they MUST clearly document how SectionName
-                      is interpreted. \n When unspecified (empty string), this will
-                      reference the entire resource. For the purpose of status, an
-                      attachment is considered successful if at least one section
-                      in the parent resource accepts it. For example, Gateway listeners
-                      can restrict which Routes can attach to them by Route kind,
-                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
-                      from the referencing Route, the Route MUST be considered successfully
-                      attached. If no Gateway listeners accept attachment from this
-                      Route, the Route MUST be considered detached from the Gateway.
-                      \n Support: Core"
+                    description: |-
+                      SectionName is the name of a section within the target resource. In the
+                      following resources, SectionName is interpreted as the following:
+
+
+                      * Gateway: Listener name. When both Port (experimental) and SectionName
+                      are specified, the name and port of the selected listener must match
+                      both specified values.
+                      * Service: Port name. When both Port (experimental) and SectionName
+                      are specified, the name and port of the selected listener must match
+                      both specified values.
+
+
+                      Implementations MAY choose to support attaching Routes to other resources.
+                      If that is the case, they MUST clearly document how SectionName is
+                      interpreted.
+
+
+                      When unspecified (empty string), this will reference the entire resource.
+                      For the purpose of status, an attachment is considered successful if at
+                      least one section in the parent resource accepts it. For example, Gateway
+                      listeners can restrict which Routes can attach to them by Route kind,
+                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                      the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this Route, the
+                      Route MUST be considered detached from the Gateway.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -258,60 +351,94 @@ spec:
                 description: UDPRouteRule is the configuration for a given rule.
                 properties:
                   backendRefs:
-                    description: "BackendRefs defines the backend(s) where matching
-                      requests should be sent. If unspecified or invalid (refers to
-                      a non-existent resource or a Service with no endpoints), the
-                      underlying implementation MUST actively reject connection attempts
-                      to this backend. Packet drops must respect weight; if an invalid
-                      backend is requested to have 80% of the packets, then 80% of
-                      packets must be dropped instead. \n Support: Core for Kubernetes
-                      Service \n Support: Extended for Kubernetes ServiceImport \n
-                      Support: Implementation-specific for any other resource \n Support
-                      for weight: Extended"
+                    description: |-
+                      BackendRefs defines the backend(s) where matching requests should be
+                      sent. If unspecified or invalid (refers to a non-existent resource or a
+                      Service with no endpoints), the underlying implementation MUST actively
+                      reject connection attempts to this backend. Packet drops must
+                      respect weight; if an invalid backend is requested to have 80% of
+                      the packets, then 80% of packets must be dropped instead.
+
+
+                      Support: Core for Kubernetes Service
+
+
+                      Support: Extended for Kubernetes ServiceImport
+
+
+                      Support: Implementation-specific for any other resource
+
+
+                      Support for weight: Extended
                     items:
-                      description: "BackendRef defines how a Route should forward
-                        a request to a Kubernetes resource. \n Note that when a namespace
-                        different than the local namespace is specified, a ReferenceGrant
-                        object is required in the referent namespace to allow that
+                      description: |-
+                        BackendRef defines how a Route should forward a request to a Kubernetes
+                        resource.
+
+
+                        Note that when a namespace different than the local namespace is specified, a
+                        ReferenceGrant object is required in the referent namespace to allow that
                         namespace's owner to accept the reference. See the ReferenceGrant
-                        documentation for details. \n <gateway:experimental:description>
-                        \n When the BackendRef points to a Kubernetes Service, implementations
-                        SHOULD honor the appProtocol field if it is set for the target
-                        Service Port. \n Implementations supporting appProtocol SHOULD
-                        recognize the Kubernetes Standard Application Protocols defined
-                        in KEP-3726. \n If a Service appProtocol isn't specified,
-                        an implementation MAY infer the backend protocol through its
-                        own means. Implementations MAY infer the protocol from the
-                        Route type referring to the backend Service. \n If a Route
-                        is not able to send traffic to the backend using the specified
-                        protocol then the backend is considered invalid. Implementations
-                        MUST set the \"ResolvedRefs\" condition to \"False\" with
-                        the \"UnsupportedProtocol\" reason. \n </gateway:experimental:description>
-                        \n Note that when the BackendTLSPolicy object is enabled by
-                        the implementation, there are some extra rules about validity
-                        to consider here. See the fields where this struct is used
-                        for more information about the exact behavior."
+                        documentation for details.
+
+
+                        <gateway:experimental:description>
+
+
+                        When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                        honor the appProtocol field if it is set for the target Service Port.
+
+
+                        Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                        Standard Application Protocols defined in KEP-3726.
+
+
+                        If a Service appProtocol isn't specified, an implementation MAY infer the
+                        backend protocol through its own means. Implementations MAY infer the
+                        protocol from the Route type referring to the backend Service.
+
+
+                        If a Route is not able to send traffic to the backend using the specified
+                        protocol then the backend is considered invalid. Implementations MUST set the
+                        "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                        </gateway:experimental:description>
+
+
+                        Note that when the BackendTLSPolicy object is enabled by the implementation,
+                        there are some extra rules about validity to consider here. See the fields
+                        where this struct is used for more information about the exact behavior.
                       properties:
                         group:
                           default: ""
-                          description: Group is the group of the referent. For example,
-                            "gateway.networking.k8s.io". When unspecified or empty
-                            string, core API group is inferred.
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Service
-                          description: "Kind is the Kubernetes resource kind of the
-                            referent. For example \"Service\". \n Defaults to \"Service\"
-                            when not specified. \n ExternalName services can refer
-                            to CNAME DNS records that may live outside of the cluster
-                            and as such are difficult to reason about in terms of
-                            conformance. They also may not be safe to forward to (see
-                            CVE-2021-25740 for more information). Implementations
-                            SHOULD NOT support ExternalName Services. \n Support:
-                            Core (Services with a type other than ExternalName) \n
-                            Support: Implementation-specific (Services with type ExternalName)"
+                          description: |-
+                            Kind is the Kubernetes resource kind of the referent. For example
+                            "Service".
+
+
+                            Defaults to "Service" when not specified.
+
+
+                            ExternalName services can refer to CNAME DNS records that may live
+                            outside of the cluster and as such are difficult to reason about in
+                            terms of conformance. They also may not be safe to forward to (see
+                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                            support ExternalName Services.
+
+
+                            Support: Core (Services with a type other than ExternalName)
+
+
+                            Support: Implementation-specific (Services with type ExternalName)
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -322,43 +449,51 @@ spec:
                           minLength: 1
                           type: string
                         namespace:
-                          description: "Namespace is the namespace of the backend.
-                            When unspecified, the local namespace is inferred. \n
-                            Note that when a namespace different than the local namespace
-                            is specified, a ReferenceGrant object is required in the
-                            referent namespace to allow that namespace's owner to
-                            accept the reference. See the ReferenceGrant documentation
-                            for details. \n Support: Core"
+                          description: |-
+                            Namespace is the namespace of the backend. When unspecified, the local
+                            namespace is inferred.
+
+
+                            Note that when a namespace different than the local namespace is specified,
+                            a ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            Support: Core
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: Port specifies the destination port number
-                            to use for this resource. Port is required when the referent
-                            is a Kubernetes Service. In this case, the port number
-                            is the service port number, not the target port. For other
-                            resources, destination port might be derived from the
-                            referent resource or this field.
+                          description: |-
+                            Port specifies the destination port number to use for this resource.
+                            Port is required when the referent is a Kubernetes Service. In this
+                            case, the port number is the service port number, not the target port.
+                            For other resources, destination port might be derived from the referent
+                            resource or this field.
                           format: int32
                           maximum: 65535
                           minimum: 1
                           type: integer
                         weight:
                           default: 1
-                          description: "Weight specifies the proportion of requests
-                            forwarded to the referenced backend. This is computed
-                            as weight/(sum of all weights in this BackendRefs list).
-                            For non-zero values, there may be some epsilon from the
-                            exact proportion defined here depending on the precision
-                            an implementation supports. Weight is not a percentage
-                            and the sum of weights does not need to equal 100. \n
-                            If only one backend is specified and it has a weight greater
-                            than 0, 100% of the traffic is forwarded to that backend.
-                            If weight is set to 0, no traffic should be forwarded
-                            for this entry. If unspecified, weight defaults to 1.
-                            \n Support for this field varies based on the context
-                            where used."
+                          description: |-
+                            Weight specifies the proportion of requests forwarded to the referenced
+                            backend. This is computed as weight/(sum of all weights in this
+                            BackendRefs list). For non-zero values, there may be some epsilon from
+                            the exact proportion defined here depending on the precision an
+                            implementation supports. Weight is not a percentage and the sum of
+                            weights does not need to equal 100.
+
+
+                            If only one backend is specified and it has a weight greater than 0, 100%
+                            of the traffic is forwarded to that backend. If weight is set to 0, no
+                            traffic should be forwarded for this entry. If unspecified, weight
+                            defaults to 1.
+
+
+                            Support for this field varies based on the context where used.
                           format: int32
                           maximum: 1000000
                           minimum: 0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
@@ -1,0 +1,266 @@
+apiVersion: meta.k8s.appscode.com/v1alpha1
+kind: ResourceDescriptor
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.networking.k8s.io
+    k8s.io/kind: BackendTLSPolicy
+    k8s.io/resource: backendtlspolicies
+    k8s.io/version: v1alpha3
+  name: gateway.networking.k8s.io-v1alpha3-backendtlspolicies
+spec:
+  resource:
+    group: gateway.networking.k8s.io
+    kind: BackendTLSPolicy
+    name: backendtlspolicies
+    scope: Namespaced
+    version: v1alpha3
+  validation:
+    openAPIV3Schema:
+      description: |-
+        BackendTLSPolicy provides a way to configure how a Gateway
+        connects to a Backend via TLS.
+      properties:
+        apiVersion:
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          type: string
+        kind:
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          properties:
+            name:
+              description: 'Name must be unique within a namespace. Is required when
+                creating resources, although some resources may allow a client to
+                request the generation of an appropriate name automatically. Name
+                is primarily intended for creation idempotence and configuration definition.
+                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: "Namespace defines the space within which each name must
+                be unique. An empty namespace is equivalent to the \"default\" namespace,
+                but \"default\" is the canonical representation. Not all objects are
+                required to be scoped to a namespace - the value of this field for
+                those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                More info: http://kubernetes.io/docs/user-guide/namespaces"
+              type: string
+            labels:
+              additionalProperties:
+                type: string
+              description: 'Map of string keys and values that can be used to organize
+                and categorize (scope and select) objects. May match selectors of
+                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            annotations:
+              additionalProperties:
+                type: string
+              description: 'Annotations is an unstructured key value map stored with
+                a resource that may be set by external tools to store and retrieve
+                arbitrary metadata. They are not queryable and should be preserved
+                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+          type: object
+        spec:
+          description: Spec defines the desired state of BackendTLSPolicy.
+          properties:
+            targetRefs:
+              description: |-
+                TargetRefs identifies an API object to apply the policy to.
+                Only Services have Extended support. Implementations MAY support
+                additional objects, with Implementation Specific support.
+                Note that this config applies to the entire referenced resource
+                by default, but this default may change in the future to provide
+                a more granular application of the policy.
+
+
+                Support: Extended for Kubernetes Service
+
+
+                Support: Implementation-specific for any other resource
+              items:
+                description: |-
+                  LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                  direct policy to. This should be used as part of Policy resources that can
+                  target single resources. For more information on how this policy attachment
+                  mode works, and a sample Policy resource, refer to the policy attachment
+                  documentation for Gateway API.
+
+
+                  Note: This should only be used for direct policy attachment when references
+                  to SectionName are actually needed. In all other cases,
+                  LocalPolicyTargetReference should be used.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              maxItems: 16
+              minItems: 1
+              type: array
+            validation:
+              description: Validation contains backend TLS validation configuration.
+              properties:
+                caCertificateRefs:
+                  description: |-
+                    CACertificateRefs contains one or more references to Kubernetes objects that
+                    contain a PEM-encoded TLS CA certificate bundle, which is used to
+                    validate a TLS handshake between the Gateway and backend Pod.
+
+
+                    If CACertificateRefs is empty or unspecified, then WellKnownCACertificates must be
+                    specified. Only one of CACertificateRefs or WellKnownCACertificates may be specified,
+                    not both. If CACertifcateRefs is empty or unspecified, the configuration for
+                    WellKnownCACertificates MUST be honored instead if supported by the implementation.
+
+
+                    References to a resource in a different namespace are invalid for the
+                    moment, although we will revisit this in the future.
+
+
+                    A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
+                    Implementations MAY choose to support attaching multiple certificates to
+                    a backend, but this behavior is implementation-specific.
+
+
+                    Support: Core - An optional single reference to a Kubernetes ConfigMap,
+                    with the CA certificate in a key named `ca.crt`.
+
+
+                    Support: Implementation-specific (More than one reference, or other kinds
+                    of resources).
+                  items:
+                    description: |-
+                      LocalObjectReference identifies an API object within the namespace of the
+                      referrer.
+                      The API object must be valid in the cluster; the Group and Kind must
+                      be registered in the cluster for this reference to be valid.
+
+
+                      References to objects with invalid Group and Kind are not valid, and must
+                      be rejected by the implementation, with appropriate Conditions set
+                      on the containing object.
+                    properties:
+                      group:
+                        description: |-
+                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                          When unspecified or empty string, core API group is inferred.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: Kind is kind of the referent. For example "HTTPRoute"
+                          or "Service".
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                  maxItems: 8
+                  type: array
+                hostname:
+                  description: |-
+                    Hostname is used for two purposes in the connection between Gateways and
+                    backends:
+
+
+                    1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
+                    2. Hostname MUST be used for authentication and MUST match the certificate
+                       served by the matching backend.
+
+
+                    Support: Core
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                wellKnownCACertificates:
+                  description: |-
+                    WellKnownCACertificates specifies whether system CA certificates may be used in
+                    the TLS handshake between the gateway and backend pod.
+
+
+                    If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
+                    must be specified with at least one entry for a valid configuration. Only one of
+                    CACertificateRefs or WellKnownCACertificates may be specified, not both. If an
+                    implementation does not support the WellKnownCACertificates field or the value
+                    supplied is not supported, the Status Conditions on the Policy MUST be
+                    updated to include an Accepted: False Condition with Reason: Invalid.
+
+
+                    Support: Implementation-specific
+                  enum:
+                  - System
+                  type: string
+              required:
+              - hostname
+              type: object
+              x-kubernetes-validations:
+              - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                  > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                  != "")'
+              - message: must specify either CACertificateRefs or WellKnownCACertificates
+                rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                  > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                  != "")
+          required:
+          - targetRefs
+          - validation
+          type: object
+      required:
+      - spec
+      type: object

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1beta1/gatewayclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1beta1/gatewayclasses.yaml
@@ -17,29 +17,42 @@ spec:
     version: v1beta1
   validation:
     openAPIV3Schema:
-      description: "GatewayClass describes a class of Gateways available to the user
-        for creating Gateway resources. \n It is recommended that this resource be
-        used as a template for Gateways. This means that a Gateway is based on the
-        state of the GatewayClass at the time it was created and changes to the GatewayClass
-        or associated parameters are not propagated down to existing Gateways. This
-        recommendation is intended to limit the blast radius of changes to GatewayClass
-        or associated parameters. If implementations choose to propagate GatewayClass
-        changes to existing Gateways, that MUST be clearly documented by the implementation.
-        \n Whenever one or more Gateways are using a GatewayClass, implementations
-        SHOULD add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer
-        on the associated GatewayClass. This ensures that a GatewayClass associated
-        with a Gateway is not deleted while in use. \n GatewayClass is a Cluster level
-        resource."
+      description: |-
+        GatewayClass describes a class of Gateways available to the user for creating
+        Gateway resources.
+
+
+        It is recommended that this resource be used as a template for Gateways. This
+        means that a Gateway is based on the state of the GatewayClass at the time it
+        was created and changes to the GatewayClass or associated parameters are not
+        propagated down to existing Gateways. This recommendation is intended to
+        limit the blast radius of changes to GatewayClass or associated parameters.
+        If implementations choose to propagate GatewayClass changes to existing
+        Gateways, that MUST be clearly documented by the implementation.
+
+
+        Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
+        add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
+        associated GatewayClass. This ensures that a GatewayClass associated with a
+        Gateway is not deleted while in use.
+
+
+        GatewayClass is a Cluster level resource.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -70,10 +83,18 @@ spec:
           description: Spec defines the desired state of GatewayClass.
           properties:
             controllerName:
-              description: "ControllerName is the name of the controller that is managing
-                Gateways of this class. The value of this field MUST be a domain prefixed
-                path. \n Example: \"example.net/gateway-controller\". \n This field
-                is not mutable and cannot be empty. \n Support: Core"
+              description: |-
+                ControllerName is the name of the controller that is managing Gateways of
+                this class. The value of this field MUST be a domain prefixed path.
+
+
+                Example: "example.net/gateway-controller".
+
+
+                This field is not mutable and cannot be empty.
+
+
+                Support: Core
               maxLength: 253
               minLength: 1
               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
@@ -86,14 +107,27 @@ spec:
               maxLength: 64
               type: string
             parametersRef:
-              description: "ParametersRef is a reference to a resource that contains
-                the configuration parameters corresponding to the GatewayClass. This
-                is optional if the controller does not require any additional configuration.
-                \n ParametersRef can reference a standard Kubernetes resource, i.e.
-                ConfigMap, or an implementation-specific custom resource. The resource
-                can be cluster-scoped or namespace-scoped. \n If the referent cannot
-                be found, the GatewayClass's \"InvalidParameters\" status condition
-                will be true. \n Support: Implementation-specific"
+              description: |-
+                ParametersRef is a reference to a resource that contains the configuration
+                parameters corresponding to the GatewayClass. This is optional if the
+                controller does not require any additional configuration.
+
+
+                ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
+                or an implementation-specific custom resource. The resource can be
+                cluster-scoped or namespace-scoped.
+
+
+                If the referent cannot be found, the GatewayClass's "InvalidParameters"
+                status condition will be true.
+
+
+                A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
+                the merging behavior is implementation specific.
+                It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+
+                Support: Implementation-specific
               properties:
                 group:
                   description: Group is the group of the referent.
@@ -112,8 +146,9 @@ spec:
                   minLength: 1
                   type: string
                 namespace:
-                  description: Namespace is the namespace of the referent. This field
-                    is required when referring to a Namespace-scoped resource and
+                  description: |-
+                    Namespace is the namespace of the referent.
+                    This field is required when referring to a Namespace-scoped resource and
                     MUST be unset when referring to a Cluster-scoped resource.
                   maxLength: 63
                   minLength: 1

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1beta1/gateways.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1beta1/gateways.yaml
@@ -17,18 +17,24 @@ spec:
     version: v1beta1
   validation:
     openAPIV3Schema:
-      description: Gateway represents an instance of a service-traffic handling infrastructure
+      description: |-
+        Gateway represents an instance of a service-traffic handling infrastructure
         by binding Listeners to a set of IP addresses.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -67,20 +73,33 @@ spec:
           description: Spec defines the desired state of Gateway.
           properties:
             addresses:
-              description: "Addresses requested for this Gateway. This is optional
-                and behavior can depend on the implementation. If a value is set in
-                the spec and the requested address is invalid or unavailable, the
-                implementation MUST indicate this in the associated entry in GatewayStatus.Addresses.
-                \n The Addresses field represents a request for the address(es) on
-                the \"outside of the Gateway\", that traffic bound for this Gateway
-                will use. This could be the IP address or hostname of an external
-                load balancer or other networking infrastructure, or some other address
-                that traffic will be sent to. \n If no Addresses are specified, the
-                implementation MAY schedule the Gateway in an implementation-specific
-                manner, assigning an appropriate set of Addresses. \n The implementation
-                MUST bind all Listeners to every GatewayAddress that it assigns to
-                the Gateway and add a corresponding entry in GatewayStatus.Addresses.
-                \n Support: Extended \n "
+              description: |+
+                Addresses requested for this Gateway. This is optional and behavior can
+                depend on the implementation. If a value is set in the spec and the
+                requested address is invalid or unavailable, the implementation MUST
+                indicate this in the associated entry in GatewayStatus.Addresses.
+
+
+                The Addresses field represents a request for the address(es) on the
+                "outside of the Gateway", that traffic bound for this Gateway will use.
+                This could be the IP address or hostname of an external load balancer or
+                other networking infrastructure, or some other address that traffic will
+                be sent to.
+
+
+                If no Addresses are specified, the implementation MAY schedule the
+                Gateway in an implementation-specific manner, assigning an appropriate
+                set of Addresses.
+
+
+                The implementation MUST bind all Listeners to every GatewayAddress that
+                it assigns to the Gateway and add a corresponding entry in
+                GatewayStatus.Addresses.
+
+
+                Support: Extended
+
+
               items:
                 description: GatewayAddress describes an address that can be bound
                   to a Gateway.
@@ -107,9 +126,12 @@ spec:
                     pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                     type: string
                   value:
-                    description: "Value of the address. The validity of the values
-                      will depend on the type and support by the controller. \n Examples:
-                      `1.2.3.4`, `128::1`, `my-ip-address`."
+                    description: |-
+                      Value of the address. The validity of the values will depend
+                      on the type and support by the controller.
+
+
+                      Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                     maxLength: 253
                     minLength: 1
                     type: string
@@ -131,176 +153,308 @@ spec:
                 rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
                   a2.type == a1.type && a2.value == a1.value) : true )'
             gatewayClassName:
-              description: GatewayClassName used for this Gateway. This is the name
-                of a GatewayClass resource.
+              description: |-
+                GatewayClassName used for this Gateway. This is the name of a
+                GatewayClass resource.
               maxLength: 253
               minLength: 1
               type: string
             infrastructure:
-              description: "Infrastructure defines infrastructure level attributes
-                about this Gateway instance. \n Support: Core \n "
+              description: |+
+                Infrastructure defines infrastructure level attributes about this Gateway instance.
+
+
+                Support: Core
+
+
               properties:
                 annotations:
                   additionalProperties:
-                    description: AnnotationValue is the value of an annotation in
-                      Gateway API. This is used for validation of maps such as TLS
-                      options. This roughly matches Kubernetes annotation validation,
-                      although the length validation in that case is based on the
-                      entire size of the annotations struct.
+                    description: |-
+                      AnnotationValue is the value of an annotation in Gateway API. This is used
+                      for validation of maps such as TLS options. This roughly matches Kubernetes
+                      annotation validation, although the length validation in that case is based
+                      on the entire size of the annotations struct.
                     maxLength: 4096
                     minLength: 0
                     type: string
-                  description: "Annotations that SHOULD be applied to any resources
-                    created in response to this Gateway. \n For implementations creating
-                    other Kubernetes objects, this should be the `metadata.annotations`
-                    field on resources. For other implementations, this refers to
-                    any relevant (implementation specific) \"annotations\" concepts.
-                    \n An implementation may chose to add additional implementation-specific
-                    annotations as they see fit. \n Support: Extended"
+                  description: |-
+                    Annotations that SHOULD be applied to any resources created in response to this Gateway.
+
+
+                    For implementations creating other Kubernetes objects, this should be the `metadata.annotations` field on resources.
+                    For other implementations, this refers to any relevant (implementation specific) "annotations" concepts.
+
+
+                    An implementation may chose to add additional implementation-specific annotations as they see fit.
+
+
+                    Support: Extended
                   maxProperties: 8
                   type: object
                 labels:
                   additionalProperties:
-                    description: AnnotationValue is the value of an annotation in
-                      Gateway API. This is used for validation of maps such as TLS
-                      options. This roughly matches Kubernetes annotation validation,
-                      although the length validation in that case is based on the
-                      entire size of the annotations struct.
+                    description: |-
+                      AnnotationValue is the value of an annotation in Gateway API. This is used
+                      for validation of maps such as TLS options. This roughly matches Kubernetes
+                      annotation validation, although the length validation in that case is based
+                      on the entire size of the annotations struct.
                     maxLength: 4096
                     minLength: 0
                     type: string
-                  description: "Labels that SHOULD be applied to any resources created
-                    in response to this Gateway. \n For implementations creating other
-                    Kubernetes objects, this should be the `metadata.labels` field
-                    on resources. For other implementations, this refers to any relevant
-                    (implementation specific) \"labels\" concepts. \n An implementation
-                    may chose to add additional implementation-specific labels as
-                    they see fit. \n Support: Extended"
+                  description: |-
+                    Labels that SHOULD be applied to any resources created in response to this Gateway.
+
+
+                    For implementations creating other Kubernetes objects, this should be the `metadata.labels` field on resources.
+                    For other implementations, this refers to any relevant (implementation specific) "labels" concepts.
+
+
+                    An implementation may chose to add additional implementation-specific labels as they see fit.
+
+
+                    Support: Extended
                   maxProperties: 8
+                  type: object
+                parametersRef:
+                  description: |-
+                    ParametersRef is a reference to a resource that contains the configuration
+                    parameters corresponding to the Gateway. This is optional if the
+                    controller does not require any additional configuration.
+
+
+                    This follows the same semantics as GatewayClass's `parametersRef`, but on a per-Gateway basis
+
+
+                    The Gateway's GatewayClass may provide its own `parametersRef`. When both are specified,
+                    the merging behavior is implementation specific.
+                    It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+
+                    Support: Implementation-specific
+                  properties:
+                    group:
+                      description: Group is the group of the referent.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the referent.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
                   type: object
               type: object
             listeners:
-              description: "Listeners associated with this Gateway. Listeners define
-                logical endpoints that are bound on this Gateway's addresses. At least
-                one Listener MUST be specified. \n Each Listener in a set of Listeners
-                (for example, in a single Gateway) MUST be _distinct_, in that a traffic
-                flow MUST be able to be assigned to exactly one listener. (This section
-                uses \"set of Listeners\" rather than \"Listeners in a single Gateway\"
-                because implementations MAY merge configuration from multiple Gateways
-                onto a single data plane, and these rules _also_ apply in that case).
-                \n Practically, this means that each listener in a set MUST have a
-                unique combination of Port, Protocol, and, if supported by the protocol,
-                Hostname. \n Some combinations of port, protocol, and TLS settings
-                are considered Core support and MUST be supported by implementations
-                based on their targeted conformance profile: \n HTTP Profile \n 1.
-                HTTPRoute, Port: 80, Protocol: HTTP 2. HTTPRoute, Port: 443, Protocol:
-                HTTPS, TLS Mode: Terminate, TLS keypair provided \n TLS Profile \n
-                1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough \n \"Distinct\"
-                Listeners have the following property: \n The implementation can match
-                inbound requests to a single distinct Listener. When multiple Listeners
-                share values for fields (for example, two Listeners with the same
-                Port value), the implementation can match requests to only one of
-                the Listeners using other Listener fields. \n For example, the following
-                Listener scenarios are distinct: \n 1. Multiple Listeners with the
-                same Port that all use the \"HTTP\" Protocol that all have unique
-                Hostname values. 2. Multiple Listeners with the same Port that use
-                either the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
-                values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners, where
-                no Listener with the same Protocol has the same Port value. \n Some
-                fields in the Listener struct have possible values that affect whether
-                the Listener is distinct. Hostname is particularly relevant for HTTP
-                or HTTPS protocols. \n When using the Hostname value to select between
-                same-Port, same-Protocol Listeners, the Hostname value must be different
-                on each Listener for the Listener to be distinct. \n When the Listeners
-                are distinct based on Hostname, inbound request hostnames MUST match
-                from the most specific to least specific Hostname values to choose
-                the correct Listener and its associated set of Routes. \n Exact matches
-                must be processed before wildcard matches, and wildcard matches must
-                be processed before fallback (empty Hostname value) matches. For example,
-                `\"foo.example.com\"` takes precedence over `\"*.example.com\"`, and
-                `\"*.example.com\"` takes precedence over `\"\"`. \n Additionally,
-                if there are multiple wildcard entries, more specific wildcard entries
-                must be processed before less specific wildcard entries. For example,
-                `\"*.foo.example.com\"` takes precedence over `\"*.example.com\"`.
-                The precise definition here is that the higher the number of dots
-                in the hostname to the right of the wildcard character, the higher
-                the precedence. \n The wildcard character will match any number of
-                characters _and dots_ to the left, however, so `\"*.example.com\"`
-                will match both `\"foo.bar.example.com\"` _and_ `\"bar.example.com\"`.
-                \n If a set of Listeners contains Listeners that are not distinct,
-                then those Listeners are Conflicted, and the implementation MUST set
-                the \"Conflicted\" condition in the Listener Status to \"True\". \n
+              description: |-
+                Listeners associated with this Gateway. Listeners define
+                logical endpoints that are bound on this Gateway's addresses.
+                At least one Listener MUST be specified.
+
+
+                Each Listener in a set of Listeners (for example, in a single Gateway)
+                MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
+                exactly one listener. (This section uses "set of Listeners" rather than
+                "Listeners in a single Gateway" because implementations MAY merge configuration
+                from multiple Gateways onto a single data plane, and these rules _also_
+                apply in that case).
+
+
+                Practically, this means that each listener in a set MUST have a unique
+                combination of Port, Protocol, and, if supported by the protocol, Hostname.
+
+
+                Some combinations of port, protocol, and TLS settings are considered
+                Core support and MUST be supported by implementations based on their
+                targeted conformance profile:
+
+
+                HTTP Profile
+
+
+                1. HTTPRoute, Port: 80, Protocol: HTTP
+                2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
+
+
+                TLS Profile
+
+
+                1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
+
+
+                "Distinct" Listeners have the following property:
+
+
+                The implementation can match inbound requests to a single distinct
+                Listener. When multiple Listeners share values for fields (for
+                example, two Listeners with the same Port value), the implementation
+                can match requests to only one of the Listeners using other
+                Listener fields.
+
+
+                For example, the following Listener scenarios are distinct:
+
+
+                1. Multiple Listeners with the same Port that all use the "HTTP"
+                   Protocol that all have unique Hostname values.
+                2. Multiple Listeners with the same Port that use either the "HTTPS" or
+                   "TLS" Protocol that all have unique Hostname values.
+                3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
+                   with the same Protocol has the same Port value.
+
+
+                Some fields in the Listener struct have possible values that affect
+                whether the Listener is distinct. Hostname is particularly relevant
+                for HTTP or HTTPS protocols.
+
+
+                When using the Hostname value to select between same-Port, same-Protocol
+                Listeners, the Hostname value must be different on each Listener for the
+                Listener to be distinct.
+
+
+                When the Listeners are distinct based on Hostname, inbound request
+                hostnames MUST match from the most specific to least specific Hostname
+                values to choose the correct Listener and its associated set of Routes.
+
+
+                Exact matches must be processed before wildcard matches, and wildcard
+                matches must be processed before fallback (empty Hostname value)
+                matches. For example, `"foo.example.com"` takes precedence over
+                `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
+
+
+                Additionally, if there are multiple wildcard entries, more specific
+                wildcard entries must be processed before less specific wildcard entries.
+                For example, `"*.foo.example.com"` takes precedence over `"*.example.com"`.
+                The precise definition here is that the higher the number of dots in the
+                hostname to the right of the wildcard character, the higher the precedence.
+
+
+                The wildcard character will match any number of characters _and dots_ to
+                the left, however, so `"*.example.com"` will match both
+                `"foo.bar.example.com"` _and_ `"bar.example.com"`.
+
+
+                If a set of Listeners contains Listeners that are not distinct, then those
+                Listeners are Conflicted, and the implementation MUST set the "Conflicted"
+                condition in the Listener Status to "True".
+
+
                 Implementations MAY choose to accept a Gateway with some Conflicted
                 Listeners only if they only accept the partial Listener set that contains
-                no Conflicted Listeners. To put this another way, implementations
-                may accept a partial Listener set only if they throw out *all* the
-                conflicting Listeners. No picking one of the conflicting listeners
-                as the winner. This also means that the Gateway must have at least
-                one non-conflicting Listener in this case, otherwise it violates the
-                requirement that at least one Listener must be present. \n The implementation
-                MUST set a \"ListenersNotValid\" condition on the Gateway Status when
-                the Gateway contains Conflicted Listeners whether or not they accept
-                the Gateway. That Condition SHOULD clearly indicate in the Message
-                which Listeners are conflicted, and which are Accepted. Additionally,
-                the Listener status for those listeners SHOULD indicate which Listeners
-                are conflicted and not Accepted. \n A Gateway's Listeners are considered
-                \"compatible\" if: \n 1. They are distinct. 2. The implementation
-                can serve them in compliance with the Addresses requirement that all
-                Listeners are available on all assigned addresses. \n Compatible combinations
-                in Extended support are expected to vary across implementations. A
-                combination that is compatible for one implementation may not be compatible
-                for another. \n For example, an implementation that cannot serve both
-                TCP and UDP listeners on the same address, or cannot mix HTTPS and
-                generic TLS listens on the same port would not consider those cases
-                compatible, even though they are distinct. \n Note that requests SHOULD
-                match at most one Listener. For example, if Listeners are defined
-                for \"foo.example.com\" and \"*.example.com\", a request to \"foo.example.com\"
-                SHOULD only be routed using routes attached to the \"foo.example.com\"
-                Listener (and not the \"*.example.com\" Listener). This concept is
-                known as \"Listener Isolation\". Implementations that do not support
-                Listener Isolation MUST clearly document this. \n Implementations
-                MAY merge separate Gateways onto a single set of Addresses if all
-                Listeners across all Gateways are compatible. \n Support: Core"
+                no Conflicted Listeners. To put this another way, implementations may
+                accept a partial Listener set only if they throw out *all* the conflicting
+                Listeners. No picking one of the conflicting listeners as the winner.
+                This also means that the Gateway must have at least one non-conflicting
+                Listener in this case, otherwise it violates the requirement that at
+                least one Listener must be present.
+
+
+                The implementation MUST set a "ListenersNotValid" condition on the
+                Gateway Status when the Gateway contains Conflicted Listeners whether or
+                not they accept the Gateway. That Condition SHOULD clearly
+                indicate in the Message which Listeners are conflicted, and which are
+                Accepted. Additionally, the Listener status for those listeners SHOULD
+                indicate which Listeners are conflicted and not Accepted.
+
+
+                A Gateway's Listeners are considered "compatible" if:
+
+
+                1. They are distinct.
+                2. The implementation can serve them in compliance with the Addresses
+                   requirement that all Listeners are available on all assigned
+                   addresses.
+
+
+                Compatible combinations in Extended support are expected to vary across
+                implementations. A combination that is compatible for one implementation
+                may not be compatible for another.
+
+
+                For example, an implementation that cannot serve both TCP and UDP listeners
+                on the same address, or cannot mix HTTPS and generic TLS listens on the same port
+                would not consider those cases compatible, even though they are distinct.
+
+
+                Note that requests SHOULD match at most one Listener. For example, if
+                Listeners are defined for "foo.example.com" and "*.example.com", a
+                request to "foo.example.com" SHOULD only be routed using routes attached
+                to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+                This concept is known as "Listener Isolation". Implementations that do
+                not support Listener Isolation MUST clearly document this.
+
+
+                Implementations MAY merge separate Gateways onto a single set of
+                Addresses if all Listeners across all Gateways are compatible.
+
+
+                Support: Core
               items:
-                description: Listener embodies the concept of a logical endpoint where
-                  a Gateway accepts network connections.
+                description: |-
+                  Listener embodies the concept of a logical endpoint where a Gateway accepts
+                  network connections.
                 properties:
                   allowedRoutes:
                     default:
                       namespaces:
                         from: Same
-                    description: "AllowedRoutes defines the types of routes that MAY
-                      be attached to a Listener and the trusted namespaces where those
-                      Route resources MAY be present. \n Although a client request
-                      may match multiple route rules, only one rule may ultimately
-                      receive the request. Matching precedence MUST be determined
-                      in order of the following criteria: \n * The most specific match
-                      as defined by the Route type. * The oldest Route based on creation
-                      timestamp. For example, a Route with a creation timestamp of
-                      \"2020-09-08 01:02:03\" is given precedence over a Route with
-                      a creation timestamp of \"2020-09-08 01:02:04\". * If everything
-                      else is equivalent, the Route appearing first in alphabetical
-                      order (namespace/name) should be given precedence. For example,
-                      foo/bar is given precedence over foo/baz. \n All valid rules
-                      within a Route attached to this Listener should be implemented.
-                      Invalid Route rules can be ignored (sometimes that will mean
+                    description: |-
+                      AllowedRoutes defines the types of routes that MAY be attached to a
+                      Listener and the trusted namespaces where those Route resources MAY be
+                      present.
+
+
+                      Although a client request may match multiple route rules, only one rule
+                      may ultimately receive the request. Matching precedence MUST be
+                      determined in order of the following criteria:
+
+
+                      * The most specific match as defined by the Route type.
+                      * The oldest Route based on creation timestamp. For example, a Route with
+                        a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+                        a Route with a creation timestamp of "2020-09-08 01:02:04".
+                      * If everything else is equivalent, the Route appearing first in
+                        alphabetical order (namespace/name) should be given precedence. For
+                        example, foo/bar is given precedence over foo/baz.
+
+
+                      All valid rules within a Route attached to this Listener should be
+                      implemented. Invalid Route rules can be ignored (sometimes that will mean
                       the full Route). If a Route rule transitions from valid to invalid,
-                      support for that Route rule should be dropped to ensure consistency.
-                      For example, even if a filter specified by a Route rule is invalid,
-                      the rest of the rules within that Route should still be supported.
-                      \n Support: Core"
+                      support for that Route rule should be dropped to ensure consistency. For
+                      example, even if a filter specified by a Route rule is invalid, the rest
+                      of the rules within that Route should still be supported.
+
+
+                      Support: Core
                     properties:
                       kinds:
-                        description: "Kinds specifies the groups and kinds of Routes
-                          that are allowed to bind to this Gateway Listener. When
-                          unspecified or empty, the kinds of Routes selected are determined
-                          using the Listener protocol. \n A RouteGroupKind MUST correspond
-                          to kinds of Routes that are compatible with the application
-                          protocol specified in the Listener's Protocol field. If
-                          an implementation does not support or recognize this resource
-                          type, it MUST set the \"ResolvedRefs\" condition to False
-                          for this Listener with the \"InvalidRouteKinds\" reason.
-                          \n Support: Core"
+                        description: |-
+                          Kinds specifies the groups and kinds of Routes that are allowed to bind
+                          to this Gateway Listener. When unspecified or empty, the kinds of Routes
+                          selected are determined using the Listener protocol.
+
+
+                          A RouteGroupKind MUST correspond to kinds of Routes that are compatible
+                          with the application protocol specified in the Listener's Protocol field.
+                          If an implementation does not support or recognize this resource type, it
+                          MUST set the "ResolvedRefs" condition to False for this Listener with the
+                          "InvalidRouteKinds" reason.
+
+
+                          Support: Core
                         items:
                           description: RouteGroupKind indicates the group and kind
                             of a Route resource.
@@ -325,36 +479,47 @@ spec:
                       namespaces:
                         default:
                           from: Same
-                        description: "Namespaces indicates namespaces from which Routes
-                          may be attached to this Listener. This is restricted to
-                          the namespace of this Gateway by default. \n Support: Core"
+                        description: |-
+                          Namespaces indicates namespaces from which Routes may be attached to this
+                          Listener. This is restricted to the namespace of this Gateway by default.
+
+
+                          Support: Core
                         properties:
                           from:
                             default: Same
-                            description: "From indicates where Routes will be selected
-                              for this Gateway. Possible values are: \n * All: Routes
-                              in all namespaces may be used by this Gateway. * Selector:
-                              Routes in namespaces selected by the selector may be
-                              used by this Gateway. * Same: Only Routes in the same
-                              namespace may be used by this Gateway. \n Support: Core"
+                            description: |-
+                              From indicates where Routes will be selected for this Gateway. Possible
+                              values are:
+
+
+                              * All: Routes in all namespaces may be used by this Gateway.
+                              * Selector: Routes in namespaces selected by the selector may be used by
+                                this Gateway.
+                              * Same: Only Routes in the same namespace may be used by this Gateway.
+
+
+                              Support: Core
                             enum:
                             - All
                             - Selector
                             - Same
                             type: string
                           selector:
-                            description: "Selector must be specified when From is
-                              set to \"Selector\". In that case, only Routes in Namespaces
-                              matching this Selector will be selected by this Gateway.
-                              This field is ignored for other values of \"From\".
-                              \n Support: Core"
+                            description: |-
+                              Selector must be specified when From is set to "Selector". In that case,
+                              only Routes in Namespaces matching this Selector will be selected by this
+                              Gateway. This field is ignored for other values of "From".
+
+
+                              Support: Core
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
                                   requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
                                     relates the key and values.
                                   properties:
                                     key:
@@ -362,131 +527,175 @@ spec:
                                         applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   required:
                                   - key
                                   - operator
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                         type: object
                     type: object
                   hostname:
-                    description: "Hostname specifies the virtual hostname to match
-                      for protocol types that define this concept. When unspecified,
-                      all hostnames are matched. This field is ignored for protocols
-                      that don't require hostname based matching. \n Implementations
-                      MUST apply Hostname matching appropriately for each of the following
-                      protocols: \n * TLS: The Listener Hostname MUST match the SNI.
-                      * HTTP: The Listener Hostname MUST match the Host header of
-                      the request. * HTTPS: The Listener Hostname SHOULD match at
-                      both the TLS and HTTP protocol layers as described above. If
-                      an implementation does not ensure that both the SNI and Host
-                      header match the Listener hostname, it MUST clearly document
-                      that. \n For HTTPRoute and TLSRoute resources, there is an interaction
-                      with the `spec.hostnames` array. When both listener and route
-                      specify hostnames, there MUST be an intersection between the
-                      values for a Route to be accepted. For more information, refer
-                      to the Route specific Hostnames documentation. \n Hostnames
-                      that are prefixed with a wildcard label (`*.`) are interpreted
-                      as a suffix match. That means that a match for `*.example.com`
-                      would match both `test.example.com`, and `foo.test.example.com`,
-                      but not `example.com`. \n Support: Core"
+                    description: |-
+                      Hostname specifies the virtual hostname to match for protocol types that
+                      define this concept. When unspecified, all hostnames are matched. This
+                      field is ignored for protocols that don't require hostname based
+                      matching.
+
+
+                      Implementations MUST apply Hostname matching appropriately for each of
+                      the following protocols:
+
+
+                      * TLS: The Listener Hostname MUST match the SNI.
+                      * HTTP: The Listener Hostname MUST match the Host header of the request.
+                      * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
+                        protocol layers as described above. If an implementation does not
+                        ensure that both the SNI and Host header match the Listener hostname,
+                        it MUST clearly document that.
+
+
+                      For HTTPRoute and TLSRoute resources, there is an interaction with the
+                      `spec.hostnames` array. When both listener and route specify hostnames,
+                      there MUST be an intersection between the values for a Route to be
+                      accepted. For more information, refer to the Route specific Hostnames
+                      documentation.
+
+
+                      Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                      as a suffix match. That means that a match for `*.example.com` would match
+                      both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   name:
-                    description: "Name is the name of the Listener. This name MUST
-                      be unique within a Gateway. \n Support: Core"
+                    description: |-
+                      Name is the name of the Listener. This name MUST be unique within a
+                      Gateway.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   port:
-                    description: "Port is the network port. Multiple listeners may
-                      use the same port, subject to the Listener compatibility rules.
-                      \n Support: Core"
+                    description: |-
+                      Port is the network port. Multiple listeners may use the
+                      same port, subject to the Listener compatibility rules.
+
+
+                      Support: Core
                     format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer
                   protocol:
-                    description: "Protocol specifies the network protocol this listener
-                      expects to receive. \n Support: Core"
+                    description: |-
+                      Protocol specifies the network protocol this listener expects to receive.
+
+
+                      Support: Core
                     maxLength: 255
                     minLength: 1
                     pattern: ^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
                     type: string
                   tls:
-                    description: "TLS is the TLS configuration for the Listener. This
-                      field is required if the Protocol field is \"HTTPS\" or \"TLS\".
-                      It is invalid to set this field if the Protocol field is \"HTTP\",
-                      \"TCP\", or \"UDP\". \n The association of SNIs to Certificate
-                      defined in GatewayTLSConfig is defined based on the Hostname
-                      field for this listener. \n The GatewayClass MUST use the longest
-                      matching SNI out of all available certificates for any TLS handshake.
-                      \n Support: Core"
+                    description: |-
+                      TLS is the TLS configuration for the Listener. This field is required if
+                      the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
+                      if the Protocol field is "HTTP", "TCP", or "UDP".
+
+
+                      The association of SNIs to Certificate defined in GatewayTLSConfig is
+                      defined based on the Hostname field for this listener.
+
+
+                      The GatewayClass MUST use the longest matching SNI out of all
+                      available certificates for any TLS handshake.
+
+
+                      Support: Core
                     properties:
                       certificateRefs:
-                        description: "CertificateRefs contains a series of references
-                          to Kubernetes objects that contains TLS certificates and
-                          private keys. These certificates are used to establish a
-                          TLS handshake for requests that match the hostname of the
-                          associated listener. \n A single CertificateRef to a Kubernetes
-                          Secret has \"Core\" support. Implementations MAY choose
-                          to support attaching multiple certificates to a Listener,
-                          but this behavior is implementation-specific. \n References
-                          to a resource in different namespace are invalid UNLESS
-                          there is a ReferenceGrant in the target namespace that allows
-                          the certificate to be attached. If a ReferenceGrant does
-                          not allow this reference, the \"ResolvedRefs\" condition
-                          MUST be set to False for this listener with the \"RefNotPermitted\"
-                          reason. \n This field is required to have at least one element
-                          when the mode is set to \"Terminate\" (default) and is optional
-                          otherwise. \n CertificateRefs can reference to standard
-                          Kubernetes resources, i.e. Secret, or implementation-specific
-                          custom resources. \n Support: Core - A single reference
-                          to a Kubernetes Secret of type kubernetes.io/tls \n Support:
-                          Implementation-specific (More than one reference or other
-                          resource types)"
+                        description: |-
+                          CertificateRefs contains a series of references to Kubernetes objects that
+                          contains TLS certificates and private keys. These certificates are used to
+                          establish a TLS handshake for requests that match the hostname of the
+                          associated listener.
+
+
+                          A single CertificateRef to a Kubernetes Secret has "Core" support.
+                          Implementations MAY choose to support attaching multiple certificates to
+                          a Listener, but this behavior is implementation-specific.
+
+
+                          References to a resource in different namespace are invalid UNLESS there
+                          is a ReferenceGrant in the target namespace that allows the certificate
+                          to be attached. If a ReferenceGrant does not allow this reference, the
+                          "ResolvedRefs" condition MUST be set to False for this listener with the
+                          "RefNotPermitted" reason.
+
+
+                          This field is required to have at least one element when the mode is set
+                          to "Terminate" (default) and is optional otherwise.
+
+
+                          CertificateRefs can reference to standard Kubernetes resources, i.e.
+                          Secret, or implementation-specific custom resources.
+
+
+                          Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
+
+                          Support: Implementation-specific (More than one reference or other resource types)
                         items:
-                          description: "SecretObjectReference identifies an API object
-                            including its namespace, defaulting to Secret. \n The
-                            API object must be valid in the cluster; the Group and
-                            Kind must be registered in the cluster for this reference
-                            to be valid. \n References to objects with invalid Group
-                            and Kind are not valid, and must be rejected by the implementation,
-                            with appropriate Conditions set on the containing object."
+                          description: |-
+                            SecretObjectReference identifies an API object including its namespace,
+                            defaulting to Secret.
+
+
+                            The API object must be valid in the cluster; the Group and Kind must
+                            be registered in the cluster for this reference to be valid.
+
+
+                            References to objects with invalid Group and Kind are not valid, and must
+                            be rejected by the implementation, with appropriate Conditions set
+                            on the containing object.
                           properties:
                             group:
                               default: ""
-                              description: Group is the group of the referent. For
-                                example, "gateway.networking.k8s.io". When unspecified
-                                or empty string, core API group is inferred.
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
                               maxLength: 253
                               pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
@@ -504,13 +713,18 @@ spec:
                               minLength: 1
                               type: string
                             namespace:
-                              description: "Namespace is the namespace of the referenced
-                                object. When unspecified, the local namespace is inferred.
-                                \n Note that when a namespace different than the local
-                                namespace is specified, a ReferenceGrant object is
-                                required in the referent namespace to allow that namespace's
-                                owner to accept the reference. See the ReferenceGrant
-                                documentation for details. \n Support: Core"
+                              description: |-
+                                Namespace is the namespace of the referenced object. When unspecified, the local
+                                namespace is inferred.
+
+
+                                Note that when a namespace different than the local namespace is specified,
+                                a ReferenceGrant object is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the ReferenceGrant
+                                documentation for details.
+
+
+                                Support: Core
                               maxLength: 63
                               minLength: 1
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -520,48 +734,157 @@ spec:
                           type: object
                         maxItems: 64
                         type: array
+                      frontendValidation:
+                        description: |+
+                          FrontendValidation holds configuration information for validating the frontend (client).
+                          Setting this field will require clients to send a client certificate
+                          required for validation during the TLS handshake. In browsers this may result in a dialog appearing
+                          that requests a user to specify the client certificate.
+                          The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+
+                          Support: Extended
+
+
+                        properties:
+                          caCertificateRefs:
+                            description: |-
+                              CACertificateRefs contains one or more references to
+                              Kubernetes objects that contain TLS certificates of
+                              the Certificate Authorities that can be used
+                              as a trust anchor to validate the certificates presented by the client.
+
+
+                              A single CA certificate reference to a Kubernetes ConfigMap
+                              has "Core" support.
+                              Implementations MAY choose to support attaching multiple CA certificates to
+                              a Listener, but this behavior is implementation-specific.
+
+
+                              Support: Core - A single reference to a Kubernetes ConfigMap
+                              with the CA certificate in a key named `ca.crt`.
+
+
+                              Support: Implementation-specific (More than one reference, or other kinds
+                              of resources).
+
+
+                              References to a resource in a different namespace are invalid UNLESS there
+                              is a ReferenceGrant in the target namespace that allows the certificate
+                              to be attached. If a ReferenceGrant does not allow this reference, the
+                              "ResolvedRefs" condition MUST be set to False for this listener with the
+                              "RefNotPermitted" reason.
+                            items:
+                              description: |-
+                                ObjectReference identifies an API object including its namespace.
+
+
+                                The API object must be valid in the cluster; the Group and Kind must
+                                be registered in the cluster for this reference to be valid.
+
+
+                                References to objects with invalid Group and Kind are not valid, and must
+                                be rejected by the implementation, with appropriate Conditions set
+                                on the containing object.
+                              properties:
+                                group:
+                                  description: |-
+                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                    When unspecified or empty string, core API group is inferred.
+                                  maxLength: 253
+                                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                kind:
+                                  description: Kind is kind of the referent. For example
+                                    "ConfigMap" or "Service".
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  type: string
+                                name:
+                                  description: Name is the name of the referent.
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of the referenced object. When unspecified, the local
+                                    namespace is inferred.
+
+
+                                    Note that when a namespace different than the local namespace is specified,
+                                    a ReferenceGrant object is required in the referent namespace to allow that
+                                    namespace's owner to accept the reference. See the ReferenceGrant
+                                    documentation for details.
+
+
+                                    Support: Core
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                              - group
+                              - kind
+                              - name
+                              type: object
+                            maxItems: 8
+                            minItems: 1
+                            type: array
+                        type: object
                       mode:
                         default: Terminate
-                        description: "Mode defines the TLS behavior for the TLS session
-                          initiated by the client. There are two possible modes: \n
-                          - Terminate: The TLS session between the downstream client
-                          and the Gateway is terminated at the Gateway. This mode
-                          requires certificateRefs to be set and contain at least
-                          one element. - Passthrough: The TLS session is NOT terminated
-                          by the Gateway. This implies that the Gateway can't decipher
-                          the TLS stream except for the ClientHello message of the
-                          TLS protocol. CertificateRefs field is ignored in this mode.
-                          \n Support: Core"
+                        description: |-
+                          Mode defines the TLS behavior for the TLS session initiated by the client.
+                          There are two possible modes:
+
+
+                          - Terminate: The TLS session between the downstream client and the
+                            Gateway is terminated at the Gateway. This mode requires certificates
+                            to be specified in some way, such as populating the certificateRefs
+                            field.
+                          - Passthrough: The TLS session is NOT terminated by the Gateway. This
+                            implies that the Gateway can't decipher the TLS stream except for
+                            the ClientHello message of the TLS protocol. The certificateRefs field
+                            is ignored in this mode.
+
+
+                          Support: Core
                         enum:
                         - Terminate
                         - Passthrough
                         type: string
                       options:
                         additionalProperties:
-                          description: AnnotationValue is the value of an annotation
-                            in Gateway API. This is used for validation of maps such
-                            as TLS options. This roughly matches Kubernetes annotation
-                            validation, although the length validation in that case
-                            is based on the entire size of the annotations struct.
+                          description: |-
+                            AnnotationValue is the value of an annotation in Gateway API. This is used
+                            for validation of maps such as TLS options. This roughly matches Kubernetes
+                            annotation validation, although the length validation in that case is based
+                            on the entire size of the annotations struct.
                           maxLength: 4096
                           minLength: 0
                           type: string
-                        description: "Options are a list of key/value pairs to enable
-                          extended TLS configuration for each implementation. For
-                          example, configuring the minimum TLS version or supported
-                          cipher suites. \n A set of common keys MAY be defined by
-                          the API in the future. To avoid any ambiguity, implementation-specific
-                          definitions MUST use domain-prefixed names, such as `example.com/my-custom-option`.
-                          Un-prefixed names are reserved for key names defined by
-                          Gateway API. \n Support: Implementation-specific"
+                        description: |-
+                          Options are a list of key/value pairs to enable extended TLS
+                          configuration for each implementation. For example, configuring the
+                          minimum TLS version or supported cipher suites.
+
+
+                          A set of common keys MAY be defined by the API in the future. To avoid
+                          any ambiguity, implementation-specific definitions MUST use
+                          domain-prefixed names, such as `example.com/my-custom-option`.
+                          Un-prefixed names are reserved for key names defined by Gateway API.
+
+
+                          Support: Implementation-specific
                         maxProperties: 16
                         type: object
                     type: object
                     x-kubernetes-validations:
-                    - message: certificateRefs must be specified when TLSModeType
+                    - message: certificateRefs or options must be specified when mode
                         is Terminate
                       rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
-                        > 0 : true'
+                        > 0 || size(self.options) > 0 : true'
                 required:
                 - name
                 - port
@@ -574,12 +897,12 @@ spec:
               - name
               x-kubernetes-list-type: map
               x-kubernetes-validations:
-              - message: tls must be specified for protocols ['HTTPS', 'TLS']
-                rule: 'self.all(l, l.protocol in [''HTTPS'', ''TLS''] ? has(l.tls)
-                  : true)'
               - message: tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']
                 rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ? !has(l.tls)
                   : true)'
+              - message: tls mode must be Terminate for protocol HTTPS
+                rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                  == '''' || l.tls.mode == ''Terminate'') : true)'
               - message: hostname must not be specified for protocols ['TCP', 'UDP']
                 rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
                   || l.hostname == '''') : true)'

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1beta1/httproutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1beta1/httproutes.yaml
@@ -17,20 +17,26 @@ spec:
     version: v1beta1
   validation:
     openAPIV3Schema:
-      description: HTTPRoute provides a way to route HTTP requests. This includes
-        the capability to match requests by hostname, path, header, or query param.
-        Filters can be used to specify additional processing steps. Backends specify
-        where matching requests should be routed.
+      description: |-
+        HTTPRoute provides a way to route HTTP requests. This includes the capability
+        to match requests by hostname, path, header, or query param. Filters can be
+        used to specify additional processing steps. Backends specify where matching
+        requests should be routed.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -69,56 +75,90 @@ spec:
           description: Spec defines the desired state of HTTPRoute.
           properties:
             hostnames:
-              description: "Hostnames defines a set of hostnames that should match
-                against the HTTP Host header to select a HTTPRoute used to process
-                the request. Implementations MUST ignore any port value specified
-                in the HTTP Host header while performing a match and (absent of any
-                applicable header modification configuration) MUST forward this header
-                unmodified to the backend. \n Valid values for Hostnames are determined
-                by RFC 1123 definition of a hostname with 2 notable exceptions: \n
-                1. IPs are not allowed. 2. A hostname may be prefixed with a wildcard
-                label (`*.`). The wildcard label must appear by itself as the first
-                label. \n If a hostname is specified by both the Listener and HTTPRoute,
-                there must be at least one intersecting hostname for the HTTPRoute
-                to be attached to the Listener. For example: \n * A Listener with
-                `test.example.com` as the hostname matches HTTPRoutes that have either
-                not specified any hostnames, or have specified at least one of `test.example.com`
-                or `*.example.com`. * A Listener with `*.example.com` as the hostname
-                matches HTTPRoutes that have either not specified any hostnames or
-                have specified at least one hostname that matches the Listener hostname.
-                For example, `*.example.com`, `test.example.com`, and `foo.test.example.com`
-                would all match. On the other hand, `example.com` and `test.example.net`
-                would not match. \n Hostnames that are prefixed with a wildcard label
-                (`*.`) are interpreted as a suffix match. That means that a match
-                for `*.example.com` would match both `test.example.com`, and `foo.test.example.com`,
-                but not `example.com`. \n If both the Listener and HTTPRoute have
-                specified hostnames, any HTTPRoute hostnames that do not match the
-                Listener hostname MUST be ignored. For example, if a Listener specified
-                `*.example.com`, and the HTTPRoute specified `test.example.com` and
-                `test.example.net`, `test.example.net` must not be considered for
-                a match. \n If both the Listener and HTTPRoute have specified hostnames,
-                and none match with the criteria above, then the HTTPRoute is not
-                accepted. The implementation must raise an 'Accepted' Condition with
-                a status of `False` in the corresponding RouteParentStatus. \n In
-                the event that multiple HTTPRoutes specify intersecting hostnames
-                (e.g. overlapping wildcard matching and exact matching hostnames),
-                precedence must be given to rules from the HTTPRoute with the largest
-                number of: \n * Characters in a matching non-wildcard hostname. *
-                Characters in a matching hostname. \n If ties exist across multiple
-                Routes, the matching precedence rules for HTTPRouteMatches takes over.
-                \n Support: Core"
+              description: |-
+                Hostnames defines a set of hostnames that should match against the HTTP Host
+                header to select a HTTPRoute used to process the request. Implementations
+                MUST ignore any port value specified in the HTTP Host header while
+                performing a match and (absent of any applicable header modification
+                configuration) MUST forward this header unmodified to the backend.
+
+
+                Valid values for Hostnames are determined by RFC 1123 definition of a
+                hostname with 2 notable exceptions:
+
+
+                1. IPs are not allowed.
+                2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                   label must appear by itself as the first label.
+
+
+                If a hostname is specified by both the Listener and HTTPRoute, there
+                must be at least one intersecting hostname for the HTTPRoute to be
+                attached to the Listener. For example:
+
+
+                * A Listener with `test.example.com` as the hostname matches HTTPRoutes
+                  that have either not specified any hostnames, or have specified at
+                  least one of `test.example.com` or `*.example.com`.
+                * A Listener with `*.example.com` as the hostname matches HTTPRoutes
+                  that have either not specified any hostnames or have specified at least
+                  one hostname that matches the Listener hostname. For example,
+                  `*.example.com`, `test.example.com`, and `foo.test.example.com` would
+                  all match. On the other hand, `example.com` and `test.example.net` would
+                  not match.
+
+
+                Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                as a suffix match. That means that a match for `*.example.com` would match
+                both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+
+                If both the Listener and HTTPRoute have specified hostnames, any
+                HTTPRoute hostnames that do not match the Listener hostname MUST be
+                ignored. For example, if a Listener specified `*.example.com`, and the
+                HTTPRoute specified `test.example.com` and `test.example.net`,
+                `test.example.net` must not be considered for a match.
+
+
+                If both the Listener and HTTPRoute have specified hostnames, and none
+                match with the criteria above, then the HTTPRoute is not accepted. The
+                implementation must raise an 'Accepted' Condition with a status of
+                `False` in the corresponding RouteParentStatus.
+
+
+                In the event that multiple HTTPRoutes specify intersecting hostnames (e.g.
+                overlapping wildcard matching and exact matching hostnames), precedence must
+                be given to rules from the HTTPRoute with the largest number of:
+
+
+                * Characters in a matching non-wildcard hostname.
+                * Characters in a matching hostname.
+
+
+                If ties exist across multiple Routes, the matching precedence rules for
+                HTTPRouteMatches takes over.
+
+
+                Support: Core
               items:
-                description: "Hostname is the fully qualified domain name of a network
-                  host. This matches the RFC 1123 definition of a hostname with 2
-                  notable exceptions: \n 1. IPs are not allowed. 2. A hostname may
-                  be prefixed with a wildcard label (`*.`). The wildcard label must
-                  appear by itself as the first label. \n Hostname can be \"precise\"
-                  which is a domain name without the terminating dot of a network
-                  host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
-                  name prefixed with a single wildcard label (e.g. `*.example.com`).
-                  \n Note that as per RFC1035 and RFC1123, a *label* must consist
-                  of lower case alphanumeric characters or '-', and must start and
-                  end with an alphanumeric character. No other punctuation is allowed."
+                description: |-
+                  Hostname is the fully qualified domain name of a network host. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                   1. IPs are not allowed.
+                   2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                      label must appear by itself as the first label.
+
+
+                  Hostname can be "precise" which is a domain name without the terminating
+                  dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                  domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                  Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                  alphanumeric characters or '-', and must start and end with an alphanumeric
+                  character. No other punctuation is allowed.
                 maxLength: 253
                 minLength: 1
                 pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -126,159 +166,246 @@ spec:
               maxItems: 16
               type: array
             parentRefs:
-              description: "ParentRefs references the resources (usually Gateways)
-                that a Route wants to be attached to. Note that the referenced parent
-                resource needs to allow this for the attachment to be complete. For
-                Gateways, that means the Gateway needs to allow attachment from Routes
-                of this kind and namespace. For Services, that means the Service must
-                either be in the same namespace for a \"producer\" route, or the mesh
-                implementation must support and allow \"consumer\" routes for the
-                referenced Service. ReferenceGrant is not applicable for governing
-                ParentRefs to Services - it is not possible to create a \"producer\"
-                route for a Service in a different namespace from the Route. \n There
-                are two kinds of parent resources with \"Core\" support: \n * Gateway
-                (Gateway conformance profile)  * Service (Mesh conformance profile,
-                experimental, ClusterIP Services only)  This API may be extended in
-                the future to support additional kinds of parent resources. \n ParentRefs
-                must be _distinct_. This means either that: \n * They select different
-                objects.  If this is the case, then parentRef entries are distinct.
-                In terms of fields, this means that the multi-part key defined by
-                `group`, `kind`, `namespace`, and `name` must be unique across all
-                parentRef entries in the Route. * They do not select different objects,
-                but for each optional field used, each ParentRef that selects the
-                same object must set the same set of optional fields to different
-                values. If one ParentRef sets a combination of optional fields, all
-                must set the same combination. \n Some examples: \n * If one ParentRef
-                sets `sectionName`, all ParentRefs referencing the same object must
-                also set `sectionName`. * If one ParentRef sets `port`, all ParentRefs
-                referencing the same object must also set `port`. * If one ParentRef
-                sets `sectionName` and `port`, all ParentRefs referencing the same
-                object must also set `sectionName` and `port`. \n It is possible to
-                separately reference multiple distinct objects that may be collapsed
-                by an implementation. For example, some implementations may choose
-                to merge compatible Gateway Listeners together. If that is the case,
-                the list of routes attached to those resources should also be merged.
-                \n Note that for ParentRefs that cross namespace boundaries, there
-                are specific rules. Cross-namespace references are only valid if they
-                are explicitly allowed by something in the namespace they are referring
-                to. For example, Gateway has the AllowedRoutes field, and ReferenceGrant
-                provides a generic way to enable other kinds of cross-namespace reference.
-                \n  ParentRefs from a Route to a Service in the same namespace are
-                \"producer\" routes, which apply default routing rules to inbound
-                connections from any namespace to the Service. \n ParentRefs from
-                a Route to a Service in a different namespace are \"consumer\" routes,
-                and these routing rules are only applied to outbound connections originating
-                from the same namespace as the Route, for which the intended destination
-                of the connections are a Service targeted as a ParentRef of the Route.
-                \ \n "
+              description: |+
+                ParentRefs references the resources (usually Gateways) that a Route wants
+                to be attached to. Note that the referenced parent resource needs to
+                allow this for the attachment to be complete. For Gateways, that means
+                the Gateway needs to allow attachment from Routes of this kind and
+                namespace. For Services, that means the Service must either be in the same
+                namespace for a "producer" route, or the mesh implementation must support
+                and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                not applicable for governing ParentRefs to Services - it is not possible to
+                create a "producer" route for a Service in a different namespace from the
+                Route.
+
+
+                There are two kinds of parent resources with "Core" support:
+
+
+                * Gateway (Gateway conformance profile)
+                * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                This API may be extended in the future to support additional kinds of parent
+                resources.
+
+
+                ParentRefs must be _distinct_. This means either that:
+
+
+                * They select different objects.  If this is the case, then parentRef
+                  entries are distinct. In terms of fields, this means that the
+                  multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                  be unique across all parentRef entries in the Route.
+                * They do not select different objects, but for each optional field used,
+                  each ParentRef that selects the same object must set the same set of
+                  optional fields to different values. If one ParentRef sets a
+                  combination of optional fields, all must set the same combination.
+
+
+                Some examples:
+
+
+                * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                  same object must also set `sectionName`.
+                * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`.
+                * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                  referencing the same object must also set `sectionName` and `port`.
+
+
+                It is possible to separately reference multiple distinct objects that may
+                be collapsed by an implementation. For example, some implementations may
+                choose to merge compatible Gateway Listeners together. If that is the
+                case, the list of routes attached to those resources should also be
+                merged.
+
+
+                Note that for ParentRefs that cross namespace boundaries, there are specific
+                rules. Cross-namespace references are only valid if they are explicitly
+                allowed by something in the namespace they are referring to. For example,
+                Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                generic way to enable other kinds of cross-namespace reference.
+
+
+
+                ParentRefs from a Route to a Service in the same namespace are "producer"
+                routes, which apply default routing rules to inbound connections from
+                any namespace to the Service.
+
+
+                ParentRefs from a Route to a Service in a different namespace are
+                "consumer" routes, and these routing rules are only applied to outbound
+                connections originating from the same namespace as the Route, for which
+                the intended destination of the connections are a Service targeted as a
+                ParentRef of the Route.
+
+
+
+
+
+
               items:
-                description: "ParentReference identifies an API object (usually a
-                  Gateway) that can be considered a parent of this resource (usually
-                  a route). There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
-                  API may be extended in the future to support additional kinds of
-                  parent resources. \n The API object must be valid in the cluster;
-                  the Group and Kind must be registered in the cluster for this reference
-                  to be valid."
+                description: |-
+                  ParentReference identifies an API object (usually a Gateway) that can be considered
+                  a parent of this resource (usually a route). There are two kinds of parent resources
+                  with "Core" support:
+
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+
+                  The API object must be valid in the cluster; the Group and Kind must
+                  be registered in the cluster for this reference to be valid.
                 properties:
                   group:
                     default: gateway.networking.k8s.io
-                    description: "Group is the group of the referent. When unspecified,
-                      \"gateway.networking.k8s.io\" is inferred. To set the core API
-                      group (such as for a \"Service\" kind referent), Group must
-                      be explicitly set to \"\" (empty string). \n Support: Core"
+                    description: |-
+                      Group is the group of the referent.
+                      When unspecified, "gateway.networking.k8s.io" is inferred.
+                      To set the core API group (such as for a "Service" kind referent),
+                      Group must be explicitly set to "" (empty string).
+
+
+                      Support: Core
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
                     default: Gateway
-                    description: "Kind is kind of the referent. \n There are two kinds
-                      of parent resources with \"Core\" support: \n * Gateway (Gateway
-                      conformance profile) * Service (Mesh conformance profile, experimental,
-                      ClusterIP Services only) \n Support for other resources is Implementation-Specific."
+                    description: |-
+                      Kind is kind of the referent.
+
+
+                      There are two kinds of parent resources with "Core" support:
+
+
+                      * Gateway (Gateway conformance profile)
+                      * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                      Support for other resources is Implementation-Specific.
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
-                    description: "Name is the name of the referent. \n Support: Core"
+                    description: |-
+                      Name is the name of the referent.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     type: string
                   namespace:
-                    description: "Namespace is the namespace of the referent. When
-                      unspecified, this refers to the local namespace of the Route.
-                      \n Note that there are specific rules for ParentRefs which cross
-                      namespace boundaries. Cross-namespace references are only valid
-                      if they are explicitly allowed by something in the namespace
-                      they are referring to. For example: Gateway has the AllowedRoutes
-                      field, and ReferenceGrant provides a generic way to enable any
-                      other kind of cross-namespace reference. \n  ParentRefs from
-                      a Route to a Service in the same namespace are \"producer\"
-                      routes, which apply default routing rules to inbound connections
-                      from any namespace to the Service. \n ParentRefs from a Route
-                      to a Service in a different namespace are \"consumer\" routes,
-                      and these routing rules are only applied to outbound connections
-                      originating from the same namespace as the Route, for which
-                      the intended destination of the connections are a Service targeted
-                      as a ParentRef of the Route.  \n Support: Core"
+                    description: |-
+                      Namespace is the namespace of the referent. When unspecified, this refers
+                      to the local namespace of the Route.
+
+
+                      Note that there are specific rules for ParentRefs which cross namespace
+                      boundaries. Cross-namespace references are only valid if they are explicitly
+                      allowed by something in the namespace they are referring to. For example:
+                      Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                      generic way to enable any other kind of cross-namespace reference.
+
+
+
+                      ParentRefs from a Route to a Service in the same namespace are "producer"
+                      routes, which apply default routing rules to inbound connections from
+                      any namespace to the Service.
+
+
+                      ParentRefs from a Route to a Service in a different namespace are
+                      "consumer" routes, and these routing rules are only applied to outbound
+                      connections originating from the same namespace as the Route, for which
+                      the intended destination of the connections are a Service targeted as a
+                      ParentRef of the Route.
+
+
+
+                      Support: Core
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   port:
-                    description: "Port is the network port this Route targets. It
-                      can be interpreted differently based on the type of parent resource.
-                      \n When the parent resource is a Gateway, this targets all listeners
-                      listening on the specified port that also support this kind
-                      of Route(and select this Route). It's not recommended to set
-                      `Port` unless the networking behaviors specified in a Route
-                      must apply to a specific port as opposed to a listener(s) whose
-                      port(s) may be changed. When both Port and SectionName are specified,
-                      the name and port of the selected listener must match both specified
-                      values. \n  When the parent resource is a Service, this targets
-                      a specific port in the Service spec. When both Port (experimental)
-                      and SectionName are specified, the name and port of the selected
-                      port must match both specified values.  \n Implementations MAY
-                      choose to support other parent resources. Implementations supporting
-                      other types of parent resources MUST clearly document how/if
-                      Port is interpreted. \n For the purpose of status, an attachment
-                      is considered successful as long as the parent resource accepts
-                      it partially. For example, Gateway listeners can restrict which
-                      Routes can attach to them by Route kind, namespace, or hostname.
-                      If 1 of 2 Gateway listeners accept attachment from the referencing
-                      Route, the Route MUST be considered successfully attached. If
-                      no Gateway listeners accept attachment from this Route, the
-                      Route MUST be considered detached from the Gateway. \n Support:
-                      Extended \n "
+                    description: |-
+                      Port is the network port this Route targets. It can be interpreted
+                      differently based on the type of parent resource.
+
+
+                      When the parent resource is a Gateway, this targets all listeners
+                      listening on the specified port that also support this kind of Route(and
+                      select this Route). It's not recommended to set `Port` unless the
+                      networking behaviors specified in a Route must apply to a specific port
+                      as opposed to a listener(s) whose port(s) may be changed. When both Port
+                      and SectionName are specified, the name and port of the selected listener
+                      must match both specified values.
+
+
+
+                      When the parent resource is a Service, this targets a specific port in the
+                      Service spec. When both Port (experimental) and SectionName are specified,
+                      the name and port of the selected port must match both specified values.
+
+
+
+                      Implementations MAY choose to support other parent resources.
+                      Implementations supporting other types of parent resources MUST clearly
+                      document how/if Port is interpreted.
+
+
+                      For the purpose of status, an attachment is considered successful as
+                      long as the parent resource accepts it partially. For example, Gateway
+                      listeners can restrict which Routes can attach to them by Route kind,
+                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                      from the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this Route,
+                      the Route MUST be considered detached from the Gateway.
+
+
+                      Support: Extended
                     format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer
                   sectionName:
-                    description: "SectionName is the name of a section within the
-                      target resource. In the following resources, SectionName is
-                      interpreted as the following: \n * Gateway: Listener Name. When
-                      both Port (experimental) and SectionName are specified, the
-                      name and port of the selected listener must match both specified
-                      values. * Service: Port Name. When both Port (experimental)
-                      and SectionName are specified, the name and port of the selected
-                      listener must match both specified values. Note that attaching
-                      Routes to Services as Parents is part of experimental Mesh support
-                      and is not supported for any other purpose. \n Implementations
-                      MAY choose to support attaching Routes to other resources. If
-                      that is the case, they MUST clearly document how SectionName
-                      is interpreted. \n When unspecified (empty string), this will
-                      reference the entire resource. For the purpose of status, an
-                      attachment is considered successful if at least one section
-                      in the parent resource accepts it. For example, Gateway listeners
-                      can restrict which Routes can attach to them by Route kind,
-                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
-                      from the referencing Route, the Route MUST be considered successfully
-                      attached. If no Gateway listeners accept attachment from this
-                      Route, the Route MUST be considered detached from the Gateway.
-                      \n Support: Core"
+                    description: |-
+                      SectionName is the name of a section within the target resource. In the
+                      following resources, SectionName is interpreted as the following:
+
+
+                      * Gateway: Listener name. When both Port (experimental) and SectionName
+                      are specified, the name and port of the selected listener must match
+                      both specified values.
+                      * Service: Port name. When both Port (experimental) and SectionName
+                      are specified, the name and port of the selected listener must match
+                      both specified values.
+
+
+                      Implementations MAY choose to support attaching Routes to other resources.
+                      If that is the case, they MUST clearly document how SectionName is
+                      interpreted.
+
+
+                      When unspecified (empty string), this will reference the entire resource.
+                      For the purpose of status, an attachment is considered successful if at
+                      least one section in the parent resource accepts it. For example, Gateway
+                      listeners can restrict which Routes can attach to them by Route kind,
+                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                      the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this Route, the
+                      Route MUST be considered detached from the Gateway.
+
+
+                      Support: Core
                     maxLength: 253
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -318,78 +445,120 @@ spec:
                     value: /
               description: Rules are a list of HTTP matchers, filters and actions.
               items:
-                description: HTTPRouteRule defines semantics for matching an HTTP
-                  request based on conditions (matches), processing it (filters),
-                  and forwarding the request to an API object (backendRefs).
+                description: |-
+                  HTTPRouteRule defines semantics for matching an HTTP request based on
+                  conditions (matches), processing it (filters), and forwarding the request to
+                  an API object (backendRefs).
                 properties:
                   backendRefs:
-                    description: "BackendRefs defines the backend(s) where matching
-                      requests should be sent. \n Failure behavior here depends on
-                      how many BackendRefs are specified and how many are invalid.
-                      \n If *all* entries in BackendRefs are invalid, and there are
-                      also no filters specified in this route rule, *all* traffic
-                      which matches this rule MUST receive a 500 status code. \n See
-                      the HTTPBackendRef definition for the rules about what makes
-                      a single HTTPBackendRef invalid. \n When a HTTPBackendRef is
-                      invalid, 500 status codes MUST be returned for requests that
-                      would have otherwise been routed to an invalid backend. If multiple
-                      backends are specified, and some are invalid, the proportion
-                      of requests that would otherwise have been routed to an invalid
-                      backend MUST receive a 500 status code. \n For example, if two
-                      backends are specified with equal weights, and one is invalid,
-                      50 percent of traffic must receive a 500. Implementations may
-                      choose how that 50 percent is determined. \n Support: Core for
-                      Kubernetes Service \n Support: Extended for Kubernetes ServiceImport
-                      \n Support: Implementation-specific for any other resource \n
-                      Support for weight: Core"
+                    description: |-
+                      BackendRefs defines the backend(s) where matching requests should be
+                      sent.
+
+
+                      Failure behavior here depends on how many BackendRefs are specified and
+                      how many are invalid.
+
+
+                      If *all* entries in BackendRefs are invalid, and there are also no filters
+                      specified in this route rule, *all* traffic which matches this rule MUST
+                      receive a 500 status code.
+
+
+                      See the HTTPBackendRef definition for the rules about what makes a single
+                      HTTPBackendRef invalid.
+
+
+                      When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
+                      requests that would have otherwise been routed to an invalid backend. If
+                      multiple backends are specified, and some are invalid, the proportion of
+                      requests that would otherwise have been routed to an invalid backend
+                      MUST receive a 500 status code.
+
+
+                      For example, if two backends are specified with equal weights, and one is
+                      invalid, 50 percent of traffic must receive a 500. Implementations may
+                      choose how that 50 percent is determined.
+
+
+                      Support: Core for Kubernetes Service
+
+
+                      Support: Extended for Kubernetes ServiceImport
+
+
+                      Support: Implementation-specific for any other resource
+
+
+                      Support for weight: Core
                     items:
-                      description: "HTTPBackendRef defines how a HTTPRoute forwards
-                        a HTTP request. \n Note that when a namespace different than
-                        the local namespace is specified, a ReferenceGrant object
-                        is required in the referent namespace to allow that namespace's
-                        owner to accept the reference. See the ReferenceGrant documentation
-                        for details. \n <gateway:experimental:description> \n When
-                        the BackendRef points to a Kubernetes Service, implementations
-                        SHOULD honor the appProtocol field if it is set for the target
-                        Service Port. \n Implementations supporting appProtocol SHOULD
-                        recognize the Kubernetes Standard Application Protocols defined
-                        in KEP-3726. \n If a Service appProtocol isn't specified,
-                        an implementation MAY infer the backend protocol through its
-                        own means. Implementations MAY infer the protocol from the
-                        Route type referring to the backend Service. \n If a Route
-                        is not able to send traffic to the backend using the specified
-                        protocol then the backend is considered invalid. Implementations
-                        MUST set the \"ResolvedRefs\" condition to \"False\" with
-                        the \"UnsupportedProtocol\" reason. \n </gateway:experimental:description>"
+                      description: |-
+                        HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.
+
+
+                        Note that when a namespace different than the local namespace is specified, a
+                        ReferenceGrant object is required in the referent namespace to allow that
+                        namespace's owner to accept the reference. See the ReferenceGrant
+                        documentation for details.
+
+
+                        <gateway:experimental:description>
+
+
+                        When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                        honor the appProtocol field if it is set for the target Service Port.
+
+
+                        Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                        Standard Application Protocols defined in KEP-3726.
+
+
+                        If a Service appProtocol isn't specified, an implementation MAY infer the
+                        backend protocol through its own means. Implementations MAY infer the
+                        protocol from the Route type referring to the backend Service.
+
+
+                        If a Route is not able to send traffic to the backend using the specified
+                        protocol then the backend is considered invalid. Implementations MUST set the
+                        "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                        </gateway:experimental:description>
                       properties:
                         filters:
-                          description: "Filters defined at this level should be executed
-                            if and only if the request is being forwarded to the backend
-                            defined here. \n Support: Implementation-specific (For
-                            broader support of filters, use the Filters field in HTTPRouteRule.)"
+                          description: |-
+                            Filters defined at this level should be executed if and only if the
+                            request is being forwarded to the backend defined here.
+
+
+                            Support: Implementation-specific (For broader support of filters, use the
+                            Filters field in HTTPRouteRule.)
                           items:
-                            description: HTTPRouteFilter defines processing steps
-                              that must be completed during the request or response
-                              lifecycle. HTTPRouteFilters are meant as an extension
-                              point to express processing that may be done in Gateway
-                              implementations. Some examples include request or response
-                              modification, implementing authentication strategies,
-                              rate-limiting, and traffic shaping. API guarantee/conformance
-                              is defined based on the type of the filter.
+                            description: |-
+                              HTTPRouteFilter defines processing steps that must be completed during the
+                              request or response lifecycle. HTTPRouteFilters are meant as an extension
+                              point to express processing that may be done in Gateway implementations. Some
+                              examples include request or response modification, implementing
+                              authentication strategies, rate-limiting, and traffic shaping. API
+                              guarantee/conformance is defined based on the type of the filter.
                             properties:
                               extensionRef:
-                                description: "ExtensionRef is an optional, implementation-specific
-                                  extension to the \"filter\" behavior.  For example,
-                                  resource \"myroutefilter\" in group \"networking.example.net\").
-                                  ExtensionRef MUST NOT be used for core and extended
-                                  filters. \n This filter can be used multiple times
-                                  within the same rule. \n Support: Implementation-specific"
+                                description: |-
+                                  ExtensionRef is an optional, implementation-specific extension to the
+                                  "filter" behavior.  For example, resource "myroutefilter" in group
+                                  "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                                  extended filters.
+
+
+                                  This filter can be used multiple times within the same rule.
+
+
+                                  Support: Implementation-specific
                                 properties:
                                   group:
-                                    description: Group is the group of the referent.
-                                      For example, "gateway.networking.k8s.io". When
-                                      unspecified or empty string, core API group
-                                      is inferred.
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
@@ -411,33 +580,49 @@ spec:
                                 - name
                                 type: object
                               requestHeaderModifier:
-                                description: "RequestHeaderModifier defines a schema
-                                  for a filter that modifies request headers. \n Support:
-                                  Core"
+                                description: |-
+                                  RequestHeaderModifier defines a schema for a filter that modifies request
+                                  headers.
+
+
+                                  Support: Core
                                 properties:
                                   add:
-                                    description: "Add adds the given header(s) (name,
-                                      value) to the request before the action. It
-                                      appends to any existing values associated with
-                                      the header name. \n Input: GET /foo HTTP/1.1
-                                      my-header: foo \n Config: add: - name: \"my-header\"
-                                      value: \"bar,baz\" \n Output: GET /foo HTTP/1.1
-                                      my-header: foo,bar,baz"
+                                    description: |-
+                                      Add adds the given header(s) (name, value) to the request
+                                      before the action. It appends to any existing values associated
+                                      with the header name.
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo
+
+
+                                      Config:
+                                        add:
+                                        - name: "my-header"
+                                          value: "bar,baz"
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo,bar,baz
                                     items:
                                       description: HTTPHeader represents an HTTP Header
                                         name and value as defined by RFC 7230.
                                       properties:
                                         name:
-                                          description: "Name is the name of the HTTP
-                                            Header to be matched. Name matching MUST
-                                            be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                            \n If multiple entries specify equivalent
-                                            header names, the first entry with an
-                                            equivalent name MUST be considered for
-                                            a match. Subsequent entries with an equivalent
-                                            header name MUST be ignored. Due to the
-                                            case-insensitivity of header names, \"foo\"
-                                            and \"Foo\" are considered equivalent."
+                                          description: |-
+                                            Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                            case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                            If multiple entries specify equivalent header names, the first entry with
+                                            an equivalent name MUST be considered for a match. Subsequent entries
+                                            with an equivalent header name MUST be ignored. Due to the
+                                            case-insensitivity of header names, "foo" and "Foo" are considered
+                                            equivalent.
                                           maxLength: 256
                                           minLength: 1
                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -458,41 +643,67 @@ spec:
                                     - name
                                     x-kubernetes-list-type: map
                                   remove:
-                                    description: "Remove the given header(s) from
-                                      the HTTP request before the action. The value
-                                      of Remove is a list of HTTP header names. Note
-                                      that the header names are case-insensitive (see
+                                    description: |-
+                                      Remove the given header(s) from the HTTP request before the action. The
+                                      value of Remove is a list of HTTP header names. Note that the header
+                                      names are case-insensitive (see
                                       https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-                                      \n Input: GET /foo HTTP/1.1 my-header1: foo
-                                      my-header2: bar my-header3: baz \n Config: remove:
-                                      [\"my-header1\", \"my-header3\"] \n Output:
-                                      GET /foo HTTP/1.1 my-header2: bar"
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header1: foo
+                                        my-header2: bar
+                                        my-header3: baz
+
+
+                                      Config:
+                                        remove: ["my-header1", "my-header3"]
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header2: bar
                                     items:
                                       type: string
                                     maxItems: 16
                                     type: array
                                     x-kubernetes-list-type: set
                                   set:
-                                    description: "Set overwrites the request with
-                                      the given header (name, value) before the action.
-                                      \n Input: GET /foo HTTP/1.1 my-header: foo \n
-                                      Config: set: - name: \"my-header\" value: \"bar\"
-                                      \n Output: GET /foo HTTP/1.1 my-header: bar"
+                                    description: |-
+                                      Set overwrites the request with the given header (name, value)
+                                      before the action.
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo
+
+
+                                      Config:
+                                        set:
+                                        - name: "my-header"
+                                          value: "bar"
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header: bar
                                     items:
                                       description: HTTPHeader represents an HTTP Header
                                         name and value as defined by RFC 7230.
                                       properties:
                                         name:
-                                          description: "Name is the name of the HTTP
-                                            Header to be matched. Name matching MUST
-                                            be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                            \n If multiple entries specify equivalent
-                                            header names, the first entry with an
-                                            equivalent name MUST be considered for
-                                            a match. Subsequent entries with an equivalent
-                                            header name MUST be ignored. Due to the
-                                            case-insensitivity of header names, \"foo\"
-                                            and \"Foo\" are considered equivalent."
+                                          description: |-
+                                            Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                            case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                            If multiple entries specify equivalent header names, the first entry with
+                                            an equivalent name MUST be considered for a match. Subsequent entries
+                                            with an equivalent header name MUST be ignored. Due to the
+                                            case-insensitivity of header names, "foo" and "Foo" are considered
+                                            equivalent.
                                           maxLength: 256
                                           minLength: 1
                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -514,63 +725,80 @@ spec:
                                     x-kubernetes-list-type: map
                                 type: object
                               requestMirror:
-                                description: "RequestMirror defines a schema for a
-                                  filter that mirrors requests. Requests are sent
-                                  to the specified destination, but responses from
-                                  that destination are ignored. \n This filter can
-                                  be used multiple times within the same rule. Note
-                                  that not all implementations will be able to support
-                                  mirroring to multiple backends. \n Support: Extended"
+                                description: |-
+                                  RequestMirror defines a schema for a filter that mirrors requests.
+                                  Requests are sent to the specified destination, but responses from
+                                  that destination are ignored.
+
+
+                                  This filter can be used multiple times within the same rule. Note that
+                                  not all implementations will be able to support mirroring to multiple
+                                  backends.
+
+
+                                  Support: Extended
                                 properties:
                                   backendRef:
-                                    description: "BackendRef references a resource
-                                      where mirrored requests are sent. \n Mirrored
-                                      requests must be sent only to a single destination
-                                      endpoint within this BackendRef, irrespective
-                                      of how many endpoints are present within this
-                                      BackendRef. \n If the referent cannot be found,
-                                      this BackendRef is invalid and must be dropped
-                                      from the Gateway. The controller must ensure
-                                      the \"ResolvedRefs\" condition on the Route
-                                      status is set to `status: False` and not configure
+                                    description: |-
+                                      BackendRef references a resource where mirrored requests are sent.
+
+
+                                      Mirrored requests must be sent only to a single destination endpoint
+                                      within this BackendRef, irrespective of how many endpoints are present
+                                      within this BackendRef.
+
+
+                                      If the referent cannot be found, this BackendRef is invalid and must be
+                                      dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                      condition on the Route status is set to `status: False` and not configure
                                       this backend in the underlying implementation.
-                                      \n If there is a cross-namespace reference to
-                                      an *existing* object that is not allowed by
-                                      a ReferenceGrant, the controller must ensure
-                                      the \"ResolvedRefs\"  condition on the Route
-                                      is set to `status: False`, with the \"RefNotPermitted\"
-                                      reason and not configure this backend in the
-                                      underlying implementation. \n In either error
-                                      case, the Message of the `ResolvedRefs` Condition
-                                      should be used to provide more detail about
-                                      the problem. \n Support: Extended for Kubernetes
-                                      Service \n Support: Implementation-specific
-                                      for any other resource"
+
+
+                                      If there is a cross-namespace reference to an *existing* object
+                                      that is not allowed by a ReferenceGrant, the controller must ensure the
+                                      "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                      with the "RefNotPermitted" reason and not configure this backend in the
+                                      underlying implementation.
+
+
+                                      In either error case, the Message of the `ResolvedRefs` Condition
+                                      should be used to provide more detail about the problem.
+
+
+                                      Support: Extended for Kubernetes Service
+
+
+                                      Support: Implementation-specific for any other resource
                                     properties:
                                       group:
                                         default: ""
-                                        description: Group is the group of the referent.
-                                          For example, "gateway.networking.k8s.io".
-                                          When unspecified or empty string, core API
-                                          group is inferred.
+                                        description: |-
+                                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                          When unspecified or empty string, core API group is inferred.
                                         maxLength: 253
                                         pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                         type: string
                                       kind:
                                         default: Service
-                                        description: "Kind is the Kubernetes resource
-                                          kind of the referent. For example \"Service\".
-                                          \n Defaults to \"Service\" when not specified.
-                                          \n ExternalName services can refer to CNAME
-                                          DNS records that may live outside of the
-                                          cluster and as such are difficult to reason
-                                          about in terms of conformance. They also
-                                          may not be safe to forward to (see CVE-2021-25740
-                                          for more information). Implementations SHOULD
-                                          NOT support ExternalName Services. \n Support:
-                                          Core (Services with a type other than ExternalName)
-                                          \n Support: Implementation-specific (Services
-                                          with type ExternalName)"
+                                        description: |-
+                                          Kind is the Kubernetes resource kind of the referent. For example
+                                          "Service".
+
+
+                                          Defaults to "Service" when not specified.
+
+
+                                          ExternalName services can refer to CNAME DNS records that may live
+                                          outside of the cluster and as such are difficult to reason about in
+                                          terms of conformance. They also may not be safe to forward to (see
+                                          CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                          support ExternalName Services.
+
+
+                                          Support: Core (Services with a type other than ExternalName)
+
+
+                                          Support: Implementation-specific (Services with type ExternalName)
                                         maxLength: 63
                                         minLength: 1
                                         pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -581,28 +809,29 @@ spec:
                                         minLength: 1
                                         type: string
                                       namespace:
-                                        description: "Namespace is the namespace of
-                                          the backend. When unspecified, the local
-                                          namespace is inferred. \n Note that when
-                                          a namespace different than the local namespace
-                                          is specified, a ReferenceGrant object is
-                                          required in the referent namespace to allow
-                                          that namespace's owner to accept the reference.
-                                          See the ReferenceGrant documentation for
-                                          details. \n Support: Core"
+                                        description: |-
+                                          Namespace is the namespace of the backend. When unspecified, the local
+                                          namespace is inferred.
+
+
+                                          Note that when a namespace different than the local namespace is specified,
+                                          a ReferenceGrant object is required in the referent namespace to allow that
+                                          namespace's owner to accept the reference. See the ReferenceGrant
+                                          documentation for details.
+
+
+                                          Support: Core
                                         maxLength: 63
                                         minLength: 1
                                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       port:
-                                        description: Port specifies the destination
-                                          port number to use for this resource. Port
-                                          is required when the referent is a Kubernetes
-                                          Service. In this case, the port number is
-                                          the service port number, not the target
-                                          port. For other resources, destination port
-                                          might be derived from the referent resource
-                                          or this field.
+                                        description: |-
+                                          Port specifies the destination port number to use for this resource.
+                                          Port is required when the referent is a Kubernetes Service. In this
+                                          case, the port number is the service port number, not the target port.
+                                          For other resources, destination port might be derived from the referent
+                                          resource or this field.
                                         format: int32
                                         maximum: 65535
                                         minimum: 1
@@ -618,80 +847,88 @@ spec:
                                 - backendRef
                                 type: object
                               requestRedirect:
-                                description: "RequestRedirect defines a schema for
-                                  a filter that responds to the request with an HTTP
-                                  redirection. \n Support: Core"
+                                description: |-
+                                  RequestRedirect defines a schema for a filter that responds to the
+                                  request with an HTTP redirection.
+
+
+                                  Support: Core
                                 properties:
                                   hostname:
-                                    description: "Hostname is the hostname to be used
-                                      in the value of the `Location` header in the
-                                      response. When empty, the hostname in the `Host`
-                                      header of the request is used. \n Support: Core"
+                                    description: |-
+                                      Hostname is the hostname to be used in the value of the `Location`
+                                      header in the response.
+                                      When empty, the hostname in the `Host` header of the request is used.
+
+
+                                      Support: Core
                                     maxLength: 253
                                     minLength: 1
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
                                   path:
-                                    description: "Path defines parameters used to
-                                      modify the path of the incoming request. The
-                                      modified path is then used to construct the
-                                      `Location` header. When empty, the request path
-                                      is used as-is. \n Support: Extended"
+                                    description: |-
+                                      Path defines parameters used to modify the path of the incoming request.
+                                      The modified path is then used to construct the `Location` header. When
+                                      empty, the request path is used as-is.
+
+
+                                      Support: Extended
                                     properties:
                                       replaceFullPath:
-                                        description: ReplaceFullPath specifies the
-                                          value with which to replace the full path
+                                        description: |-
+                                          ReplaceFullPath specifies the value with which to replace the full path
                                           of a request during a rewrite or redirect.
                                         maxLength: 1024
                                         type: string
                                       replacePrefixMatch:
-                                        description: "ReplacePrefixMatch specifies
-                                          the value with which to replace the prefix
-                                          match of a request during a rewrite or redirect.
-                                          For example, a request to \"/foo/bar\" with
-                                          a prefix match of \"/foo\" and a ReplacePrefixMatch
-                                          of \"/xyz\" would be modified to \"/xyz/bar\".
-                                          \n Note that this matches the behavior of
-                                          the PathPrefix match type. This matches
-                                          full path elements. A path element refers
-                                          to the list of labels in the path split
-                                          by the `/` separator. When specified, a
-                                          trailing `/` is ignored. For example, the
-                                          paths `/abc`, `/abc/`, and `/abc/def` would
-                                          all match the prefix `/abc`, but the path
-                                          `/abcd` would not. \n ReplacePrefixMatch
-                                          is only compatible with a `PathPrefix` HTTPRouteMatch.
-                                          Using any other HTTPRouteMatch type on the
-                                          same HTTPRouteRule will result in the implementation
-                                          setting the Accepted Condition for the Route
-                                          to `status: False`. \n Request Path | Prefix
-                                          Match | Replace Prefix | Modified Path -------------|--------------|----------------|----------
-                                          /foo/bar     | /foo         | /xyz           |
-                                          /xyz/bar /foo/bar     | /foo         | /xyz/
-                                          \         | /xyz/bar /foo/bar     | /foo/
-                                          \       | /xyz           | /xyz/bar /foo/bar
-                                          \    | /foo/        | /xyz/          | /xyz/bar
-                                          /foo         | /foo         | /xyz           |
-                                          /xyz /foo/        | /foo         | /xyz
-                                          \          | /xyz/ /foo/bar     | /foo         |
-                                          <empty string> | /bar /foo/        | /foo
-                                          \        | <empty string> | / /foo         |
-                                          /foo         | <empty string> | / /foo/
-                                          \       | /foo         | /              |
-                                          / /foo         | /foo         | /              |
-                                          /"
+                                        description: |-
+                                          ReplacePrefixMatch specifies the value with which to replace the prefix
+                                          match of a request during a rewrite or redirect. For example, a request
+                                          to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                          of "/xyz" would be modified to "/xyz/bar".
+
+
+                                          Note that this matches the behavior of the PathPrefix match type. This
+                                          matches full path elements. A path element refers to the list of labels
+                                          in the path split by the `/` separator. When specified, a trailing `/` is
+                                          ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                          match the prefix `/abc`, but the path `/abcd` would not.
+
+
+                                          ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                          Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                          the implementation setting the Accepted Condition for the Route to `status: False`.
+
+
+                                          Request Path | Prefix Match | Replace Prefix | Modified Path
+                                          -------------|--------------|----------------|----------
+                                          /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                          /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                          /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                          /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                          /foo         | /foo         | /xyz           | /xyz
+                                          /foo/        | /foo         | /xyz           | /xyz/
+                                          /foo/bar     | /foo         | <empty string> | /bar
+                                          /foo/        | /foo         | <empty string> | /
+                                          /foo         | /foo         | <empty string> | /
+                                          /foo/        | /foo         | /              | /
+                                          /foo         | /foo         | /              | /
                                         maxLength: 1024
                                         type: string
                                       type:
-                                        description: "Type defines the type of path
-                                          modifier. Additional types may be added
-                                          in a future release of the API. \n Note
-                                          that values may be added to this enum, implementations
-                                          must ensure that unknown values will not
-                                          cause a crash. \n Unknown values here must
-                                          result in the implementation setting the
-                                          Accepted Condition for the Route to `status:
-                                          False`, with a Reason of `UnsupportedValue`."
+                                        description: |-
+                                          Type defines the type of path modifier. Additional types may be
+                                          added in a future release of the API.
+
+
+                                          Note that values may be added to this enum, implementations
+                                          must ensure that unknown values will not cause a crash.
+
+
+                                          Unknown values here must result in the implementation setting the
+                                          Accepted Condition for the Route to `status: False`, with a
+                                          Reason of `UnsupportedValue`.
                                         enum:
                                         - ReplaceFullPath
                                         - ReplacePrefixMatch
@@ -717,91 +954,127 @@ spec:
                                       rule: 'has(self.replacePrefixMatch) ? self.type
                                         == ''ReplacePrefixMatch'' : true'
                                   port:
-                                    description: "Port is the port to be used in the
-                                      value of the `Location` header in the response.
-                                      \n If no port is specified, the redirect port
-                                      MUST be derived using the following rules: \n
-                                      * If redirect scheme is not-empty, the redirect
-                                      port MUST be the well-known port associated
-                                      with the redirect scheme. Specifically \"http\"
-                                      to port 80 and \"https\" to port 443. If the
-                                      redirect scheme does not have a well-known port,
-                                      the listener port of the Gateway SHOULD be used.
-                                      * If redirect scheme is empty, the redirect
-                                      port MUST be the Gateway Listener port. \n Implementations
-                                      SHOULD NOT add the port number in the 'Location'
-                                      header in the following cases: \n * A Location
-                                      header that will use HTTP (whether that is determined
-                                      via the Listener protocol or the Scheme field)
-                                      _and_ use port 80. * A Location header that
-                                      will use HTTPS (whether that is determined via
-                                      the Listener protocol or the Scheme field) _and_
-                                      use port 443. \n Support: Extended"
+                                    description: |-
+                                      Port is the port to be used in the value of the `Location`
+                                      header in the response.
+
+
+                                      If no port is specified, the redirect port MUST be derived using the
+                                      following rules:
+
+
+                                      * If redirect scheme is not-empty, the redirect port MUST be the well-known
+                                        port associated with the redirect scheme. Specifically "http" to port 80
+                                        and "https" to port 443. If the redirect scheme does not have a
+                                        well-known port, the listener port of the Gateway SHOULD be used.
+                                      * If redirect scheme is empty, the redirect port MUST be the Gateway
+                                        Listener port.
+
+
+                                      Implementations SHOULD NOT add the port number in the 'Location'
+                                      header in the following cases:
+
+
+                                      * A Location header that will use HTTP (whether that is determined via
+                                        the Listener protocol or the Scheme field) _and_ use port 80.
+                                      * A Location header that will use HTTPS (whether that is determined via
+                                        the Listener protocol or the Scheme field) _and_ use port 443.
+
+
+                                      Support: Extended
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
                                     type: integer
                                   scheme:
-                                    description: "Scheme is the scheme to be used
-                                      in the value of the `Location` header in the
-                                      response. When empty, the scheme of the request
-                                      is used. \n Scheme redirects can affect the
-                                      port of the redirect, for more information,
-                                      refer to the documentation for the port field
-                                      of this filter. \n Note that values may be added
-                                      to this enum, implementations must ensure that
-                                      unknown values will not cause a crash. \n Unknown
-                                      values here must result in the implementation
-                                      setting the Accepted Condition for the Route
-                                      to `status: False`, with a Reason of `UnsupportedValue`.
-                                      \n Support: Extended"
+                                    description: |-
+                                      Scheme is the scheme to be used in the value of the `Location` header in
+                                      the response. When empty, the scheme of the request is used.
+
+
+                                      Scheme redirects can affect the port of the redirect, for more information,
+                                      refer to the documentation for the port field of this filter.
+
+
+                                      Note that values may be added to this enum, implementations
+                                      must ensure that unknown values will not cause a crash.
+
+
+                                      Unknown values here must result in the implementation setting the
+                                      Accepted Condition for the Route to `status: False`, with a
+                                      Reason of `UnsupportedValue`.
+
+
+                                      Support: Extended
                                     enum:
                                     - http
                                     - https
                                     type: string
                                   statusCode:
                                     default: 302
-                                    description: "StatusCode is the HTTP status code
-                                      to be used in response. \n Note that values
-                                      may be added to this enum, implementations must
-                                      ensure that unknown values will not cause a
-                                      crash. \n Unknown values here must result in
-                                      the implementation setting the Accepted Condition
-                                      for the Route to `status: False`, with a Reason
-                                      of `UnsupportedValue`. \n Support: Core"
+                                    description: |-
+                                      StatusCode is the HTTP status code to be used in response.
+
+
+                                      Note that values may be added to this enum, implementations
+                                      must ensure that unknown values will not cause a crash.
+
+
+                                      Unknown values here must result in the implementation setting the
+                                      Accepted Condition for the Route to `status: False`, with a
+                                      Reason of `UnsupportedValue`.
+
+
+                                      Support: Core
                                     enum:
                                     - 301
                                     - 302
                                     type: integer
                                 type: object
                               responseHeaderModifier:
-                                description: "ResponseHeaderModifier defines a schema
-                                  for a filter that modifies response headers. \n
-                                  Support: Extended"
+                                description: |-
+                                  ResponseHeaderModifier defines a schema for a filter that modifies response
+                                  headers.
+
+
+                                  Support: Extended
                                 properties:
                                   add:
-                                    description: "Add adds the given header(s) (name,
-                                      value) to the request before the action. It
-                                      appends to any existing values associated with
-                                      the header name. \n Input: GET /foo HTTP/1.1
-                                      my-header: foo \n Config: add: - name: \"my-header\"
-                                      value: \"bar,baz\" \n Output: GET /foo HTTP/1.1
-                                      my-header: foo,bar,baz"
+                                    description: |-
+                                      Add adds the given header(s) (name, value) to the request
+                                      before the action. It appends to any existing values associated
+                                      with the header name.
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo
+
+
+                                      Config:
+                                        add:
+                                        - name: "my-header"
+                                          value: "bar,baz"
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo,bar,baz
                                     items:
                                       description: HTTPHeader represents an HTTP Header
                                         name and value as defined by RFC 7230.
                                       properties:
                                         name:
-                                          description: "Name is the name of the HTTP
-                                            Header to be matched. Name matching MUST
-                                            be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                            \n If multiple entries specify equivalent
-                                            header names, the first entry with an
-                                            equivalent name MUST be considered for
-                                            a match. Subsequent entries with an equivalent
-                                            header name MUST be ignored. Due to the
-                                            case-insensitivity of header names, \"foo\"
-                                            and \"Foo\" are considered equivalent."
+                                          description: |-
+                                            Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                            case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                            If multiple entries specify equivalent header names, the first entry with
+                                            an equivalent name MUST be considered for a match. Subsequent entries
+                                            with an equivalent header name MUST be ignored. Due to the
+                                            case-insensitivity of header names, "foo" and "Foo" are considered
+                                            equivalent.
                                           maxLength: 256
                                           minLength: 1
                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -822,41 +1095,67 @@ spec:
                                     - name
                                     x-kubernetes-list-type: map
                                   remove:
-                                    description: "Remove the given header(s) from
-                                      the HTTP request before the action. The value
-                                      of Remove is a list of HTTP header names. Note
-                                      that the header names are case-insensitive (see
+                                    description: |-
+                                      Remove the given header(s) from the HTTP request before the action. The
+                                      value of Remove is a list of HTTP header names. Note that the header
+                                      names are case-insensitive (see
                                       https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-                                      \n Input: GET /foo HTTP/1.1 my-header1: foo
-                                      my-header2: bar my-header3: baz \n Config: remove:
-                                      [\"my-header1\", \"my-header3\"] \n Output:
-                                      GET /foo HTTP/1.1 my-header2: bar"
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header1: foo
+                                        my-header2: bar
+                                        my-header3: baz
+
+
+                                      Config:
+                                        remove: ["my-header1", "my-header3"]
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header2: bar
                                     items:
                                       type: string
                                     maxItems: 16
                                     type: array
                                     x-kubernetes-list-type: set
                                   set:
-                                    description: "Set overwrites the request with
-                                      the given header (name, value) before the action.
-                                      \n Input: GET /foo HTTP/1.1 my-header: foo \n
-                                      Config: set: - name: \"my-header\" value: \"bar\"
-                                      \n Output: GET /foo HTTP/1.1 my-header: bar"
+                                    description: |-
+                                      Set overwrites the request with the given header (name, value)
+                                      before the action.
+
+
+                                      Input:
+                                        GET /foo HTTP/1.1
+                                        my-header: foo
+
+
+                                      Config:
+                                        set:
+                                        - name: "my-header"
+                                          value: "bar"
+
+
+                                      Output:
+                                        GET /foo HTTP/1.1
+                                        my-header: bar
                                     items:
                                       description: HTTPHeader represents an HTTP Header
                                         name and value as defined by RFC 7230.
                                       properties:
                                         name:
-                                          description: "Name is the name of the HTTP
-                                            Header to be matched. Name matching MUST
-                                            be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                            \n If multiple entries specify equivalent
-                                            header names, the first entry with an
-                                            equivalent name MUST be considered for
-                                            a match. Subsequent entries with an equivalent
-                                            header name MUST be ignored. Due to the
-                                            case-insensitivity of header names, \"foo\"
-                                            and \"Foo\" are considered equivalent."
+                                          description: |-
+                                            Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                            case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                            If multiple entries specify equivalent header names, the first entry with
+                                            an equivalent name MUST be considered for a match. Subsequent entries
+                                            with an equivalent header name MUST be ignored. Due to the
+                                            case-insensitivity of header names, "foo" and "Foo" are considered
+                                            equivalent.
                                           maxLength: 256
                                           minLength: 1
                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -878,35 +1177,46 @@ spec:
                                     x-kubernetes-list-type: map
                                 type: object
                               type:
-                                description: "Type identifies the type of filter to
-                                  apply. As with other API fields, types are classified
-                                  into three conformance levels: \n - Core: Filter
-                                  types and their corresponding configuration defined
-                                  by \"Support: Core\" in this package, e.g. \"RequestHeaderModifier\".
-                                  All implementations must support core filters. \n
-                                  - Extended: Filter types and their corresponding
-                                  configuration defined by \"Support: Extended\" in
-                                  this package, e.g. \"RequestMirror\". Implementers
-                                  are encouraged to support extended filters. \n -
-                                  Implementation-specific: Filters that are defined
-                                  and supported by specific vendors. In the future,
-                                  filters showing convergence in behavior across multiple
-                                  implementations will be considered for inclusion
-                                  in extended or core conformance levels. Filter-specific
-                                  configuration for such filters is specified using
-                                  the ExtensionRef field. `Type` should be set to
-                                  \"ExtensionRef\" for custom filters. \n Implementers
-                                  are encouraged to define custom implementation types
-                                  to extend the core API with implementation-specific
-                                  behavior. \n If a reference to a custom filter type
-                                  cannot be resolved, the filter MUST NOT be skipped.
-                                  Instead, requests that would have been processed
-                                  by that filter MUST receive a HTTP error response.
-                                  \n Note that values may be added to this enum, implementations
-                                  must ensure that unknown values will not cause a
-                                  crash. \n Unknown values here must result in the
-                                  implementation setting the Accepted Condition for
-                                  the Route to `status: False`, with a Reason of `UnsupportedValue`."
+                                description: |-
+                                  Type identifies the type of filter to apply. As with other API fields,
+                                  types are classified into three conformance levels:
+
+
+                                  - Core: Filter types and their corresponding configuration defined by
+                                    "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                    implementations must support core filters.
+
+
+                                  - Extended: Filter types and their corresponding configuration defined by
+                                    "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                    are encouraged to support extended filters.
+
+
+                                  - Implementation-specific: Filters that are defined and supported by
+                                    specific vendors.
+                                    In the future, filters showing convergence in behavior across multiple
+                                    implementations will be considered for inclusion in extended or core
+                                    conformance levels. Filter-specific configuration for such filters
+                                    is specified using the ExtensionRef field. `Type` should be set to
+                                    "ExtensionRef" for custom filters.
+
+
+                                  Implementers are encouraged to define custom implementation types to
+                                  extend the core API with implementation-specific behavior.
+
+
+                                  If a reference to a custom filter type cannot be resolved, the filter
+                                  MUST NOT be skipped. Instead, requests that would have been processed by
+                                  that filter MUST receive a HTTP error response.
+
+
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a crash.
+
+
+                                  Unknown values here must result in the implementation setting the
+                                  Accepted Condition for the Route to `status: False`, with a
+                                  Reason of `UnsupportedValue`.
                                 enum:
                                 - RequestHeaderModifier
                                 - ResponseHeaderModifier
@@ -916,76 +1226,84 @@ spec:
                                 - ExtensionRef
                                 type: string
                               urlRewrite:
-                                description: "URLRewrite defines a schema for a filter
-                                  that modifies a request during forwarding. \n Support:
-                                  Extended"
+                                description: |-
+                                  URLRewrite defines a schema for a filter that modifies a request during forwarding.
+
+
+                                  Support: Extended
                                 properties:
                                   hostname:
-                                    description: "Hostname is the value to be used
-                                      to replace the Host header value during forwarding.
-                                      \n Support: Extended"
+                                    description: |-
+                                      Hostname is the value to be used to replace the Host header value during
+                                      forwarding.
+
+
+                                      Support: Extended
                                     maxLength: 253
                                     minLength: 1
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
                                   path:
-                                    description: "Path defines a path rewrite. \n
-                                      Support: Extended"
+                                    description: |-
+                                      Path defines a path rewrite.
+
+
+                                      Support: Extended
                                     properties:
                                       replaceFullPath:
-                                        description: ReplaceFullPath specifies the
-                                          value with which to replace the full path
+                                        description: |-
+                                          ReplaceFullPath specifies the value with which to replace the full path
                                           of a request during a rewrite or redirect.
                                         maxLength: 1024
                                         type: string
                                       replacePrefixMatch:
-                                        description: "ReplacePrefixMatch specifies
-                                          the value with which to replace the prefix
-                                          match of a request during a rewrite or redirect.
-                                          For example, a request to \"/foo/bar\" with
-                                          a prefix match of \"/foo\" and a ReplacePrefixMatch
-                                          of \"/xyz\" would be modified to \"/xyz/bar\".
-                                          \n Note that this matches the behavior of
-                                          the PathPrefix match type. This matches
-                                          full path elements. A path element refers
-                                          to the list of labels in the path split
-                                          by the `/` separator. When specified, a
-                                          trailing `/` is ignored. For example, the
-                                          paths `/abc`, `/abc/`, and `/abc/def` would
-                                          all match the prefix `/abc`, but the path
-                                          `/abcd` would not. \n ReplacePrefixMatch
-                                          is only compatible with a `PathPrefix` HTTPRouteMatch.
-                                          Using any other HTTPRouteMatch type on the
-                                          same HTTPRouteRule will result in the implementation
-                                          setting the Accepted Condition for the Route
-                                          to `status: False`. \n Request Path | Prefix
-                                          Match | Replace Prefix | Modified Path -------------|--------------|----------------|----------
-                                          /foo/bar     | /foo         | /xyz           |
-                                          /xyz/bar /foo/bar     | /foo         | /xyz/
-                                          \         | /xyz/bar /foo/bar     | /foo/
-                                          \       | /xyz           | /xyz/bar /foo/bar
-                                          \    | /foo/        | /xyz/          | /xyz/bar
-                                          /foo         | /foo         | /xyz           |
-                                          /xyz /foo/        | /foo         | /xyz
-                                          \          | /xyz/ /foo/bar     | /foo         |
-                                          <empty string> | /bar /foo/        | /foo
-                                          \        | <empty string> | / /foo         |
-                                          /foo         | <empty string> | / /foo/
-                                          \       | /foo         | /              |
-                                          / /foo         | /foo         | /              |
-                                          /"
+                                        description: |-
+                                          ReplacePrefixMatch specifies the value with which to replace the prefix
+                                          match of a request during a rewrite or redirect. For example, a request
+                                          to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                          of "/xyz" would be modified to "/xyz/bar".
+
+
+                                          Note that this matches the behavior of the PathPrefix match type. This
+                                          matches full path elements. A path element refers to the list of labels
+                                          in the path split by the `/` separator. When specified, a trailing `/` is
+                                          ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                          match the prefix `/abc`, but the path `/abcd` would not.
+
+
+                                          ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                          Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                          the implementation setting the Accepted Condition for the Route to `status: False`.
+
+
+                                          Request Path | Prefix Match | Replace Prefix | Modified Path
+                                          -------------|--------------|----------------|----------
+                                          /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                          /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                          /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                          /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                          /foo         | /foo         | /xyz           | /xyz
+                                          /foo/        | /foo         | /xyz           | /xyz/
+                                          /foo/bar     | /foo         | <empty string> | /bar
+                                          /foo/        | /foo         | <empty string> | /
+                                          /foo         | /foo         | <empty string> | /
+                                          /foo/        | /foo         | /              | /
+                                          /foo         | /foo         | /              | /
                                         maxLength: 1024
                                         type: string
                                       type:
-                                        description: "Type defines the type of path
-                                          modifier. Additional types may be added
-                                          in a future release of the API. \n Note
-                                          that values may be added to this enum, implementations
-                                          must ensure that unknown values will not
-                                          cause a crash. \n Unknown values here must
-                                          result in the implementation setting the
-                                          Accepted Condition for the Route to `status:
-                                          False`, with a Reason of `UnsupportedValue`."
+                                        description: |-
+                                          Type defines the type of path modifier. Additional types may be
+                                          added in a future release of the API.
+
+
+                                          Note that values may be added to this enum, implementations
+                                          must ensure that unknown values will not cause a crash.
+
+
+                                          Unknown values here must result in the implementation setting the
+                                          Accepted Condition for the Route to `status: False`, with a
+                                          Reason of `UnsupportedValue`.
                                         enum:
                                         - ReplaceFullPath
                                         - ReplacePrefixMatch
@@ -1081,24 +1399,33 @@ spec:
                               1
                         group:
                           default: ""
-                          description: Group is the group of the referent. For example,
-                            "gateway.networking.k8s.io". When unspecified or empty
-                            string, core API group is inferred.
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Service
-                          description: "Kind is the Kubernetes resource kind of the
-                            referent. For example \"Service\". \n Defaults to \"Service\"
-                            when not specified. \n ExternalName services can refer
-                            to CNAME DNS records that may live outside of the cluster
-                            and as such are difficult to reason about in terms of
-                            conformance. They also may not be safe to forward to (see
-                            CVE-2021-25740 for more information). Implementations
-                            SHOULD NOT support ExternalName Services. \n Support:
-                            Core (Services with a type other than ExternalName) \n
-                            Support: Implementation-specific (Services with type ExternalName)"
+                          description: |-
+                            Kind is the Kubernetes resource kind of the referent. For example
+                            "Service".
+
+
+                            Defaults to "Service" when not specified.
+
+
+                            ExternalName services can refer to CNAME DNS records that may live
+                            outside of the cluster and as such are difficult to reason about in
+                            terms of conformance. They also may not be safe to forward to (see
+                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                            support ExternalName Services.
+
+
+                            Support: Core (Services with a type other than ExternalName)
+
+
+                            Support: Implementation-specific (Services with type ExternalName)
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1109,43 +1436,51 @@ spec:
                           minLength: 1
                           type: string
                         namespace:
-                          description: "Namespace is the namespace of the backend.
-                            When unspecified, the local namespace is inferred. \n
-                            Note that when a namespace different than the local namespace
-                            is specified, a ReferenceGrant object is required in the
-                            referent namespace to allow that namespace's owner to
-                            accept the reference. See the ReferenceGrant documentation
-                            for details. \n Support: Core"
+                          description: |-
+                            Namespace is the namespace of the backend. When unspecified, the local
+                            namespace is inferred.
+
+
+                            Note that when a namespace different than the local namespace is specified,
+                            a ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            Support: Core
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: Port specifies the destination port number
-                            to use for this resource. Port is required when the referent
-                            is a Kubernetes Service. In this case, the port number
-                            is the service port number, not the target port. For other
-                            resources, destination port might be derived from the
-                            referent resource or this field.
+                          description: |-
+                            Port specifies the destination port number to use for this resource.
+                            Port is required when the referent is a Kubernetes Service. In this
+                            case, the port number is the service port number, not the target port.
+                            For other resources, destination port might be derived from the referent
+                            resource or this field.
                           format: int32
                           maximum: 65535
                           minimum: 1
                           type: integer
                         weight:
                           default: 1
-                          description: "Weight specifies the proportion of requests
-                            forwarded to the referenced backend. This is computed
-                            as weight/(sum of all weights in this BackendRefs list).
-                            For non-zero values, there may be some epsilon from the
-                            exact proportion defined here depending on the precision
-                            an implementation supports. Weight is not a percentage
-                            and the sum of weights does not need to equal 100. \n
-                            If only one backend is specified and it has a weight greater
-                            than 0, 100% of the traffic is forwarded to that backend.
-                            If weight is set to 0, no traffic should be forwarded
-                            for this entry. If unspecified, weight defaults to 1.
-                            \n Support for this field varies based on the context
-                            where used."
+                          description: |-
+                            Weight specifies the proportion of requests forwarded to the referenced
+                            backend. This is computed as weight/(sum of all weights in this
+                            BackendRefs list). For non-zero values, there may be some epsilon from
+                            the exact proportion defined here depending on the precision an
+                            implementation supports. Weight is not a percentage and the sum of
+                            weights does not need to equal 100.
+
+
+                            If only one backend is specified and it has a weight greater than 0, 100%
+                            of the traffic is forwarded to that backend. If weight is set to 0, no
+                            traffic should be forwarded for this entry. If unspecified, weight
+                            defaults to 1.
+
+
+                            Support for this field varies based on the context where used.
                           format: int32
                           maximum: 1000000
                           minimum: 0
@@ -1160,45 +1495,77 @@ spec:
                     maxItems: 16
                     type: array
                   filters:
-                    description: "Filters define the filters that are applied to requests
-                      that match this rule. \n The effects of ordering of multiple
-                      behaviors are currently unspecified. This can change in the
-                      future based on feedback during the alpha stage. \n Conformance-levels
-                      at this level are defined based on the type of filter: \n -
-                      ALL core filters MUST be supported by all implementations. -
-                      Implementers are encouraged to support extended filters. - Implementation-specific
-                      custom filters have no API guarantees across implementations.
-                      \n Specifying the same filter multiple times is not supported
-                      unless explicitly indicated in the filter. \n All filters are
-                      expected to be compatible with each other except for the URLRewrite
-                      and RequestRedirect filters, which may not be combined. If an
-                      implementation can not support other combinations of filters,
-                      they must clearly document that limitation. In cases where incompatible
-                      or unsupported filters are specified and cause the `Accepted`
-                      condition to be set to status `False`, implementations may use
-                      the `IncompatibleFilters` reason to specify this configuration
-                      error. \n Support: Core"
+                    description: |-
+                      Filters define the filters that are applied to requests that match
+                      this rule.
+
+
+                      Wherever possible, implementations SHOULD implement filters in the order
+                      they are specified.
+
+
+                      Implementations MAY choose to implement this ordering strictly, rejecting
+                      any combination or order of filters that can not be supported. If implementations
+                      choose a strict interpretation of filter ordering, they MUST clearly document
+                      that behavior.
+
+
+                      To reject an invalid combination or order of filters, implementations SHOULD
+                      consider the Route Rules with this configuration invalid. If all Route Rules
+                      in a Route are invalid, the entire Route would be considered invalid. If only
+                      a portion of Route Rules are invalid, implementations MUST set the
+                      "PartiallyInvalid" condition for the Route.
+
+
+                      Conformance-levels at this level are defined based on the type of filter:
+
+
+                      - ALL core filters MUST be supported by all implementations.
+                      - Implementers are encouraged to support extended filters.
+                      - Implementation-specific custom filters have no API guarantees across
+                        implementations.
+
+
+                      Specifying the same filter multiple times is not supported unless explicitly
+                      indicated in the filter.
+
+
+                      All filters are expected to be compatible with each other except for the
+                      URLRewrite and RequestRedirect filters, which may not be combined. If an
+                      implementation can not support other combinations of filters, they must clearly
+                      document that limitation. In cases where incompatible or unsupported
+                      filters are specified and cause the `Accepted` condition to be set to status
+                      `False`, implementations may use the `IncompatibleFilters` reason to specify
+                      this configuration error.
+
+
+                      Support: Core
                     items:
-                      description: HTTPRouteFilter defines processing steps that must
-                        be completed during the request or response lifecycle. HTTPRouteFilters
-                        are meant as an extension point to express processing that
-                        may be done in Gateway implementations. Some examples include
-                        request or response modification, implementing authentication
-                        strategies, rate-limiting, and traffic shaping. API guarantee/conformance
-                        is defined based on the type of the filter.
+                      description: |-
+                        HTTPRouteFilter defines processing steps that must be completed during the
+                        request or response lifecycle. HTTPRouteFilters are meant as an extension
+                        point to express processing that may be done in Gateway implementations. Some
+                        examples include request or response modification, implementing
+                        authentication strategies, rate-limiting, and traffic shaping. API
+                        guarantee/conformance is defined based on the type of the filter.
                       properties:
                         extensionRef:
-                          description: "ExtensionRef is an optional, implementation-specific
-                            extension to the \"filter\" behavior.  For example, resource
-                            \"myroutefilter\" in group \"networking.example.net\").
-                            ExtensionRef MUST NOT be used for core and extended filters.
-                            \n This filter can be used multiple times within the same
-                            rule. \n Support: Implementation-specific"
+                          description: |-
+                            ExtensionRef is an optional, implementation-specific extension to the
+                            "filter" behavior.  For example, resource "myroutefilter" in group
+                            "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                            extended filters.
+
+
+                            This filter can be used multiple times within the same rule.
+
+
+                            Support: Implementation-specific
                           properties:
                             group:
-                              description: Group is the group of the referent. For
-                                example, "gateway.networking.k8s.io". When unspecified
-                                or empty string, core API group is inferred.
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
                               maxLength: 253
                               pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
@@ -1220,30 +1587,49 @@ spec:
                           - name
                           type: object
                         requestHeaderModifier:
-                          description: "RequestHeaderModifier defines a schema for
-                            a filter that modifies request headers. \n Support: Core"
+                          description: |-
+                            RequestHeaderModifier defines a schema for a filter that modifies request
+                            headers.
+
+
+                            Support: Core
                           properties:
                             add:
-                              description: "Add adds the given header(s) (name, value)
-                                to the request before the action. It appends to any
-                                existing values associated with the header name. \n
-                                Input: GET /foo HTTP/1.1 my-header: foo \n Config:
-                                add: - name: \"my-header\" value: \"bar,baz\" \n Output:
-                                GET /foo HTTP/1.1 my-header: foo,bar,baz"
+                              description: |-
+                                Add adds the given header(s) (name, value) to the request
+                                before the action. It appends to any existing values associated
+                                with the header name.
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo
+
+
+                                Config:
+                                  add:
+                                  - name: "my-header"
+                                    value: "bar,baz"
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo,bar,baz
                               items:
                                 description: HTTPHeader represents an HTTP Header
                                   name and value as defined by RFC 7230.
                                 properties:
                                   name:
-                                    description: "Name is the name of the HTTP Header
-                                      to be matched. Name matching MUST be case insensitive.
-                                      (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                      \n If multiple entries specify equivalent header
-                                      names, the first entry with an equivalent name
-                                      MUST be considered for a match. Subsequent entries
-                                      with an equivalent header name MUST be ignored.
-                                      Due to the case-insensitivity of header names,
-                                      \"foo\" and \"Foo\" are considered equivalent."
+                                    description: |-
+                                      Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                      case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                      If multiple entries specify equivalent header names, the first entry with
+                                      an equivalent name MUST be considered for a match. Subsequent entries
+                                      with an equivalent header name MUST be ignored. Due to the
+                                      case-insensitivity of header names, "foo" and "Foo" are considered
+                                      equivalent.
                                     maxLength: 256
                                     minLength: 1
                                     pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1264,39 +1650,67 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             remove:
-                              description: "Remove the given header(s) from the HTTP
-                                request before the action. The value of Remove is
-                                a list of HTTP header names. Note that the header
-                                names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-                                \n Input: GET /foo HTTP/1.1 my-header1: foo my-header2:
-                                bar my-header3: baz \n Config: remove: [\"my-header1\",
-                                \"my-header3\"] \n Output: GET /foo HTTP/1.1 my-header2:
-                                bar"
+                              description: |-
+                                Remove the given header(s) from the HTTP request before the action. The
+                                value of Remove is a list of HTTP header names. Note that the header
+                                names are case-insensitive (see
+                                https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header1: foo
+                                  my-header2: bar
+                                  my-header3: baz
+
+
+                                Config:
+                                  remove: ["my-header1", "my-header3"]
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header2: bar
                               items:
                                 type: string
                               maxItems: 16
                               type: array
                               x-kubernetes-list-type: set
                             set:
-                              description: "Set overwrites the request with the given
-                                header (name, value) before the action. \n Input:
-                                GET /foo HTTP/1.1 my-header: foo \n Config: set: -
-                                name: \"my-header\" value: \"bar\" \n Output: GET
-                                /foo HTTP/1.1 my-header: bar"
+                              description: |-
+                                Set overwrites the request with the given header (name, value)
+                                before the action.
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo
+
+
+                                Config:
+                                  set:
+                                  - name: "my-header"
+                                    value: "bar"
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header: bar
                               items:
                                 description: HTTPHeader represents an HTTP Header
                                   name and value as defined by RFC 7230.
                                 properties:
                                   name:
-                                    description: "Name is the name of the HTTP Header
-                                      to be matched. Name matching MUST be case insensitive.
-                                      (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                      \n If multiple entries specify equivalent header
-                                      names, the first entry with an equivalent name
-                                      MUST be considered for a match. Subsequent entries
-                                      with an equivalent header name MUST be ignored.
-                                      Due to the case-insensitivity of header names,
-                                      \"foo\" and \"Foo\" are considered equivalent."
+                                    description: |-
+                                      Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                      case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                      If multiple entries specify equivalent header names, the first entry with
+                                      an equivalent name MUST be considered for a match. Subsequent entries
+                                      with an equivalent header name MUST be ignored. Due to the
+                                      case-insensitivity of header names, "foo" and "Foo" are considered
+                                      equivalent.
                                     maxLength: 256
                                     minLength: 1
                                     pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1318,58 +1732,80 @@ spec:
                               x-kubernetes-list-type: map
                           type: object
                         requestMirror:
-                          description: "RequestMirror defines a schema for a filter
-                            that mirrors requests. Requests are sent to the specified
-                            destination, but responses from that destination are ignored.
-                            \n This filter can be used multiple times within the same
-                            rule. Note that not all implementations will be able to
-                            support mirroring to multiple backends. \n Support: Extended"
+                          description: |-
+                            RequestMirror defines a schema for a filter that mirrors requests.
+                            Requests are sent to the specified destination, but responses from
+                            that destination are ignored.
+
+
+                            This filter can be used multiple times within the same rule. Note that
+                            not all implementations will be able to support mirroring to multiple
+                            backends.
+
+
+                            Support: Extended
                           properties:
                             backendRef:
-                              description: "BackendRef references a resource where
-                                mirrored requests are sent. \n Mirrored requests must
-                                be sent only to a single destination endpoint within
-                                this BackendRef, irrespective of how many endpoints
-                                are present within this BackendRef. \n If the referent
-                                cannot be found, this BackendRef is invalid and must
-                                be dropped from the Gateway. The controller must ensure
-                                the \"ResolvedRefs\" condition on the Route status
-                                is set to `status: False` and not configure this backend
-                                in the underlying implementation. \n If there is a
-                                cross-namespace reference to an *existing* object
-                                that is not allowed by a ReferenceGrant, the controller
-                                must ensure the \"ResolvedRefs\"  condition on the
-                                Route is set to `status: False`, with the \"RefNotPermitted\"
-                                reason and not configure this backend in the underlying
-                                implementation. \n In either error case, the Message
-                                of the `ResolvedRefs` Condition should be used to
-                                provide more detail about the problem. \n Support:
-                                Extended for Kubernetes Service \n Support: Implementation-specific
-                                for any other resource"
+                              description: |-
+                                BackendRef references a resource where mirrored requests are sent.
+
+
+                                Mirrored requests must be sent only to a single destination endpoint
+                                within this BackendRef, irrespective of how many endpoints are present
+                                within this BackendRef.
+
+
+                                If the referent cannot be found, this BackendRef is invalid and must be
+                                dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                condition on the Route status is set to `status: False` and not configure
+                                this backend in the underlying implementation.
+
+
+                                If there is a cross-namespace reference to an *existing* object
+                                that is not allowed by a ReferenceGrant, the controller must ensure the
+                                "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                with the "RefNotPermitted" reason and not configure this backend in the
+                                underlying implementation.
+
+
+                                In either error case, the Message of the `ResolvedRefs` Condition
+                                should be used to provide more detail about the problem.
+
+
+                                Support: Extended for Kubernetes Service
+
+
+                                Support: Implementation-specific for any other resource
                               properties:
                                 group:
                                   default: ""
-                                  description: Group is the group of the referent.
-                                    For example, "gateway.networking.k8s.io". When
-                                    unspecified or empty string, core API group is
-                                    inferred.
+                                  description: |-
+                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                    When unspecified or empty string, core API group is inferred.
                                   maxLength: 253
                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                   type: string
                                 kind:
                                   default: Service
-                                  description: "Kind is the Kubernetes resource kind
-                                    of the referent. For example \"Service\". \n Defaults
-                                    to \"Service\" when not specified. \n ExternalName
-                                    services can refer to CNAME DNS records that may
-                                    live outside of the cluster and as such are difficult
-                                    to reason about in terms of conformance. They
-                                    also may not be safe to forward to (see CVE-2021-25740
-                                    for more information). Implementations SHOULD
-                                    NOT support ExternalName Services. \n Support:
-                                    Core (Services with a type other than ExternalName)
-                                    \n Support: Implementation-specific (Services
-                                    with type ExternalName)"
+                                  description: |-
+                                    Kind is the Kubernetes resource kind of the referent. For example
+                                    "Service".
+
+
+                                    Defaults to "Service" when not specified.
+
+
+                                    ExternalName services can refer to CNAME DNS records that may live
+                                    outside of the cluster and as such are difficult to reason about in
+                                    terms of conformance. They also may not be safe to forward to (see
+                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                    support ExternalName Services.
+
+
+                                    Support: Core (Services with a type other than ExternalName)
+
+
+                                    Support: Implementation-specific (Services with type ExternalName)
                                   maxLength: 63
                                   minLength: 1
                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1380,25 +1816,28 @@ spec:
                                   minLength: 1
                                   type: string
                                 namespace:
-                                  description: "Namespace is the namespace of the
-                                    backend. When unspecified, the local namespace
-                                    is inferred. \n Note that when a namespace different
-                                    than the local namespace is specified, a ReferenceGrant
-                                    object is required in the referent namespace to
-                                    allow that namespace's owner to accept the reference.
-                                    See the ReferenceGrant documentation for details.
-                                    \n Support: Core"
+                                  description: |-
+                                    Namespace is the namespace of the backend. When unspecified, the local
+                                    namespace is inferred.
+
+
+                                    Note that when a namespace different than the local namespace is specified,
+                                    a ReferenceGrant object is required in the referent namespace to allow that
+                                    namespace's owner to accept the reference. See the ReferenceGrant
+                                    documentation for details.
+
+
+                                    Support: Core
                                   maxLength: 63
                                   minLength: 1
                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                   type: string
                                 port:
-                                  description: Port specifies the destination port
-                                    number to use for this resource. Port is required
-                                    when the referent is a Kubernetes Service. In
-                                    this case, the port number is the service port
-                                    number, not the target port. For other resources,
-                                    destination port might be derived from the referent
+                                  description: |-
+                                    Port specifies the destination port number to use for this resource.
+                                    Port is required when the referent is a Kubernetes Service. In this
+                                    case, the port number is the service port number, not the target port.
+                                    For other resources, destination port might be derived from the referent
                                     resource or this field.
                                   format: int32
                                   maximum: 65535
@@ -1415,75 +1854,88 @@ spec:
                           - backendRef
                           type: object
                         requestRedirect:
-                          description: "RequestRedirect defines a schema for a filter
-                            that responds to the request with an HTTP redirection.
-                            \n Support: Core"
+                          description: |-
+                            RequestRedirect defines a schema for a filter that responds to the
+                            request with an HTTP redirection.
+
+
+                            Support: Core
                           properties:
                             hostname:
-                              description: "Hostname is the hostname to be used in
-                                the value of the `Location` header in the response.
-                                When empty, the hostname in the `Host` header of the
-                                request is used. \n Support: Core"
+                              description: |-
+                                Hostname is the hostname to be used in the value of the `Location`
+                                header in the response.
+                                When empty, the hostname in the `Host` header of the request is used.
+
+
+                                Support: Core
                               maxLength: 253
                               minLength: 1
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
                             path:
-                              description: "Path defines parameters used to modify
-                                the path of the incoming request. The modified path
-                                is then used to construct the `Location` header. When
-                                empty, the request path is used as-is. \n Support:
-                                Extended"
+                              description: |-
+                                Path defines parameters used to modify the path of the incoming request.
+                                The modified path is then used to construct the `Location` header. When
+                                empty, the request path is used as-is.
+
+
+                                Support: Extended
                               properties:
                                 replaceFullPath:
-                                  description: ReplaceFullPath specifies the value
-                                    with which to replace the full path of a request
-                                    during a rewrite or redirect.
+                                  description: |-
+                                    ReplaceFullPath specifies the value with which to replace the full path
+                                    of a request during a rewrite or redirect.
                                   maxLength: 1024
                                   type: string
                                 replacePrefixMatch:
-                                  description: "ReplacePrefixMatch specifies the value
-                                    with which to replace the prefix match of a request
-                                    during a rewrite or redirect. For example, a request
-                                    to \"/foo/bar\" with a prefix match of \"/foo\"
-                                    and a ReplacePrefixMatch of \"/xyz\" would be
-                                    modified to \"/xyz/bar\". \n Note that this matches
-                                    the behavior of the PathPrefix match type. This
-                                    matches full path elements. A path element refers
-                                    to the list of labels in the path split by the
-                                    `/` separator. When specified, a trailing `/`
-                                    is ignored. For example, the paths `/abc`, `/abc/`,
-                                    and `/abc/def` would all match the prefix `/abc`,
-                                    but the path `/abcd` would not. \n ReplacePrefixMatch
-                                    is only compatible with a `PathPrefix` HTTPRouteMatch.
-                                    Using any other HTTPRouteMatch type on the same
-                                    HTTPRouteRule will result in the implementation
-                                    setting the Accepted Condition for the Route to
-                                    `status: False`. \n Request Path | Prefix Match
-                                    | Replace Prefix | Modified Path -------------|--------------|----------------|----------
-                                    /foo/bar     | /foo         | /xyz           |
-                                    /xyz/bar /foo/bar     | /foo         | /xyz/          |
-                                    /xyz/bar /foo/bar     | /foo/        | /xyz           |
-                                    /xyz/bar /foo/bar     | /foo/        | /xyz/          |
-                                    /xyz/bar /foo         | /foo         | /xyz           |
-                                    /xyz /foo/        | /foo         | /xyz           |
-                                    /xyz/ /foo/bar     | /foo         | <empty string>
-                                    | /bar /foo/        | /foo         | <empty string>
-                                    | / /foo         | /foo         | <empty string>
-                                    | / /foo/        | /foo         | /              |
-                                    / /foo         | /foo         | /              |
-                                    /"
+                                  description: |-
+                                    ReplacePrefixMatch specifies the value with which to replace the prefix
+                                    match of a request during a rewrite or redirect. For example, a request
+                                    to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                    of "/xyz" would be modified to "/xyz/bar".
+
+
+                                    Note that this matches the behavior of the PathPrefix match type. This
+                                    matches full path elements. A path element refers to the list of labels
+                                    in the path split by the `/` separator. When specified, a trailing `/` is
+                                    ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                    match the prefix `/abc`, but the path `/abcd` would not.
+
+
+                                    ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                    Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                    the implementation setting the Accepted Condition for the Route to `status: False`.
+
+
+                                    Request Path | Prefix Match | Replace Prefix | Modified Path
+                                    -------------|--------------|----------------|----------
+                                    /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                    /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                    /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                    /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                    /foo         | /foo         | /xyz           | /xyz
+                                    /foo/        | /foo         | /xyz           | /xyz/
+                                    /foo/bar     | /foo         | <empty string> | /bar
+                                    /foo/        | /foo         | <empty string> | /
+                                    /foo         | /foo         | <empty string> | /
+                                    /foo/        | /foo         | /              | /
+                                    /foo         | /foo         | /              | /
                                   maxLength: 1024
                                   type: string
                                 type:
-                                  description: "Type defines the type of path modifier.
-                                    Additional types may be added in a future release
-                                    of the API. \n Note that values may be added to
-                                    this enum, implementations must ensure that unknown
-                                    values will not cause a crash. \n Unknown values
-                                    here must result in the implementation setting
-                                    the Accepted Condition for the Route to `status:
-                                    False`, with a Reason of `UnsupportedValue`."
+                                  description: |-
+                                    Type defines the type of path modifier. Additional types may be
+                                    added in a future release of the API.
+
+
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause a crash.
+
+
+                                    Unknown values here must result in the implementation setting the
+                                    Accepted Condition for the Route to `status: False`, with a
+                                    Reason of `UnsupportedValue`.
                                   enum:
                                   - ReplaceFullPath
                                   - ReplacePrefixMatch
@@ -1509,83 +1961,127 @@ spec:
                                 rule: 'has(self.replacePrefixMatch) ? self.type ==
                                   ''ReplacePrefixMatch'' : true'
                             port:
-                              description: "Port is the port to be used in the value
-                                of the `Location` header in the response. \n If no
-                                port is specified, the redirect port MUST be derived
-                                using the following rules: \n * If redirect scheme
-                                is not-empty, the redirect port MUST be the well-known
-                                port associated with the redirect scheme. Specifically
-                                \"http\" to port 80 and \"https\" to port 443. If
-                                the redirect scheme does not have a well-known port,
-                                the listener port of the Gateway SHOULD be used. *
-                                If redirect scheme is empty, the redirect port MUST
-                                be the Gateway Listener port. \n Implementations SHOULD
-                                NOT add the port number in the 'Location' header in
-                                the following cases: \n * A Location header that will
-                                use HTTP (whether that is determined via the Listener
-                                protocol or the Scheme field) _and_ use port 80. *
-                                A Location header that will use HTTPS (whether that
-                                is determined via the Listener protocol or the Scheme
-                                field) _and_ use port 443. \n Support: Extended"
+                              description: |-
+                                Port is the port to be used in the value of the `Location`
+                                header in the response.
+
+
+                                If no port is specified, the redirect port MUST be derived using the
+                                following rules:
+
+
+                                * If redirect scheme is not-empty, the redirect port MUST be the well-known
+                                  port associated with the redirect scheme. Specifically "http" to port 80
+                                  and "https" to port 443. If the redirect scheme does not have a
+                                  well-known port, the listener port of the Gateway SHOULD be used.
+                                * If redirect scheme is empty, the redirect port MUST be the Gateway
+                                  Listener port.
+
+
+                                Implementations SHOULD NOT add the port number in the 'Location'
+                                header in the following cases:
+
+
+                                * A Location header that will use HTTP (whether that is determined via
+                                  the Listener protocol or the Scheme field) _and_ use port 80.
+                                * A Location header that will use HTTPS (whether that is determined via
+                                  the Listener protocol or the Scheme field) _and_ use port 443.
+
+
+                                Support: Extended
                               format: int32
                               maximum: 65535
                               minimum: 1
                               type: integer
                             scheme:
-                              description: "Scheme is the scheme to be used in the
-                                value of the `Location` header in the response. When
-                                empty, the scheme of the request is used. \n Scheme
-                                redirects can affect the port of the redirect, for
-                                more information, refer to the documentation for the
-                                port field of this filter. \n Note that values may
-                                be added to this enum, implementations must ensure
-                                that unknown values will not cause a crash. \n Unknown
-                                values here must result in the implementation setting
-                                the Accepted Condition for the Route to `status: False`,
-                                with a Reason of `UnsupportedValue`. \n Support: Extended"
+                              description: |-
+                                Scheme is the scheme to be used in the value of the `Location` header in
+                                the response. When empty, the scheme of the request is used.
+
+
+                                Scheme redirects can affect the port of the redirect, for more information,
+                                refer to the documentation for the port field of this filter.
+
+
+                                Note that values may be added to this enum, implementations
+                                must ensure that unknown values will not cause a crash.
+
+
+                                Unknown values here must result in the implementation setting the
+                                Accepted Condition for the Route to `status: False`, with a
+                                Reason of `UnsupportedValue`.
+
+
+                                Support: Extended
                               enum:
                               - http
                               - https
                               type: string
                             statusCode:
                               default: 302
-                              description: "StatusCode is the HTTP status code to
-                                be used in response. \n Note that values may be added
-                                to this enum, implementations must ensure that unknown
-                                values will not cause a crash. \n Unknown values here
-                                must result in the implementation setting the Accepted
-                                Condition for the Route to `status: False`, with a
-                                Reason of `UnsupportedValue`. \n Support: Core"
+                              description: |-
+                                StatusCode is the HTTP status code to be used in response.
+
+
+                                Note that values may be added to this enum, implementations
+                                must ensure that unknown values will not cause a crash.
+
+
+                                Unknown values here must result in the implementation setting the
+                                Accepted Condition for the Route to `status: False`, with a
+                                Reason of `UnsupportedValue`.
+
+
+                                Support: Core
                               enum:
                               - 301
                               - 302
                               type: integer
                           type: object
                         responseHeaderModifier:
-                          description: "ResponseHeaderModifier defines a schema for
-                            a filter that modifies response headers. \n Support: Extended"
+                          description: |-
+                            ResponseHeaderModifier defines a schema for a filter that modifies response
+                            headers.
+
+
+                            Support: Extended
                           properties:
                             add:
-                              description: "Add adds the given header(s) (name, value)
-                                to the request before the action. It appends to any
-                                existing values associated with the header name. \n
-                                Input: GET /foo HTTP/1.1 my-header: foo \n Config:
-                                add: - name: \"my-header\" value: \"bar,baz\" \n Output:
-                                GET /foo HTTP/1.1 my-header: foo,bar,baz"
+                              description: |-
+                                Add adds the given header(s) (name, value) to the request
+                                before the action. It appends to any existing values associated
+                                with the header name.
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo
+
+
+                                Config:
+                                  add:
+                                  - name: "my-header"
+                                    value: "bar,baz"
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo,bar,baz
                               items:
                                 description: HTTPHeader represents an HTTP Header
                                   name and value as defined by RFC 7230.
                                 properties:
                                   name:
-                                    description: "Name is the name of the HTTP Header
-                                      to be matched. Name matching MUST be case insensitive.
-                                      (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                      \n If multiple entries specify equivalent header
-                                      names, the first entry with an equivalent name
-                                      MUST be considered for a match. Subsequent entries
-                                      with an equivalent header name MUST be ignored.
-                                      Due to the case-insensitivity of header names,
-                                      \"foo\" and \"Foo\" are considered equivalent."
+                                    description: |-
+                                      Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                      case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                      If multiple entries specify equivalent header names, the first entry with
+                                      an equivalent name MUST be considered for a match. Subsequent entries
+                                      with an equivalent header name MUST be ignored. Due to the
+                                      case-insensitivity of header names, "foo" and "Foo" are considered
+                                      equivalent.
                                     maxLength: 256
                                     minLength: 1
                                     pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1606,39 +2102,67 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             remove:
-                              description: "Remove the given header(s) from the HTTP
-                                request before the action. The value of Remove is
-                                a list of HTTP header names. Note that the header
-                                names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-                                \n Input: GET /foo HTTP/1.1 my-header1: foo my-header2:
-                                bar my-header3: baz \n Config: remove: [\"my-header1\",
-                                \"my-header3\"] \n Output: GET /foo HTTP/1.1 my-header2:
-                                bar"
+                              description: |-
+                                Remove the given header(s) from the HTTP request before the action. The
+                                value of Remove is a list of HTTP header names. Note that the header
+                                names are case-insensitive (see
+                                https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header1: foo
+                                  my-header2: bar
+                                  my-header3: baz
+
+
+                                Config:
+                                  remove: ["my-header1", "my-header3"]
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header2: bar
                               items:
                                 type: string
                               maxItems: 16
                               type: array
                               x-kubernetes-list-type: set
                             set:
-                              description: "Set overwrites the request with the given
-                                header (name, value) before the action. \n Input:
-                                GET /foo HTTP/1.1 my-header: foo \n Config: set: -
-                                name: \"my-header\" value: \"bar\" \n Output: GET
-                                /foo HTTP/1.1 my-header: bar"
+                              description: |-
+                                Set overwrites the request with the given header (name, value)
+                                before the action.
+
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo
+
+
+                                Config:
+                                  set:
+                                  - name: "my-header"
+                                    value: "bar"
+
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header: bar
                               items:
                                 description: HTTPHeader represents an HTTP Header
                                   name and value as defined by RFC 7230.
                                 properties:
                                   name:
-                                    description: "Name is the name of the HTTP Header
-                                      to be matched. Name matching MUST be case insensitive.
-                                      (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                      \n If multiple entries specify equivalent header
-                                      names, the first entry with an equivalent name
-                                      MUST be considered for a match. Subsequent entries
-                                      with an equivalent header name MUST be ignored.
-                                      Due to the case-insensitivity of header names,
-                                      \"foo\" and \"Foo\" are considered equivalent."
+                                    description: |-
+                                      Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                      case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                      If multiple entries specify equivalent header names, the first entry with
+                                      an equivalent name MUST be considered for a match. Subsequent entries
+                                      with an equivalent header name MUST be ignored. Due to the
+                                      case-insensitivity of header names, "foo" and "Foo" are considered
+                                      equivalent.
                                     maxLength: 256
                                     minLength: 1
                                     pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1660,32 +2184,46 @@ spec:
                               x-kubernetes-list-type: map
                           type: object
                         type:
-                          description: "Type identifies the type of filter to apply.
-                            As with other API fields, types are classified into three
-                            conformance levels: \n - Core: Filter types and their
-                            corresponding configuration defined by \"Support: Core\"
-                            in this package, e.g. \"RequestHeaderModifier\". All implementations
-                            must support core filters. \n - Extended: Filter types
-                            and their corresponding configuration defined by \"Support:
-                            Extended\" in this package, e.g. \"RequestMirror\". Implementers
-                            are encouraged to support extended filters. \n - Implementation-specific:
-                            Filters that are defined and supported by specific vendors.
-                            In the future, filters showing convergence in behavior
-                            across multiple implementations will be considered for
-                            inclusion in extended or core conformance levels. Filter-specific
-                            configuration for such filters is specified using the
-                            ExtensionRef field. `Type` should be set to \"ExtensionRef\"
-                            for custom filters. \n Implementers are encouraged to
-                            define custom implementation types to extend the core
-                            API with implementation-specific behavior. \n If a reference
-                            to a custom filter type cannot be resolved, the filter
-                            MUST NOT be skipped. Instead, requests that would have
-                            been processed by that filter MUST receive a HTTP error
-                            response. \n Note that values may be added to this enum,
-                            implementations must ensure that unknown values will not
-                            cause a crash. \n Unknown values here must result in the
-                            implementation setting the Accepted Condition for the
-                            Route to `status: False`, with a Reason of `UnsupportedValue`."
+                          description: |-
+                            Type identifies the type of filter to apply. As with other API fields,
+                            types are classified into three conformance levels:
+
+
+                            - Core: Filter types and their corresponding configuration defined by
+                              "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                              implementations must support core filters.
+
+
+                            - Extended: Filter types and their corresponding configuration defined by
+                              "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                              are encouraged to support extended filters.
+
+
+                            - Implementation-specific: Filters that are defined and supported by
+                              specific vendors.
+                              In the future, filters showing convergence in behavior across multiple
+                              implementations will be considered for inclusion in extended or core
+                              conformance levels. Filter-specific configuration for such filters
+                              is specified using the ExtensionRef field. `Type` should be set to
+                              "ExtensionRef" for custom filters.
+
+
+                            Implementers are encouraged to define custom implementation types to
+                            extend the core API with implementation-specific behavior.
+
+
+                            If a reference to a custom filter type cannot be resolved, the filter
+                            MUST NOT be skipped. Instead, requests that would have been processed by
+                            that filter MUST receive a HTTP error response.
+
+
+                            Note that values may be added to this enum, implementations
+                            must ensure that unknown values will not cause a crash.
+
+
+                            Unknown values here must result in the implementation setting the
+                            Accepted Condition for the Route to `status: False`, with a
+                            Reason of `UnsupportedValue`.
                           enum:
                           - RequestHeaderModifier
                           - ResponseHeaderModifier
@@ -1695,70 +2233,84 @@ spec:
                           - ExtensionRef
                           type: string
                         urlRewrite:
-                          description: "URLRewrite defines a schema for a filter that
-                            modifies a request during forwarding. \n Support: Extended"
+                          description: |-
+                            URLRewrite defines a schema for a filter that modifies a request during forwarding.
+
+
+                            Support: Extended
                           properties:
                             hostname:
-                              description: "Hostname is the value to be used to replace
-                                the Host header value during forwarding. \n Support:
-                                Extended"
+                              description: |-
+                                Hostname is the value to be used to replace the Host header value during
+                                forwarding.
+
+
+                                Support: Extended
                               maxLength: 253
                               minLength: 1
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
                             path:
-                              description: "Path defines a path rewrite. \n Support:
-                                Extended"
+                              description: |-
+                                Path defines a path rewrite.
+
+
+                                Support: Extended
                               properties:
                                 replaceFullPath:
-                                  description: ReplaceFullPath specifies the value
-                                    with which to replace the full path of a request
-                                    during a rewrite or redirect.
+                                  description: |-
+                                    ReplaceFullPath specifies the value with which to replace the full path
+                                    of a request during a rewrite or redirect.
                                   maxLength: 1024
                                   type: string
                                 replacePrefixMatch:
-                                  description: "ReplacePrefixMatch specifies the value
-                                    with which to replace the prefix match of a request
-                                    during a rewrite or redirect. For example, a request
-                                    to \"/foo/bar\" with a prefix match of \"/foo\"
-                                    and a ReplacePrefixMatch of \"/xyz\" would be
-                                    modified to \"/xyz/bar\". \n Note that this matches
-                                    the behavior of the PathPrefix match type. This
-                                    matches full path elements. A path element refers
-                                    to the list of labels in the path split by the
-                                    `/` separator. When specified, a trailing `/`
-                                    is ignored. For example, the paths `/abc`, `/abc/`,
-                                    and `/abc/def` would all match the prefix `/abc`,
-                                    but the path `/abcd` would not. \n ReplacePrefixMatch
-                                    is only compatible with a `PathPrefix` HTTPRouteMatch.
-                                    Using any other HTTPRouteMatch type on the same
-                                    HTTPRouteRule will result in the implementation
-                                    setting the Accepted Condition for the Route to
-                                    `status: False`. \n Request Path | Prefix Match
-                                    | Replace Prefix | Modified Path -------------|--------------|----------------|----------
-                                    /foo/bar     | /foo         | /xyz           |
-                                    /xyz/bar /foo/bar     | /foo         | /xyz/          |
-                                    /xyz/bar /foo/bar     | /foo/        | /xyz           |
-                                    /xyz/bar /foo/bar     | /foo/        | /xyz/          |
-                                    /xyz/bar /foo         | /foo         | /xyz           |
-                                    /xyz /foo/        | /foo         | /xyz           |
-                                    /xyz/ /foo/bar     | /foo         | <empty string>
-                                    | /bar /foo/        | /foo         | <empty string>
-                                    | / /foo         | /foo         | <empty string>
-                                    | / /foo/        | /foo         | /              |
-                                    / /foo         | /foo         | /              |
-                                    /"
+                                  description: |-
+                                    ReplacePrefixMatch specifies the value with which to replace the prefix
+                                    match of a request during a rewrite or redirect. For example, a request
+                                    to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                    of "/xyz" would be modified to "/xyz/bar".
+
+
+                                    Note that this matches the behavior of the PathPrefix match type. This
+                                    matches full path elements. A path element refers to the list of labels
+                                    in the path split by the `/` separator. When specified, a trailing `/` is
+                                    ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                    match the prefix `/abc`, but the path `/abcd` would not.
+
+
+                                    ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                    Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                    the implementation setting the Accepted Condition for the Route to `status: False`.
+
+
+                                    Request Path | Prefix Match | Replace Prefix | Modified Path
+                                    -------------|--------------|----------------|----------
+                                    /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                    /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                    /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                    /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                    /foo         | /foo         | /xyz           | /xyz
+                                    /foo/        | /foo         | /xyz           | /xyz/
+                                    /foo/bar     | /foo         | <empty string> | /bar
+                                    /foo/        | /foo         | <empty string> | /
+                                    /foo         | /foo         | <empty string> | /
+                                    /foo/        | /foo         | /              | /
+                                    /foo         | /foo         | /              | /
                                   maxLength: 1024
                                   type: string
                                 type:
-                                  description: "Type defines the type of path modifier.
-                                    Additional types may be added in a future release
-                                    of the API. \n Note that values may be added to
-                                    this enum, implementations must ensure that unknown
-                                    values will not cause a crash. \n Unknown values
-                                    here must result in the implementation setting
-                                    the Accepted Condition for the Route to `status:
-                                    False`, with a Reason of `UnsupportedValue`."
+                                  description: |-
+                                    Type defines the type of path modifier. Additional types may be
+                                    added in a future release of the API.
+
+
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause a crash.
+
+
+                                    Unknown values here must result in the implementation setting the
+                                    Accepted Condition for the Route to `status: False`, with a
+                                    Reason of `UnsupportedValue`.
                                   enum:
                                   - ReplaceFullPath
                                   - ReplacePrefixMatch
@@ -1850,84 +2402,134 @@ spec:
                     - path:
                         type: PathPrefix
                         value: /
-                    description: "Matches define conditions used for matching the
-                      rule against incoming HTTP requests. Each match is independent,
-                      i.e. this rule will be matched if **any** one of the matches
-                      is satisfied. \n For example, take the following matches configuration:
-                      \n ``` matches: - path: value: \"/foo\" headers: - name: \"version\"
-                      value: \"v2\" - path: value: \"/v2/foo\" ``` \n For a request
-                      to match against this rule, a request must satisfy EITHER of
-                      the two conditions: \n - path prefixed with `/foo` AND contains
-                      the header `version: v2` - path prefix of `/v2/foo` \n See the
-                      documentation for HTTPRouteMatch on how to specify multiple
-                      match conditions that should be ANDed together. \n If no matches
-                      are specified, the default is a prefix path match on \"/\",
-                      which has the effect of matching every HTTP request. \n Proxy
-                      or Load Balancer routing configuration generated from HTTPRoutes
-                      MUST prioritize matches based on the following criteria, continuing
-                      on ties. Across all rules specified on applicable Routes, precedence
-                      must be given to the match having: \n * \"Exact\" path match.
-                      * \"Prefix\" path match with largest number of characters. *
-                      Method match. * Largest number of header matches. * Largest
-                      number of query param matches. \n Note: The precedence of RegularExpression
-                      path matches are implementation-specific. \n If ties still exist
-                      across multiple Routes, matching precedence MUST be determined
-                      in order of the following criteria, continuing on ties: \n *
-                      The oldest Route based on creation timestamp. * The Route appearing
-                      first in alphabetical order by \"{namespace}/{name}\". \n If
-                      ties still exist within an HTTPRoute, matching precedence MUST
-                      be granted to the FIRST matching rule (in list order) with a
-                      match meeting the above criteria. \n When no rules matching
-                      a request have been successfully attached to the parent a request
-                      is coming from, a HTTP 404 status code MUST be returned."
+                    description: |-
+                      Matches define conditions used for matching the rule against incoming
+                      HTTP requests. Each match is independent, i.e. this rule will be matched
+                      if **any** one of the matches is satisfied.
+
+
+                      For example, take the following matches configuration:
+
+
+                      ```
+                      matches:
+                      - path:
+                          value: "/foo"
+                        headers:
+                        - name: "version"
+                          value: "v2"
+                      - path:
+                          value: "/v2/foo"
+                      ```
+
+
+                      For a request to match against this rule, a request must satisfy
+                      EITHER of the two conditions:
+
+
+                      - path prefixed with `/foo` AND contains the header `version: v2`
+                      - path prefix of `/v2/foo`
+
+
+                      See the documentation for HTTPRouteMatch on how to specify multiple
+                      match conditions that should be ANDed together.
+
+
+                      If no matches are specified, the default is a prefix
+                      path match on "/", which has the effect of matching every
+                      HTTP request.
+
+
+                      Proxy or Load Balancer routing configuration generated from HTTPRoutes
+                      MUST prioritize matches based on the following criteria, continuing on
+                      ties. Across all rules specified on applicable Routes, precedence must be
+                      given to the match having:
+
+
+                      * "Exact" path match.
+                      * "Prefix" path match with largest number of characters.
+                      * Method match.
+                      * Largest number of header matches.
+                      * Largest number of query param matches.
+
+
+                      Note: The precedence of RegularExpression path matches are implementation-specific.
+
+
+                      If ties still exist across multiple Routes, matching precedence MUST be
+                      determined in order of the following criteria, continuing on ties:
+
+
+                      * The oldest Route based on creation timestamp.
+                      * The Route appearing first in alphabetical order by
+                        "{namespace}/{name}".
+
+
+                      If ties still exist within an HTTPRoute, matching precedence MUST be granted
+                      to the FIRST matching rule (in list order) with a match meeting the above
+                      criteria.
+
+
+                      When no rules matching a request have been successfully attached to the
+                      parent a request is coming from, a HTTP 404 status code MUST be returned.
                     items:
                       description: "HTTPRouteMatch defines the predicate used to match
-                        requests to a given action. Multiple match types are ANDed
-                        together, i.e. the match will evaluate to true only if all
-                        conditions are satisfied. \n For example, the match below
-                        will match a HTTP request only if its path starts with `/foo`
-                        AND it contains the `version: v1` header: \n ``` match: \n
-                        path: value: \"/foo\" headers: - name: \"version\" value \"v1\"
-                        \n ```"
+                        requests to a given\naction. Multiple match types are ANDed
+                        together, i.e. the match will\nevaluate to true only if all
+                        conditions are satisfied.\n\n\nFor example, the match below
+                        will match a HTTP request only if its path\nstarts with `/foo`
+                        AND it contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                        \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t  value
+                        \"v1\"\n\n\n```"
                       properties:
                         headers:
-                          description: Headers specifies HTTP request header matchers.
-                            Multiple match values are ANDed together, meaning, a request
-                            must match all the specified headers to select the route.
+                          description: |-
+                            Headers specifies HTTP request header matchers. Multiple match values are
+                            ANDed together, meaning, a request must match all the specified headers
+                            to select the route.
                           items:
-                            description: HTTPHeaderMatch describes how to select a
-                              HTTP route by matching HTTP request headers.
+                            description: |-
+                              HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                              headers.
                             properties:
                               name:
-                                description: "Name is the name of the HTTP Header
-                                  to be matched. Name matching MUST be case insensitive.
-                                  (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                  \n If multiple entries specify equivalent header
-                                  names, only the first entry with an equivalent name
-                                  MUST be considered for a match. Subsequent entries
-                                  with an equivalent header name MUST be ignored.
-                                  Due to the case-insensitivity of header names, \"foo\"
-                                  and \"Foo\" are considered equivalent. \n When a
-                                  header is repeated in an HTTP request, it is implementation-specific
-                                  behavior as to how this is represented. Generally,
-                                  proxies should follow the guidance from the RFC:
-                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
-                                  regarding processing a repeated header, with special
-                                  handling for \"Set-Cookie\"."
+                                description: |-
+                                  Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                  case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                  If multiple entries specify equivalent header names, only the first
+                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                  entries with an equivalent header name MUST be ignored. Due to the
+                                  case-insensitivity of header names, "foo" and "Foo" are considered
+                                  equivalent.
+
+
+                                  When a header is repeated in an HTTP request, it is
+                                  implementation-specific behavior as to how this is represented.
+                                  Generally, proxies should follow the guidance from the RFC:
+                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                  processing a repeated header, with special handling for "Set-Cookie".
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                 type: string
                               type:
                                 default: Exact
-                                description: "Type specifies how to match against
-                                  the value of the header. \n Support: Core (Exact)
-                                  \n Support: Implementation-specific (RegularExpression)
-                                  \n Since RegularExpression HeaderMatchType has implementation-specific
-                                  conformance, implementations can support POSIX,
-                                  PCRE or any other dialects of regular expressions.
-                                  Please read the implementation's documentation to
-                                  determine the supported dialect."
+                                description: |-
+                                  Type specifies how to match against the value of the header.
+
+
+                                  Support: Core (Exact)
+
+
+                                  Support: Implementation-specific (RegularExpression)
+
+
+                                  Since RegularExpression HeaderMatchType has implementation-specific
+                                  conformance, implementations can support POSIX, PCRE or any other dialects
+                                  of regular expressions. Please read the implementation's documentation to
+                                  determine the supported dialect.
                                 enum:
                                 - Exact
                                 - RegularExpression
@@ -1948,9 +2550,13 @@ spec:
                           - name
                           x-kubernetes-list-type: map
                         method:
-                          description: "Method specifies HTTP method matcher. When
-                            specified, this route will be matched only if the request
-                            has the specified method. \n Support: Extended"
+                          description: |-
+                            Method specifies HTTP method matcher.
+                            When specified, this route will be matched only if the request has the
+                            specified method.
+
+
+                            Support: Extended
                           enum:
                           - GET
                           - HEAD
@@ -1966,15 +2572,20 @@ spec:
                           default:
                             type: PathPrefix
                             value: /
-                          description: Path specifies a HTTP request path matcher.
-                            If this field is not specified, a default prefix match
-                            on the "/" path is provided.
+                          description: |-
+                            Path specifies a HTTP request path matcher. If this field is not
+                            specified, a default prefix match on the "/" path is provided.
                           properties:
                             type:
                               default: PathPrefix
-                              description: "Type specifies how to match against the
-                                path Value. \n Support: Core (Exact, PathPrefix) \n
-                                Support: Implementation-specific (RegularExpression)"
+                              description: |-
+                                Type specifies how to match against the path Value.
+
+
+                                Support: Core (Exact, PathPrefix)
+
+
+                                Support: Implementation-specific (RegularExpression)
                               enum:
                               - Exact
                               - PathPrefix
@@ -2032,46 +2643,60 @@ spec:
                             rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
                               : true'
                         queryParams:
-                          description: "QueryParams specifies HTTP query parameter
-                            matchers. Multiple match values are ANDed together, meaning,
-                            a request must match all the specified query parameters
-                            to select the route. \n Support: Extended"
+                          description: |-
+                            QueryParams specifies HTTP query parameter matchers. Multiple match
+                            values are ANDed together, meaning, a request must match all the
+                            specified query parameters to select the route.
+
+
+                            Support: Extended
                           items:
-                            description: HTTPQueryParamMatch describes how to select
-                              a HTTP route by matching HTTP query parameters.
+                            description: |-
+                              HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                              query parameters.
                             properties:
                               name:
-                                description: "Name is the name of the HTTP query param
-                                  to be matched. This must be an exact string match.
-                                  (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
-                                  \n If multiple entries specify equivalent query
-                                  param names, only the first entry with an equivalent
-                                  name MUST be considered for a match. Subsequent
-                                  entries with an equivalent query param name MUST
-                                  be ignored. \n If a query param is repeated in an
-                                  HTTP request, the behavior is purposely left undefined,
-                                  since different data planes have different capabilities.
-                                  However, it is *recommended* that implementations
-                                  should match against the first value of the param
-                                  if the data plane supports it, as this behavior
-                                  is expected in other load balancing contexts outside
-                                  of the Gateway API. \n Users SHOULD NOT route traffic
-                                  based on repeated query params to guard themselves
-                                  against potential differences in the implementations."
+                                description: |-
+                                  Name is the name of the HTTP query param to be matched. This must be an
+                                  exact string match. (See
+                                  https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                  If multiple entries specify equivalent query param names, only the first
+                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                  entries with an equivalent query param name MUST be ignored.
+
+
+                                  If a query param is repeated in an HTTP request, the behavior is
+                                  purposely left undefined, since different data planes have different
+                                  capabilities. However, it is *recommended* that implementations should
+                                  match against the first value of the param if the data plane supports it,
+                                  as this behavior is expected in other load balancing contexts outside of
+                                  the Gateway API.
+
+
+                                  Users SHOULD NOT route traffic based on repeated query params to guard
+                                  themselves against potential differences in the implementations.
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                 type: string
                               type:
                                 default: Exact
-                                description: "Type specifies how to match against
-                                  the value of the query parameter. \n Support: Extended
-                                  (Exact) \n Support: Implementation-specific (RegularExpression)
-                                  \n Since RegularExpression QueryParamMatchType has
-                                  Implementation-specific conformance, implementations
-                                  can support POSIX, PCRE or any other dialects of
-                                  regular expressions. Please read the implementation's
-                                  documentation to determine the supported dialect."
+                                description: |-
+                                  Type specifies how to match against the value of the query parameter.
+
+
+                                  Support: Extended (Exact)
+
+
+                                  Support: Implementation-specific (RegularExpression)
+
+
+                                  Since RegularExpression QueryParamMatchType has Implementation-specific
+                                  conformance, implementations can support POSIX, PCRE or any other
+                                  dialects of regular expressions. Please read the implementation's
+                                  documentation to determine the supported dialect.
                                 enum:
                                 - Exact
                                 - RegularExpression
@@ -2094,39 +2719,168 @@ spec:
                       type: object
                     maxItems: 8
                     type: array
+                  sessionPersistence:
+                    description: |+
+                      SessionPersistence defines and configures session persistence
+                      for the route rule.
+
+
+                      Support: Extended
+
+
+                    properties:
+                      absoluteTimeout:
+                        description: |-
+                          AbsoluteTimeout defines the absolute timeout of the persistent
+                          session. Once the AbsoluteTimeout duration has elapsed, the
+                          session becomes invalid.
+
+
+                          Support: Extended
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                      cookieConfig:
+                        description: |-
+                          CookieConfig provides configuration settings that are specific
+                          to cookie-based session persistence.
+
+
+                          Support: Core
+                        properties:
+                          lifetimeType:
+                            default: Session
+                            description: |-
+                              LifetimeType specifies whether the cookie has a permanent or
+                              session-based lifetime. A permanent cookie persists until its
+                              specified expiry time, defined by the Expires or Max-Age cookie
+                              attributes, while a session cookie is deleted when the current
+                              session ends.
+
+
+                              When set to "Permanent", AbsoluteTimeout indicates the
+                              cookie's lifetime via the Expires or Max-Age cookie attributes
+                              and is required.
+
+
+                              When set to "Session", AbsoluteTimeout indicates the
+                              absolute lifetime of the cookie tracked by the gateway and
+                              is optional.
+
+
+                              Support: Core for "Session" type
+
+
+                              Support: Extended for "Permanent" type
+                            enum:
+                            - Permanent
+                            - Session
+                            type: string
+                        type: object
+                      idleTimeout:
+                        description: |-
+                          IdleTimeout defines the idle timeout of the persistent session.
+                          Once the session has been idle for more than the specified
+                          IdleTimeout duration, the session becomes invalid.
+
+
+                          Support: Extended
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                      sessionName:
+                        description: |-
+                          SessionName defines the name of the persistent session token
+                          which may be reflected in the cookie or the header. Users
+                          should avoid reusing session names to prevent unintended
+                          consequences, such as rejection or unpredictable behavior.
+
+
+                          Support: Implementation-specific
+                        maxLength: 128
+                        type: string
+                      type:
+                        default: Cookie
+                        description: |-
+                          Type defines the type of session persistence such as through
+                          the use a header or cookie. Defaults to cookie based session
+                          persistence.
+
+
+                          Support: Core for "Cookie" type
+
+
+                          Support: Extended for "Header" type
+                        enum:
+                        - Cookie
+                        - Header
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                        is Permanent
+                      rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                        != ''Permanent'' || has(self.absoluteTimeout)'
                   timeouts:
-                    description: "Timeouts defines the timeouts that can be configured
-                      for an HTTP request. \n Support: Extended \n "
+                    description: |+
+                      Timeouts defines the timeouts that can be configured for an HTTP request.
+
+
+                      Support: Extended
+
+
                     properties:
                       backendRequest:
-                        description: "BackendRequest specifies a timeout for an individual
-                          request from the gateway to a backend. This covers the time
-                          from when the request first starts being sent from the gateway
-                          to when the full response has been received from the backend.
-                          \n An entire client HTTP transaction with a gateway, covered
-                          by the Request timeout, may result in more than one call
-                          from the gateway to the destination backend, for example,
-                          if automatic retries are supported. \n Because the Request
-                          timeout encompasses the BackendRequest timeout, the value
-                          of BackendRequest must be <= the value of Request timeout.
-                          \n Support: Extended"
+                        description: |-
+                          BackendRequest specifies a timeout for an individual request from the gateway
+                          to a backend. This covers the time from when the request first starts being
+                          sent from the gateway to when the full response has been received from the backend.
+
+
+                          Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                          completely. Implementations that cannot completely disable the timeout MUST
+                          instead interpret the zero duration as the longest possible value to which
+                          the timeout can be set.
+
+
+                          An entire client HTTP transaction with a gateway, covered by the Request timeout,
+                          may result in more than one call from the gateway to the destination backend,
+                          for example, if automatic retries are supported.
+
+
+                          Because the Request timeout encompasses the BackendRequest timeout, the value of
+                          BackendRequest must be <= the value of Request timeout.
+
+
+                          Support: Extended
                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                       request:
-                        description: "Request specifies the maximum duration for a
-                          gateway to respond to an HTTP request. If the gateway has
-                          not been able to respond before this deadline is met, the
-                          gateway MUST return a timeout error. \n For example, setting
-                          the `rules.timeouts.request` field to the value `10s` in
-                          an `HTTPRoute` will cause a timeout if a client request
-                          is taking longer than 10 seconds to complete. \n This timeout
-                          is intended to cover as close to the whole request-response
-                          transaction as possible although an implementation MAY choose
-                          to start the timeout after the entire request stream has
-                          been received instead of immediately after the transaction
-                          is initiated by the client. \n When this field is unspecified,
-                          request timeout behavior is implementation-specific. \n
-                          Support: Extended"
+                        description: |-
+                          Request specifies the maximum duration for a gateway to respond to an HTTP request.
+                          If the gateway has not been able to respond before this deadline is met, the gateway
+                          MUST return a timeout error.
+
+
+                          For example, setting the `rules.timeouts.request` field to the value `10s` in an
+                          `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
+                          to complete.
+
+
+                          Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                          completely. Implementations that cannot completely disable the timeout MUST
+                          instead interpret the zero duration as the longest possible value to which
+                          the timeout can be set.
+
+
+                          This timeout is intended to cover as close to the whole request-response transaction
+                          as possible although an implementation MAY choose to start the timeout after the entire
+                          request stream has been received instead of immediately after the transaction is
+                          initiated by the client.
+
+
+                          When this field is unspecified, request timeout behavior is implementation-specific.
+
+
+                          Support: Extended
                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                     type: object

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1beta1/referencegrants.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/gateway.networking.k8s.io/v1beta1/referencegrants.yaml
@@ -17,28 +17,41 @@ spec:
     version: v1beta1
   validation:
     openAPIV3Schema:
-      description: "ReferenceGrant identifies kinds of resources in other namespaces
-        that are trusted to reference the specified kinds of resources in the same
-        namespace as the policy. \n Each ReferenceGrant can be used to represent a
-        unique trust relationship. Additional Reference Grants can be used to add
-        to the set of trusted sources of inbound references for the namespace they
-        are defined within. \n All cross-namespace references in Gateway API (with
-        the exception of cross-namespace Gateway-route attachment) require a ReferenceGrant.
-        \n ReferenceGrant is a form of runtime verification allowing users to assert
+      description: |-
+        ReferenceGrant identifies kinds of resources in other namespaces that are
+        trusted to reference the specified kinds of resources in the same namespace
+        as the policy.
+
+
+        Each ReferenceGrant can be used to represent a unique trust relationship.
+        Additional Reference Grants can be used to add to the set of trusted
+        sources of inbound references for the namespace they are defined within.
+
+
+        All cross-namespace references in Gateway API (with the exception of cross-namespace
+        Gateway-route attachment) require a ReferenceGrant.
+
+
+        ReferenceGrant is a form of runtime verification allowing users to assert
         which cross-namespace object references are permitted. Implementations that
         support ReferenceGrant MUST NOT permit cross-namespace references which have
         no grant, and MUST respond to the removal of a grant by revoking the access
-        that the grant allowed."
+        that the grant allowed.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           properties:
@@ -77,34 +90,58 @@ spec:
           description: Spec defines the desired state of ReferenceGrant.
           properties:
             from:
-              description: "From describes the trusted namespaces and kinds that can
-                reference the resources described in \"To\". Each entry in this list
-                MUST be considered to be an additional place that references can be
-                valid from, or to put this another way, entries MUST be combined using
-                OR. \n Support: Core"
+              description: |-
+                From describes the trusted namespaces and kinds that can reference the
+                resources described in "To". Each entry in this list MUST be considered
+                to be an additional place that references can be valid from, or to put
+                this another way, entries MUST be combined using OR.
+
+
+                Support: Core
               items:
                 description: ReferenceGrantFrom describes trusted namespaces and kinds.
                 properties:
                   group:
-                    description: "Group is the group of the referent. When empty,
-                      the Kubernetes core API group is inferred. \n Support: Core"
+                    description: |-
+                      Group is the group of the referent.
+                      When empty, the Kubernetes core API group is inferred.
+
+
+                      Support: Core
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
-                    description: "Kind is the kind of the referent. Although implementations
-                      may support additional resources, the following types are part
-                      of the \"Core\" support level for this field. \n When used to
-                      permit a SecretObjectReference: \n * Gateway \n When used to
-                      permit a BackendObjectReference: \n * GRPCRoute * HTTPRoute
-                      * TCPRoute * TLSRoute * UDPRoute"
+                    description: |-
+                      Kind is the kind of the referent. Although implementations may support
+                      additional resources, the following types are part of the "Core"
+                      support level for this field.
+
+
+                      When used to permit a SecretObjectReference:
+
+
+                      * Gateway
+
+
+                      When used to permit a BackendObjectReference:
+
+
+                      * GRPCRoute
+                      * HTTPRoute
+                      * TCPRoute
+                      * TLSRoute
+                      * UDPRoute
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   namespace:
-                    description: "Namespace is the namespace of the referent. \n Support:
-                      Core"
+                    description: |-
+                      Namespace is the namespace of the referent.
+
+
+                      Support: Core
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -118,34 +155,47 @@ spec:
               minItems: 1
               type: array
             to:
-              description: "To describes the resources that may be referenced by the
-                resources described in \"From\". Each entry in this list MUST be considered
-                to be an additional place that references can be valid to, or to put
-                this another way, entries MUST be combined using OR. \n Support: Core"
+              description: |-
+                To describes the resources that may be referenced by the resources
+                described in "From". Each entry in this list MUST be considered to be an
+                additional place that references can be valid to, or to put this another
+                way, entries MUST be combined using OR.
+
+
+                Support: Core
               items:
-                description: ReferenceGrantTo describes what Kinds are allowed as
-                  targets of the references.
+                description: |-
+                  ReferenceGrantTo describes what Kinds are allowed as targets of the
+                  references.
                 properties:
                   group:
-                    description: "Group is the group of the referent. When empty,
-                      the Kubernetes core API group is inferred. \n Support: Core"
+                    description: |-
+                      Group is the group of the referent.
+                      When empty, the Kubernetes core API group is inferred.
+
+
+                      Support: Core
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
-                    description: "Kind is the kind of the referent. Although implementations
-                      may support additional resources, the following types are part
-                      of the \"Core\" support level for this field: \n * Secret when
-                      used to permit a SecretObjectReference * Service when used to
-                      permit a BackendObjectReference"
+                    description: |-
+                      Kind is the kind of the referent. Although implementations may support
+                      additional resources, the following types are part of the "Core"
+                      support level for this field:
+
+
+                      * Secret when used to permit a SecretObjectReference
+                      * Service when used to permit a BackendObjectReference
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
-                    description: Name is the name of the referent. When unspecified,
-                      this policy refers to all resources of the specified Group and
-                      Kind in the local namespace.
+                    description: |-
+                      Name is the name of the referent. When unspecified, this policy
+                      refers to all resources of the specified Group and Kind in the local
+                      namespace.
                     maxLength: 253
                     minLength: 1
                     type: string

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Elasticsearch
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/kafkaopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/kafkaopsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Kafka
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MariaDB
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Memcached
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MongoDB
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MySQL
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: PerconaXtraDB
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: PgBouncer
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Postgres
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.proxyRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: ProxySQL
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Redis
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
@@ -15,7 +15,7 @@ spec:
     references:
     - '{.spec.databaseRef.name}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: RedisSentinel
     type: MatchRef
   resource:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/supervisor.appscode.com/v1alpha1/recommendations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/supervisor.appscode.com/v1alpha1/recommendations.yaml
@@ -17,7 +17,7 @@ spec:
     references:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Elasticsearch
     type: MatchRef
   - labels:
@@ -37,7 +37,7 @@ spec:
     references:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MariaDB
     type: MatchRef
   - labels:
@@ -57,7 +57,7 @@ spec:
     references:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Memcached
     type: MatchRef
   - labels:
@@ -77,7 +77,7 @@ spec:
     references:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MongoDB
     type: MatchRef
   - labels:
@@ -97,7 +97,7 @@ spec:
     references:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: MySQL
     type: MatchRef
   - labels:
@@ -117,7 +117,7 @@ spec:
     references:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: PerconaXtraDB
     type: MatchRef
   - labels:
@@ -137,7 +137,7 @@ spec:
     references:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: PgBouncer
     type: MatchRef
   - labels:
@@ -157,7 +157,7 @@ spec:
     references:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Postgres
     type: MatchRef
   - labels:
@@ -177,7 +177,7 @@ spec:
     references:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: ProxySQL
     type: MatchRef
   - labels:
@@ -197,7 +197,7 @@ spec:
     references:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
-      apiVersion: kubedb.com/v1alpha2
+      apiVersion: kubedb.com/v1
       kind: Redis
     type: MatchRef
   - labels:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/voyager.appscode.com/v1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/voyager.appscode.com/v1/ingresses.yaml
@@ -289,7 +289,8 @@ spec:
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources,
-                                  in this case pods.
+                                  in this case pods. If it's null, this PodAffinityTerm
+                                  matches with no Pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -336,6 +337,44 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: MatchLabelKeys is a set of pod label
+                                  keys to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key in (value)` to select the
+                                  group of existing pods which pods will be taken
+                                  into consideration for the incoming pod's pod (anti)
+                                  affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is
+                                  empty. The same key is forbidden to exist in both
+                                  MatchLabelKeys and LabelSelector. Also, MatchLabelKeys
+                                  cannot be set when LabelSelector isn't set. This
+                                  is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                  feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: MismatchLabelKeys is a set of pod label
+                                  keys to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key notin (value)` to select
+                                  the group of existing pods which pods will be taken
+                                  into consideration for the incoming pod's pod (anti)
+                                  affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is
+                                  empty. The same key is forbidden to exist in both
+                                  MismatchLabelKeys and LabelSelector. Also, MismatchLabelKeys
+                                  cannot be set when LabelSelector isn't set. This
+                                  is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                  feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               namespaceSelector:
                                 description: A label query over the set of namespaces
                                   that the term applies to. The term is applied to
@@ -443,7 +482,8 @@ spec:
                         properties:
                           labelSelector:
                             description: A label query over a set of resources, in
-                              this case pods.
+                              this case pods. If it's null, this PodAffinityTerm matches
+                              with no Pods.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -488,6 +528,42 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: MatchLabelKeys is a set of pod label keys
+                              to select which pods will be taken into consideration.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are merged with `LabelSelector`
+                              as `key in (value)` to select the group of existing
+                              pods which pods will be taken into consideration for
+                              the incoming pod's pod (anti) affinity. Keys that don't
+                              exist in the incoming pod labels will be ignored. The
+                              default value is empty. The same key is forbidden to
+                              exist in both MatchLabelKeys and LabelSelector. Also,
+                              MatchLabelKeys cannot be set when LabelSelector isn't
+                              set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                              feature gate.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          mismatchLabelKeys:
+                            description: MismatchLabelKeys is a set of pod label keys
+                              to select which pods will be taken into consideration.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are merged with `LabelSelector`
+                              as `key notin (value)` to select the group of existing
+                              pods which pods will be taken into consideration for
+                              the incoming pod's pod (anti) affinity. Keys that don't
+                              exist in the incoming pod labels will be ignored. The
+                              default value is empty. The same key is forbidden to
+                              exist in both MismatchLabelKeys and LabelSelector. Also,
+                              MismatchLabelKeys cannot be set when LabelSelector isn't
+                              set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                              feature gate.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
                           namespaceSelector:
                             description: A label query over the set of namespaces
                               that the term applies to. The term is applied to the
@@ -590,7 +666,8 @@ spec:
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources,
-                                  in this case pods.
+                                  in this case pods. If it's null, this PodAffinityTerm
+                                  matches with no Pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -637,6 +714,44 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: MatchLabelKeys is a set of pod label
+                                  keys to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key in (value)` to select the
+                                  group of existing pods which pods will be taken
+                                  into consideration for the incoming pod's pod (anti)
+                                  affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is
+                                  empty. The same key is forbidden to exist in both
+                                  MatchLabelKeys and LabelSelector. Also, MatchLabelKeys
+                                  cannot be set when LabelSelector isn't set. This
+                                  is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                  feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: MismatchLabelKeys is a set of pod label
+                                  keys to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key notin (value)` to select
+                                  the group of existing pods which pods will be taken
+                                  into consideration for the incoming pod's pod (anti)
+                                  affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is
+                                  empty. The same key is forbidden to exist in both
+                                  MismatchLabelKeys and LabelSelector. Also, MismatchLabelKeys
+                                  cannot be set when LabelSelector isn't set. This
+                                  is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                  feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               namespaceSelector:
                                 description: A label query over the set of namespaces
                                   that the term applies to. The term is applied to
@@ -744,7 +859,8 @@ spec:
                         properties:
                           labelSelector:
                             description: A label query over a set of resources, in
-                              this case pods.
+                              this case pods. If it's null, this PodAffinityTerm matches
+                              with no Pods.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -789,6 +905,42 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: MatchLabelKeys is a set of pod label keys
+                              to select which pods will be taken into consideration.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are merged with `LabelSelector`
+                              as `key in (value)` to select the group of existing
+                              pods which pods will be taken into consideration for
+                              the incoming pod's pod (anti) affinity. Keys that don't
+                              exist in the incoming pod labels will be ignored. The
+                              default value is empty. The same key is forbidden to
+                              exist in both MatchLabelKeys and LabelSelector. Also,
+                              MatchLabelKeys cannot be set when LabelSelector isn't
+                              set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                              feature gate.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          mismatchLabelKeys:
+                            description: MismatchLabelKeys is a set of pod label keys
+                              to select which pods will be taken into consideration.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are merged with `LabelSelector`
+                              as `key notin (value)` to select the group of existing
+                              pods which pods will be taken into consideration for
+                              the incoming pod's pod (anti) affinity. Keys that don't
+                              exist in the incoming pod labels will be ignored. The
+                              default value is empty. The same key is forbidden to
+                              exist in both MismatchLabelKeys and LabelSelector. Also,
+                              MismatchLabelKeys cannot be set when LabelSelector isn't
+                              set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                              feature gate.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
                           namespaceSelector:
                             description: A label query over the set of namespaces
                               that the term applies to. The term is applied to the
@@ -964,6 +1116,102 @@ spec:
                           description: Projection that may be projected along with
                             other supported volume types
                           properties:
+                            clusterTrustBundle:
+                              description: "ClusterTrustBundle allows a pod to access
+                                the `.spec.trustBundle` field of ClusterTrustBundle
+                                objects in an auto-updating file. \n Alpha, gated
+                                by the ClusterTrustBundleProjection feature gate.
+                                \n ClusterTrustBundle objects can either be selected
+                                by name, or by the combination of signer name and
+                                a label selector. \n Kubelet performs aggressive normalization
+                                of the PEM contents written into the pod filesystem.
+                                \ Esoteric PEM features such as inter-block comments
+                                and block headers are stripped.  Certificates are
+                                deduplicated. The ordering of certificates within
+                                the file is arbitrary, and Kubelet may change the
+                                order over time."
+                              properties:
+                                labelSelector:
+                                  description: Select all ClusterTrustBundles that
+                                    match this label selector.  Only has effect if
+                                    signerName is set.  Mutually-exclusive with name.  If
+                                    unset, interpreted as "match nothing".  If set
+                                    but empty, interpreted as "match everything".
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                name:
+                                  description: Select a single ClusterTrustBundle
+                                    by object name.  Mutually-exclusive with signerName
+                                    and labelSelector.
+                                  type: string
+                                optional:
+                                  description: If true, don't block pod startup if
+                                    the referenced ClusterTrustBundle(s) aren't available.  If
+                                    using name, then the named ClusterTrustBundle
+                                    is allowed not to exist.  If using signerName,
+                                    then the combination of signerName and labelSelector
+                                    is allowed to match zero ClusterTrustBundles.
+                                  type: boolean
+                                path:
+                                  description: Relative path from the volume root
+                                    to write the bundle.
+                                  type: string
+                                signerName:
+                                  description: Select all ClusterTrustBundles that
+                                    match this signer name. Mutually-exclusive with
+                                    name.  The contents of all selected ClusterTrustBundles
+                                    will be unified and deduplicated.
+                                  type: string
+                              required:
+                              - path
+                              type: object
                             configMap:
                               description: configMap information about the configMap
                                 data to project
@@ -1274,6 +1522,27 @@ spec:
                   description: 'Compute Resources required by coordinator container.
                     Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   properties:
+                    claims:
+                      description: "Claims lists the names of resources, defined in
+                        spec.resourceClaims, that are used by this container. \n This
+                        is an alpha field and requires enabling the DynamicResourceAllocation
+                        feature gate. \n This field is immutable. It can only be set
+                        for containers."
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: Name must match the name of one entry in
+                              pod.spec.resourceClaims of the Pod where this field
+                              is used. It makes that resource available inside a container.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
                     limits:
                       additionalProperties:
                         anyOf:
@@ -1294,7 +1563,8 @@ spec:
                       description: 'Requests describes the minimum amount of compute
                         resources required. If Requests is omitted for a container,
                         it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        to an implementation-defined value. Requests cannot exceed
+                        Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                       type: object
                   type: object
                 securityContext:
@@ -1410,7 +1680,8 @@ spec:
                             in a file on the node should be used. The profile must
                             be preconfigured on the node to work. Must be a descending
                             path, relative to the kubelet's configured seccomp profile
-                            location. Must only be set if type is "Localhost".
+                            location. Must be set if type is "Localhost". Must NOT
+                            be set for any other type.
                           type: string
                         type:
                           description: "type indicates which kind of seccomp profile
@@ -1441,15 +1712,11 @@ spec:
                           type: string
                         hostProcess:
                           description: HostProcess determines if a container should
-                            be run as a 'Host Process' container. This field is alpha-level
-                            and will only be honored by components that enable the
-                            WindowsHostProcessContainers feature flag. Setting this
-                            field without the feature flag will result in errors when
-                            validating the Pod. All of a Pod's containers must have
-                            the same effective HostProcess value (it is not allowed
-                            to have a mix of HostProcess containers and non-HostProcess
-                            containers).  In addition, if HostProcess is true then
-                            HostNetwork must also be set to true.
+                            be run as a 'Host Process' container. All of a Pod's containers
+                            must have the same effective HostProcess value (it is
+                            not allowed to have a mix of HostProcess containers and
+                            non-HostProcess containers). In addition, if HostProcess
+                            is true then HostNetwork must also be set to true.
                           type: boolean
                         runAsUserName:
                           description: The UserName in Windows to run the entrypoint
@@ -1518,19 +1785,19 @@ spec:
                     a mutually exclusive setting with "Resource".
                   properties:
                     name:
-                      description: Name is the referenced service. The service must
+                      description: name is the referenced service. The service must
                         exist in the same namespace as the Ingress object.
                       type: string
                     port:
-                      description: Port of the referenced service. A port name or
+                      description: port of the referenced service. A port name or
                         port number is required for a IngressServiceBackend.
                       properties:
                         name:
-                          description: Name is the name of the port on the Service.
+                          description: name is the name of the port on the Service.
                             This is a mutually exclusive setting with "Number".
                           type: string
                         number:
-                          description: Number is the numerical port number (e.g. 80)
+                          description: number is the numerical port number (e.g. 80)
                             on the Service. This is a mutually exclusive setting with
                             "Name".
                           format: int32
@@ -1655,9 +1922,7 @@ spec:
                   format: int32
                   type: integer
                 grpc:
-                  description: GRPC specifies an action involving a GRPC port. This
-                    is a beta field and requires enabling GRPCContainerProbe feature
-                    gate.
+                  description: GRPC specifies an action involving a GRPC port.
                   properties:
                     port:
                       description: Port number of the gRPC service. Number must be
@@ -1688,7 +1953,9 @@ spec:
                           in HTTP probes
                         properties:
                           name:
-                            description: The header field name
+                            description: The header field name. This will be canonicalized
+                              upon output, so case-variant names will be understood
+                              as the same header.
                             type: string
                           value:
                             description: The header field value
@@ -1910,8 +2177,9 @@ spec:
                       description: localhostProfile indicates a profile defined in
                         a file on the node should be used. The profile must be preconfigured
                         on the node to work. Must be a descending path, relative to
-                        the kubelet's configured seccomp profile location. Must only
-                        be set if type is "Localhost".
+                        the kubelet's configured seccomp profile location. Must be
+                        set if type is "Localhost". Must NOT be set for any other
+                        type.
                       type: string
                     type:
                       description: "type indicates which kind of seccomp profile will
@@ -1942,14 +2210,11 @@ spec:
                       type: string
                     hostProcess:
                       description: HostProcess determines if a container should be
-                        run as a 'Host Process' container. This field is alpha-level
-                        and will only be honored by components that enable the WindowsHostProcessContainers
-                        feature flag. Setting this field without the feature flag
-                        will result in errors when validating the Pod. All of a Pod's
-                        containers must have the same effective HostProcess value
-                        (it is not allowed to have a mix of HostProcess containers
-                        and non-HostProcess containers).  In addition, if HostProcess
-                        is true then HostNetwork must also be set to true.
+                        run as a 'Host Process' container. All of a Pod's containers
+                        must have the same effective HostProcess value (it is not
+                        allowed to have a mix of HostProcess containers and non-HostProcess
+                        containers). In addition, if HostProcess is true then HostNetwork
+                        must also be set to true.
                       type: boolean
                     runAsUserName:
                       description: The UserName in Windows to run the entrypoint of
@@ -1987,9 +2252,7 @@ spec:
                   format: int32
                   type: integer
                 grpc:
-                  description: GRPC specifies an action involving a GRPC port. This
-                    is a beta field and requires enabling GRPCContainerProbe feature
-                    gate.
+                  description: GRPC specifies an action involving a GRPC port.
                   properties:
                     port:
                       description: Port number of the gRPC service. Number must be
@@ -2020,7 +2283,9 @@ spec:
                           in HTTP probes
                         properties:
                           name:
-                            description: The header field name
+                            description: The header field name. This will be canonicalized
+                              upon output, so case-variant names will be understood
+                              as the same header.
                             type: string
                           value:
                             description: The header field value
@@ -2104,6 +2369,26 @@ spec:
             resources:
               description: Compute Resources required by the HAProxy container.
               properties:
+                claims:
+                  description: "Claims lists the names of resources, defined in spec.resourceClaims,
+                    that are used by this container. \n This is an alpha field and
+                    requires enabling the DynamicResourceAllocation feature gate.
+                    \n This field is immutable. It can only be set for containers."
+                  items:
+                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                    properties:
+                      name:
+                        description: Name must match the name of one entry in pod.spec.resourceClaims
+                          of the Pod where this field is used. It makes that resource
+                          available inside a container.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
                 limits:
                   additionalProperties:
                     anyOf:
@@ -2124,7 +2409,7 @@ spec:
                   description: 'Requests describes the minimum amount of compute resources
                     required. If Requests is omitted for a container, it defaults
                     to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                   type: object
               type: object
             rules:
@@ -2256,22 +2541,22 @@ spec:
                                     This is a mutually exclusive setting with "Resource".
                                   properties:
                                     name:
-                                      description: Name is the referenced service.
+                                      description: name is the referenced service.
                                         The service must exist in the same namespace
                                         as the Ingress object.
                                       type: string
                                     port:
-                                      description: Port of the referenced service.
+                                      description: port of the referenced service.
                                         A port name or port number is required for
                                         a IngressServiceBackend.
                                       properties:
                                         name:
-                                          description: Name is the name of the port
+                                          description: name is the name of the port
                                             on the Service. This is a mutually exclusive
                                             setting with "Number".
                                           type: string
                                         number:
-                                          description: Number is the numerical port
+                                          description: number is the numerical port
                                             number (e.g. 80) on the Service. This
                                             is a mutually exclusive setting with "Name".
                                           format: int32
@@ -2386,21 +2671,21 @@ spec:
                               This is a mutually exclusive setting with "Resource".
                             properties:
                               name:
-                                description: Name is the referenced service. The service
+                                description: name is the referenced service. The service
                                   must exist in the same namespace as the Ingress
                                   object.
                                 type: string
                               port:
-                                description: Port of the referenced service. A port
+                                description: port of the referenced service. A port
                                   name or port number is required for a IngressServiceBackend.
                                 properties:
                                   name:
-                                    description: Name is the name of the port on the
+                                    description: name is the name of the port on the
                                       Service. This is a mutually exclusive setting
                                       with "Number".
                                     type: string
                                   number:
-                                    description: Number is the numerical port number
+                                    description: number is the numerical port number
                                       (e.g. 80) on the Service. This is a mutually
                                       exclusive setting with "Name".
                                     format: int32
@@ -2518,8 +2803,9 @@ spec:
                       description: localhostProfile indicates a profile defined in
                         a file on the node should be used. The profile must be preconfigured
                         on the node to work. Must be a descending path, relative to
-                        the kubelet's configured seccomp profile location. Must only
-                        be set if type is "Localhost".
+                        the kubelet's configured seccomp profile location. Must be
+                        set if type is "Localhost". Must NOT be set for any other
+                        type.
                       type: string
                     type:
                       description: "type indicates which kind of seccomp profile will
@@ -2533,9 +2819,14 @@ spec:
                   type: object
                 supplementalGroups:
                   description: A list of groups applied to the first process run in
-                    each container, in addition to the container's primary GID.  If
-                    unspecified, no groups will be added to any container. Note that
-                    this field cannot be set when spec.os.name is windows.
+                    each container, in addition to the container's primary GID, the
+                    fsGroup (if specified), and group memberships defined in the container
+                    image for the uid of the container process. If unspecified, no
+                    additional groups are added to any container. Note that group
+                    memberships defined in the container image for the uid of the
+                    container process are still effective, even if they are not included
+                    in this list. Note that this field cannot be set when spec.os.name
+                    is windows.
                   items:
                     format: int64
                     type: integer
@@ -2578,14 +2869,11 @@ spec:
                       type: string
                     hostProcess:
                       description: HostProcess determines if a container should be
-                        run as a 'Host Process' container. This field is alpha-level
-                        and will only be honored by components that enable the WindowsHostProcessContainers
-                        feature flag. Setting this field without the feature flag
-                        will result in errors when validating the Pod. All of a Pod's
-                        containers must have the same effective HostProcess value
-                        (it is not allowed to have a mix of HostProcess containers
-                        and non-HostProcess containers).  In addition, if HostProcess
-                        is true then HostNetwork must also be set to true.
+                        run as a 'Host Process' container. All of a Pod's containers
+                        must have the same effective HostProcess value (it is not
+                        allowed to have a mix of HostProcess containers and non-HostProcess
+                        containers). In addition, if HostProcess is true then HostNetwork
+                        must also be set to true.
                       type: boolean
                     runAsUserName:
                       description: The UserName in Windows to run the entrypoint of

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/voyager.appscode.com/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcedescriptors/voyager.appscode.com/v1beta1/ingresses.yaml
@@ -289,7 +289,8 @@ spec:
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources,
-                                  in this case pods.
+                                  in this case pods. If it's null, this PodAffinityTerm
+                                  matches with no Pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -336,6 +337,44 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: MatchLabelKeys is a set of pod label
+                                  keys to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key in (value)` to select the
+                                  group of existing pods which pods will be taken
+                                  into consideration for the incoming pod's pod (anti)
+                                  affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is
+                                  empty. The same key is forbidden to exist in both
+                                  MatchLabelKeys and LabelSelector. Also, MatchLabelKeys
+                                  cannot be set when LabelSelector isn't set. This
+                                  is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                  feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: MismatchLabelKeys is a set of pod label
+                                  keys to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key notin (value)` to select
+                                  the group of existing pods which pods will be taken
+                                  into consideration for the incoming pod's pod (anti)
+                                  affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is
+                                  empty. The same key is forbidden to exist in both
+                                  MismatchLabelKeys and LabelSelector. Also, MismatchLabelKeys
+                                  cannot be set when LabelSelector isn't set. This
+                                  is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                  feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               namespaceSelector:
                                 description: A label query over the set of namespaces
                                   that the term applies to. The term is applied to
@@ -443,7 +482,8 @@ spec:
                         properties:
                           labelSelector:
                             description: A label query over a set of resources, in
-                              this case pods.
+                              this case pods. If it's null, this PodAffinityTerm matches
+                              with no Pods.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -488,6 +528,42 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: MatchLabelKeys is a set of pod label keys
+                              to select which pods will be taken into consideration.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are merged with `LabelSelector`
+                              as `key in (value)` to select the group of existing
+                              pods which pods will be taken into consideration for
+                              the incoming pod's pod (anti) affinity. Keys that don't
+                              exist in the incoming pod labels will be ignored. The
+                              default value is empty. The same key is forbidden to
+                              exist in both MatchLabelKeys and LabelSelector. Also,
+                              MatchLabelKeys cannot be set when LabelSelector isn't
+                              set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                              feature gate.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          mismatchLabelKeys:
+                            description: MismatchLabelKeys is a set of pod label keys
+                              to select which pods will be taken into consideration.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are merged with `LabelSelector`
+                              as `key notin (value)` to select the group of existing
+                              pods which pods will be taken into consideration for
+                              the incoming pod's pod (anti) affinity. Keys that don't
+                              exist in the incoming pod labels will be ignored. The
+                              default value is empty. The same key is forbidden to
+                              exist in both MismatchLabelKeys and LabelSelector. Also,
+                              MismatchLabelKeys cannot be set when LabelSelector isn't
+                              set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                              feature gate.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
                           namespaceSelector:
                             description: A label query over the set of namespaces
                               that the term applies to. The term is applied to the
@@ -590,7 +666,8 @@ spec:
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources,
-                                  in this case pods.
+                                  in this case pods. If it's null, this PodAffinityTerm
+                                  matches with no Pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -637,6 +714,44 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: MatchLabelKeys is a set of pod label
+                                  keys to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key in (value)` to select the
+                                  group of existing pods which pods will be taken
+                                  into consideration for the incoming pod's pod (anti)
+                                  affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is
+                                  empty. The same key is forbidden to exist in both
+                                  MatchLabelKeys and LabelSelector. Also, MatchLabelKeys
+                                  cannot be set when LabelSelector isn't set. This
+                                  is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                  feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: MismatchLabelKeys is a set of pod label
+                                  keys to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key notin (value)` to select
+                                  the group of existing pods which pods will be taken
+                                  into consideration for the incoming pod's pod (anti)
+                                  affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is
+                                  empty. The same key is forbidden to exist in both
+                                  MismatchLabelKeys and LabelSelector. Also, MismatchLabelKeys
+                                  cannot be set when LabelSelector isn't set. This
+                                  is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                  feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               namespaceSelector:
                                 description: A label query over the set of namespaces
                                   that the term applies to. The term is applied to
@@ -744,7 +859,8 @@ spec:
                         properties:
                           labelSelector:
                             description: A label query over a set of resources, in
-                              this case pods.
+                              this case pods. If it's null, this PodAffinityTerm matches
+                              with no Pods.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -789,6 +905,42 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: MatchLabelKeys is a set of pod label keys
+                              to select which pods will be taken into consideration.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are merged with `LabelSelector`
+                              as `key in (value)` to select the group of existing
+                              pods which pods will be taken into consideration for
+                              the incoming pod's pod (anti) affinity. Keys that don't
+                              exist in the incoming pod labels will be ignored. The
+                              default value is empty. The same key is forbidden to
+                              exist in both MatchLabelKeys and LabelSelector. Also,
+                              MatchLabelKeys cannot be set when LabelSelector isn't
+                              set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                              feature gate.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          mismatchLabelKeys:
+                            description: MismatchLabelKeys is a set of pod label keys
+                              to select which pods will be taken into consideration.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are merged with `LabelSelector`
+                              as `key notin (value)` to select the group of existing
+                              pods which pods will be taken into consideration for
+                              the incoming pod's pod (anti) affinity. Keys that don't
+                              exist in the incoming pod labels will be ignored. The
+                              default value is empty. The same key is forbidden to
+                              exist in both MismatchLabelKeys and LabelSelector. Also,
+                              MismatchLabelKeys cannot be set when LabelSelector isn't
+                              set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity
+                              feature gate.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
                           namespaceSelector:
                             description: A label query over the set of namespaces
                               that the term applies to. The term is applied to the
@@ -1038,6 +1190,102 @@ spec:
                           description: Projection that may be projected along with
                             other supported volume types
                           properties:
+                            clusterTrustBundle:
+                              description: "ClusterTrustBundle allows a pod to access
+                                the `.spec.trustBundle` field of ClusterTrustBundle
+                                objects in an auto-updating file. \n Alpha, gated
+                                by the ClusterTrustBundleProjection feature gate.
+                                \n ClusterTrustBundle objects can either be selected
+                                by name, or by the combination of signer name and
+                                a label selector. \n Kubelet performs aggressive normalization
+                                of the PEM contents written into the pod filesystem.
+                                \ Esoteric PEM features such as inter-block comments
+                                and block headers are stripped.  Certificates are
+                                deduplicated. The ordering of certificates within
+                                the file is arbitrary, and Kubelet may change the
+                                order over time."
+                              properties:
+                                labelSelector:
+                                  description: Select all ClusterTrustBundles that
+                                    match this label selector.  Only has effect if
+                                    signerName is set.  Mutually-exclusive with name.  If
+                                    unset, interpreted as "match nothing".  If set
+                                    but empty, interpreted as "match everything".
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                name:
+                                  description: Select a single ClusterTrustBundle
+                                    by object name.  Mutually-exclusive with signerName
+                                    and labelSelector.
+                                  type: string
+                                optional:
+                                  description: If true, don't block pod startup if
+                                    the referenced ClusterTrustBundle(s) aren't available.  If
+                                    using name, then the named ClusterTrustBundle
+                                    is allowed not to exist.  If using signerName,
+                                    then the combination of signerName and labelSelector
+                                    is allowed to match zero ClusterTrustBundles.
+                                  type: boolean
+                                path:
+                                  description: Relative path from the volume root
+                                    to write the bundle.
+                                  type: string
+                                signerName:
+                                  description: Select all ClusterTrustBundles that
+                                    match this signer name. Mutually-exclusive with
+                                    name.  The contents of all selected ClusterTrustBundles
+                                    will be unified and deduplicated.
+                                  type: string
+                              required:
+                              - path
+                              type: object
                             configMap:
                               description: configMap information about the configMap
                                 data to project
@@ -1348,6 +1596,27 @@ spec:
                   description: 'Compute Resources required by coordinator container.
                     Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   properties:
+                    claims:
+                      description: "Claims lists the names of resources, defined in
+                        spec.resourceClaims, that are used by this container. \n This
+                        is an alpha field and requires enabling the DynamicResourceAllocation
+                        feature gate. \n This field is immutable. It can only be set
+                        for containers."
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: Name must match the name of one entry in
+                              pod.spec.resourceClaims of the Pod where this field
+                              is used. It makes that resource available inside a container.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
                     limits:
                       additionalProperties:
                         anyOf:
@@ -1368,7 +1637,8 @@ spec:
                       description: 'Requests describes the minimum amount of compute
                         resources required. If Requests is omitted for a container,
                         it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        to an implementation-defined value. Requests cannot exceed
+                        Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                       type: object
                   type: object
                 securityContext:
@@ -1484,7 +1754,8 @@ spec:
                             in a file on the node should be used. The profile must
                             be preconfigured on the node to work. Must be a descending
                             path, relative to the kubelet's configured seccomp profile
-                            location. Must only be set if type is "Localhost".
+                            location. Must be set if type is "Localhost". Must NOT
+                            be set for any other type.
                           type: string
                         type:
                           description: "type indicates which kind of seccomp profile
@@ -1515,15 +1786,11 @@ spec:
                           type: string
                         hostProcess:
                           description: HostProcess determines if a container should
-                            be run as a 'Host Process' container. This field is alpha-level
-                            and will only be honored by components that enable the
-                            WindowsHostProcessContainers feature flag. Setting this
-                            field without the feature flag will result in errors when
-                            validating the Pod. All of a Pod's containers must have
-                            the same effective HostProcess value (it is not allowed
-                            to have a mix of HostProcess containers and non-HostProcess
-                            containers).  In addition, if HostProcess is true then
-                            HostNetwork must also be set to true.
+                            be run as a 'Host Process' container. All of a Pod's containers
+                            must have the same effective HostProcess value (it is
+                            not allowed to have a mix of HostProcess containers and
+                            non-HostProcess containers). In addition, if HostProcess
+                            is true then HostNetwork must also be set to true.
                           type: boolean
                         runAsUserName:
                           description: The UserName in Windows to run the entrypoint
@@ -1652,9 +1919,7 @@ spec:
                   format: int32
                   type: integer
                 grpc:
-                  description: GRPC specifies an action involving a GRPC port. This
-                    is a beta field and requires enabling GRPCContainerProbe feature
-                    gate.
+                  description: GRPC specifies an action involving a GRPC port.
                   properties:
                     port:
                       description: Port number of the gRPC service. Number must be
@@ -1685,7 +1950,9 @@ spec:
                           in HTTP probes
                         properties:
                           name:
-                            description: The header field name
+                            description: The header field name. This will be canonicalized
+                              upon output, so case-variant names will be understood
+                              as the same header.
                             type: string
                           value:
                             description: The header field value
@@ -1907,8 +2174,9 @@ spec:
                       description: localhostProfile indicates a profile defined in
                         a file on the node should be used. The profile must be preconfigured
                         on the node to work. Must be a descending path, relative to
-                        the kubelet's configured seccomp profile location. Must only
-                        be set if type is "Localhost".
+                        the kubelet's configured seccomp profile location. Must be
+                        set if type is "Localhost". Must NOT be set for any other
+                        type.
                       type: string
                     type:
                       description: "type indicates which kind of seccomp profile will
@@ -1939,14 +2207,11 @@ spec:
                       type: string
                     hostProcess:
                       description: HostProcess determines if a container should be
-                        run as a 'Host Process' container. This field is alpha-level
-                        and will only be honored by components that enable the WindowsHostProcessContainers
-                        feature flag. Setting this field without the feature flag
-                        will result in errors when validating the Pod. All of a Pod's
-                        containers must have the same effective HostProcess value
-                        (it is not allowed to have a mix of HostProcess containers
-                        and non-HostProcess containers).  In addition, if HostProcess
-                        is true then HostNetwork must also be set to true.
+                        run as a 'Host Process' container. All of a Pod's containers
+                        must have the same effective HostProcess value (it is not
+                        allowed to have a mix of HostProcess containers and non-HostProcess
+                        containers). In addition, if HostProcess is true then HostNetwork
+                        must also be set to true.
                       type: boolean
                     runAsUserName:
                       description: The UserName in Windows to run the entrypoint of
@@ -1984,9 +2249,7 @@ spec:
                   format: int32
                   type: integer
                 grpc:
-                  description: GRPC specifies an action involving a GRPC port. This
-                    is a beta field and requires enabling GRPCContainerProbe feature
-                    gate.
+                  description: GRPC specifies an action involving a GRPC port.
                   properties:
                     port:
                       description: Port number of the gRPC service. Number must be
@@ -2017,7 +2280,9 @@ spec:
                           in HTTP probes
                         properties:
                           name:
-                            description: The header field name
+                            description: The header field name. This will be canonicalized
+                              upon output, so case-variant names will be understood
+                              as the same header.
                             type: string
                           value:
                             description: The header field value
@@ -2101,6 +2366,26 @@ spec:
             resources:
               description: Compute Resources required by the sidecar container.
               properties:
+                claims:
+                  description: "Claims lists the names of resources, defined in spec.resourceClaims,
+                    that are used by this container. \n This is an alpha field and
+                    requires enabling the DynamicResourceAllocation feature gate.
+                    \n This field is immutable. It can only be set for containers."
+                  items:
+                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                    properties:
+                      name:
+                        description: Name must match the name of one entry in pod.spec.resourceClaims
+                          of the Pod where this field is used. It makes that resource
+                          available inside a container.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
                 limits:
                   additionalProperties:
                     anyOf:
@@ -2121,7 +2406,7 @@ spec:
                   description: 'Requests describes the minimum amount of compute resources
                     required. If Requests is omitted for a container, it defaults
                     to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                   type: object
               type: object
             rules:
@@ -2499,8 +2784,9 @@ spec:
                       description: localhostProfile indicates a profile defined in
                         a file on the node should be used. The profile must be preconfigured
                         on the node to work. Must be a descending path, relative to
-                        the kubelet's configured seccomp profile location. Must only
-                        be set if type is "Localhost".
+                        the kubelet's configured seccomp profile location. Must be
+                        set if type is "Localhost". Must NOT be set for any other
+                        type.
                       type: string
                     type:
                       description: "type indicates which kind of seccomp profile will
@@ -2514,9 +2800,14 @@ spec:
                   type: object
                 supplementalGroups:
                   description: A list of groups applied to the first process run in
-                    each container, in addition to the container's primary GID.  If
-                    unspecified, no groups will be added to any container. Note that
-                    this field cannot be set when spec.os.name is windows.
+                    each container, in addition to the container's primary GID, the
+                    fsGroup (if specified), and group memberships defined in the container
+                    image for the uid of the container process. If unspecified, no
+                    additional groups are added to any container. Note that group
+                    memberships defined in the container image for the uid of the
+                    container process are still effective, even if they are not included
+                    in this list. Note that this field cannot be set when spec.os.name
+                    is windows.
                   items:
                     format: int64
                     type: integer
@@ -2559,14 +2850,11 @@ spec:
                       type: string
                     hostProcess:
                       description: HostProcess determines if a container should be
-                        run as a 'Host Process' container. This field is alpha-level
-                        and will only be honored by components that enable the WindowsHostProcessContainers
-                        feature flag. Setting this field without the feature flag
-                        will result in errors when validating the Pod. All of a Pod's
-                        containers must have the same effective HostProcess value
-                        (it is not allowed to have a mix of HostProcess containers
-                        and non-HostProcess containers).  In addition, if HostProcess
-                        is true then HostNetwork must also be set to true.
+                        run as a 'Host Process' container. All of a Pod's containers
+                        must have the same effective HostProcess value (it is not
+                        allowed to have a mix of HostProcess containers and non-HostProcess
+                        containers). In addition, if HostProcess is true then HostNetwork
+                        must also be set to true.
                       type: boolean
                     runAsUserName:
                       description: The UserName in Windows to run the entrypoint of

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backends.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backends.yaml
@@ -1,0 +1,17 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceEditor
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.envoyproxy.io
+    k8s.io/kind: Backend
+    k8s.io/resource: backends
+    k8s.io/version: v1alpha1
+  name: gateway.envoyproxy.io-v1alpha1-backends
+spec:
+  resource:
+    group: gateway.envoyproxy.io
+    kind: Backend
+    name: backends
+    scope: Namespaced
+    version: v1alpha1

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
@@ -1,0 +1,17 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceEditor
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.envoyproxy.io
+    k8s.io/kind: EnvoyExtensionPolicy
+    k8s.io/resource: envoyextensionpolicies
+    k8s.io/version: v1alpha1
+  name: gateway.envoyproxy.io-v1alpha1-envoyextensionpolicies
+spec:
+  resource:
+    group: gateway.envoyproxy.io
+    kind: EnvoyExtensionPolicy
+    name: envoyextensionpolicies
+    scope: Namespaced
+    version: v1alpha1

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/grpcroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/grpcroutes.yaml
@@ -1,0 +1,17 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceEditor
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.networking.k8s.io
+    k8s.io/kind: GRPCRoute
+    k8s.io/resource: grpcroutes
+    k8s.io/version: v1
+  name: gateway.networking.k8s.io-v1-grpcroutes
+spec:
+  resource:
+    group: gateway.networking.k8s.io
+    kind: GRPCRoute
+    name: grpcroutes
+    scope: Namespaced
+    version: v1

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
@@ -1,0 +1,17 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceEditor
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.networking.k8s.io
+    k8s.io/kind: BackendLBPolicy
+    k8s.io/resource: backendlbpolicies
+    k8s.io/version: v1alpha2
+  name: gateway.networking.k8s.io-v1alpha2-backendlbpolicies
+spec:
+  resource:
+    group: gateway.networking.k8s.io
+    kind: BackendLBPolicy
+    name: backendlbpolicies
+    scope: Namespaced
+    version: v1alpha2

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
@@ -1,0 +1,17 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceEditor
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.networking.k8s.io
+    k8s.io/kind: BackendTLSPolicy
+    k8s.io/resource: backendtlspolicies
+    k8s.io/version: v1alpha3
+  name: gateway.networking.k8s.io-v1alpha3-backendtlspolicies
+spec:
+  resource:
+    group: gateway.networking.k8s.io
+    kind: BackendTLSPolicy
+    name: backendtlspolicies
+    scope: Namespaced
+    version: v1alpha3

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceoutlines/core.kubestash.com/v1alpha1/restoresessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceoutlines/core.kubestash.com/v1alpha1/restoresessions.yaml
@@ -10,6 +10,53 @@ metadata:
   name: core.kubestash.com-v1alpha1-restoresessions
 spec:
   defaultLayout: true
+  pages:
+  - name: Overview
+    sections:
+    - blocks:
+      - kind: Block
+        name: core.kubestash.com-v1alpha1-restoresessions
+      info:
+        actions:
+          create: Never
+        displayMode: Field
+        kind: Self
+        view:
+          name: core.kubestash.com-v1alpha1-restoresessions
+    - blocks:
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Repository
+        query:
+          byLabel: located_on
+          type: GraphQL
+        ref:
+          group: storage.kubestash.com
+          kind: Repository
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Snapshot
+        query:
+          byLabel: storage
+          type: GraphQL
+        ref:
+          group: storage.kubestash.com
+          kind: Snapshot
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Encryption Secret
+        query:
+          byLabel: auth_secret
+          type: GraphQL
+        ref:
+          group: ""
+          kind: Secret
   resource:
     group: core.kubestash.com
     kind: RestoreSession

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/gateway.envoyproxy.io/v1alpha1/backends.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/gateway.envoyproxy.io/v1alpha1/backends.yaml
@@ -1,0 +1,18 @@
+apiVersion: meta.k8s.appscode.com/v1alpha1
+kind: ResourceTableDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.envoyproxy.io
+    k8s.io/kind: Backend
+    k8s.io/resource: backends
+    k8s.io/version: v1alpha1
+  name: gateway.envoyproxy.io-v1alpha1-backends
+spec:
+  defaultView: true
+  resource:
+    group: gateway.envoyproxy.io
+    kind: Backend
+    name: backends
+    scope: Namespaced
+    version: v1alpha1

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
@@ -1,0 +1,18 @@
+apiVersion: meta.k8s.appscode.com/v1alpha1
+kind: ResourceTableDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.envoyproxy.io
+    k8s.io/kind: EnvoyExtensionPolicy
+    k8s.io/resource: envoyextensionpolicies
+    k8s.io/version: v1alpha1
+  name: gateway.envoyproxy.io-v1alpha1-envoyextensionpolicies
+spec:
+  defaultView: true
+  resource:
+    group: gateway.envoyproxy.io
+    kind: EnvoyExtensionPolicy
+    name: envoyextensionpolicies
+    scope: Namespaced
+    version: v1alpha1

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/gateway.networking.k8s.io/v1/grpcroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/gateway.networking.k8s.io/v1/grpcroutes.yaml
@@ -1,0 +1,18 @@
+apiVersion: meta.k8s.appscode.com/v1alpha1
+kind: ResourceTableDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.networking.k8s.io
+    k8s.io/kind: GRPCRoute
+    k8s.io/resource: grpcroutes
+    k8s.io/version: v1
+  name: gateway.networking.k8s.io-v1-grpcroutes
+spec:
+  defaultView: true
+  resource:
+    group: gateway.networking.k8s.io
+    kind: GRPCRoute
+    name: grpcroutes
+    scope: Namespaced
+    version: v1

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
@@ -1,0 +1,18 @@
+apiVersion: meta.k8s.appscode.com/v1alpha1
+kind: ResourceTableDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.networking.k8s.io
+    k8s.io/kind: BackendLBPolicy
+    k8s.io/resource: backendlbpolicies
+    k8s.io/version: v1alpha2
+  name: gateway.networking.k8s.io-v1alpha2-backendlbpolicies
+spec:
+  defaultView: true
+  resource:
+    group: gateway.networking.k8s.io
+    kind: BackendLBPolicy
+    name: backendlbpolicies
+    scope: Namespaced
+    version: v1alpha2

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
@@ -1,0 +1,18 @@
+apiVersion: meta.k8s.appscode.com/v1alpha1
+kind: ResourceTableDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s.io/group: gateway.networking.k8s.io
+    k8s.io/kind: BackendTLSPolicy
+    k8s.io/resource: backendtlspolicies
+    k8s.io/version: v1alpha3
+  name: gateway.networking.k8s.io-v1alpha3-backendtlspolicies
+spec:
+  defaultView: true
+  resource:
+    group: gateway.networking.k8s.io
+    kind: BackendTLSPolicy
+    name: backendtlspolicies
+    scope: Namespaced
+    version: v1alpha3

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/storage.kubestash.com/v1alpha1/repositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourcetabledefinitions/storage.kubestash.com/v1alpha1/repositories.yaml
@@ -49,8 +49,6 @@ spec:
         {{ $color := "gray" }}
         {{ if $integrity }}
           {{ $color = "success" }}
-        {{ else }}
-          {{ $color = "danger" }}
         {{ end }}
         {{- printf "%s" $color -}}
     name: Integrity

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1985,7 +1985,7 @@ kmodules.xyz/monitoring-agent-api/client
 ## explicit; go 1.22.0
 kmodules.xyz/offshoot-api/api/v1
 kmodules.xyz/offshoot-api/api/v2
-# kmodules.xyz/resource-metadata v0.18.13-0.20240823113925-d6c4a55d03cb
+# kmodules.xyz/resource-metadata v0.18.13-0.20240829025444-b72d620479e5
 ## explicit; go 1.22.1
 kmodules.xyz/resource-metadata/apis/core/install
 kmodules.xyz/resource-metadata/apis/core/v1alpha1


### PR DESCRIPTION
This should remove these type of error logs: 

"msg"="Failed to evaluate Feature status" "error"="no matches for kind \"K8sAllowedRepos\" in version \"constraints.gatekeeper.sh/v1beta1\"" "Feature"={"name":"gatekeeper-templates"} "controller"="feature" "controllerGroup"="ui.k8s.appscode.com" "controllerKind"="Feature" "name"="gatekeeper-templates" "namespace"="" "reconcileID"="d3d1100b-eb24-49ee-bab2-1c61d40dc75d"

