### PR TITLE
Isolate per-connection failures in graph reconciler

### DIFF
--- a/pkg/graph/lib.go
+++ b/pkg/graph/lib.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 	"kmodules.xyz/apiversion"
 	kmapi "kmodules.xyz/client-go/api/v1"
@@ -155,6 +156,7 @@ func (finder ObjectFinder) ListConnectedObjectIDs(src *unstructured.Unstructured
 	}
 
 	edges := map[kmapi.EdgeLabel]ksets.OID{}
+	var errs []error
 	for _, conns := range connsPerGKL {
 		if len(conns) > 1 {
 			sort.Slice(conns, func(i, j int) bool {
@@ -162,9 +164,10 @@ func (finder ObjectFinder) ListConnectedObjectIDs(src *unstructured.Unstructured
 				return d > 0
 			})
 		}
+		dst := conns[0].Target.GroupVersionKind()
 		objects, err := finder.ResourcesFor(src, &Edge{
 			Src:        srcGVK,
-			Dst:        conns[0].Target.GroupVersionKind(),
+			Dst:        dst,
 			W:          0,
 			Connection: conns[0].ResourceConnectionSpec,
 			Forward:    true,
@@ -172,7 +175,9 @@ func (finder ObjectFinder) ListConnectedObjectIDs(src *unstructured.Unstructured
 		if kerr.IsNotFound(err) || meta.IsNoMatchError(err) || (err == nil && len(objects) == 0) {
 			continue
 		} else if err != nil {
-			return nil, err
+			// Skip this connection but keep the edges resolved from the others.
+			errs = append(errs, fmt.Errorf("failed to resolve connection %v -> %v: %w", srcGVK, dst, err))
+			continue
 		}
 		for _, obj := range objects {
 			oid := kmapi.NewObjectID(obj).OID()
@@ -185,7 +190,7 @@ func (finder ObjectFinder) ListConnectedObjectIDs(src *unstructured.Unstructured
 		}
 	}
 
-	return edges, nil
+	return edges, utilerrors.NewAggregate(errs)
 }
 
 func (finder ObjectFinder) ResourcesFor(src *unstructured.Unstructured, e *Edge) ([]*unstructured.Unstructured, error) {

--- a/pkg/graph/reconciler.go
+++ b/pkg/graph/reconciler.go
@@ -19,12 +19,14 @@ package graph
 import (
 	"context"
 	"errors"
+	"slices"
 	"time"
 
 	core "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/discovery"
 	kmapi "kmodules.xyz/client-go/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -71,21 +73,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		finder := ObjectFinder{
 			Client: r.Client,
 		}
-		if result, err := finder.ListConnectedObjectIDs(&obj, rd.Spec.Connections); err != nil {
-			// In case of discovery error, we don't return error because errors are rate limited.
-			// We need to keep trying until the reconciliation is successful.
-			if IsDiscoveryError(err) {
-				log.Error(err, "unable to list connections", "group", r.R.Group, "kind", r.R.Kind)
-				return reconcile.Result{RequeueAfter: 500 * time.Millisecond}, nil
-			}
-			// we'll ignore not-found errors, since they can't be fixed by an immediate
-			// requeue (we'll need to wait for a new notification), and we can get them
-			// on deleted requests.
-			return reconcile.Result{}, client.IgnoreNotFound(err)
-		} else if gvk == gvkService && result[kmapi.EdgeLabelExposedBy].Len() == 0 {
+		// result holds the edges that resolved even when ferr != nil, so one bad
+		// connection doesn't discard the rest of the object's graph.
+		result, ferr := finder.ListConnectedObjectIDs(&obj, rd.Spec.Connections)
+
+		// Discovery errors are transient: keep the existing graph and retry fast.
+		if ferr != nil && anyDiscoveryError(ferr) {
+			log.Error(ferr, "unable to list some connections", "group", r.R.Group, "kind", r.R.Kind)
+			return reconcile.Result{RequeueAfter: 500 * time.Millisecond}, nil
+		}
+
+		if gvk == gvkService && result[kmapi.EdgeLabelExposedBy].Len() == 0 {
 			return reconcile.Result{RequeueAfter: 2 * time.Minute}, nil
-		} else {
-			objGraph.Update(kmapi.NewObjectID(&obj).OID(), result)
+		}
+
+		// Persist whatever resolved, even if some connections failed.
+		objGraph.Update(kmapi.NewObjectID(&obj).OID(), result)
+
+		if ferr != nil {
+			// Partial graph already persisted; return err for exponential-backoff retry.
+			log.Error(ferr, "some connections failed to resolve; graph updated with partial result", "group", r.R.Group, "kind", r.R.Kind)
+			return reconcile.Result{}, client.IgnoreNotFound(ferr)
 		}
 	}
 
@@ -98,6 +106,15 @@ func IsDiscoveryError(err error) bool {
 		return true
 	}
 	return errors.Is(err, &discovery.ErrGroupDiscoveryFailed{})
+}
+
+// anyDiscoveryError reports whether err (or any error in an aggregate) is a
+// discovery error; needed because the k8s aggregate type implements Is but not As.
+func anyDiscoveryError(err error) bool {
+	if agg, ok := err.(utilerrors.Aggregate); ok {
+		return slices.ContainsFunc(utilerrors.Flatten(agg).Errors(), IsDiscoveryError)
+	}
+	return IsDiscoveryError(err)
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
## Problem

The graph adjacency cache (`objGraph`) is built per-object by the reconciler in `pkg/graph/reconciler.go`. `ListConnectedObjectIDs` evaluated every connection in `rd.Spec.Connections`, and on the **first** non-NotFound/NoMatch error it did `return nil, err` — aborting the whole object. The reconciler then returned without calling `objGraph.Update`, so the object got **zero** edges.

Observed in the wild: a PostgreSQL 11 instance whose `ui.kubedb.com` query view runs a `pg_stat_statements` query using `total_exec_time` (a column that only exists in PG ≥ 13). The query fails with `pq: column "total_exec_time" does not exist`, which poisoned the entire graph build — `offshoot`, `auth_secret`, `catalog`, and the working views were all dropped, even though they resolve purely from the K8s API and have nothing to do with the SQL view.

## Fix

- **`ListConnectedObjectIDs`**: a failing connection is now skipped (error wrapped with `src -> target` context and accumulated), the remaining connections still resolve, and the function returns `(edges, utilerrors.NewAggregate(errs))`.
- **`Reconcile`**:
  - Discovery errors keep their existing semantics — don't overwrite the graph, requeue fast (500ms). Detected via the new `anyDiscoveryError` helper (the k8s aggregate type implements `Is` but not `As`, so `IsDiscoveryError` can't see through it).
  - For any other failure, the partial graph is persisted via `objGraph.Update` first, then the error is returned for exponential-backoff retry.

Net: one bad connection no longer wipes an object's whole graph.

## Out of scope

The kubedb-side query bug (`total_exec_time` vs `total_time` for PG < 13) lives in a different repo and is unchanged.

## Test

- `go build ./pkg/graph/...`, `go vet`, `gofmt` clean
- `go test ./pkg/graph/...` passes