### PR TITLE
graph: skip kube-ui-server own API groups in resource poller

### DIFF
--- a/pkg/graph/setup.go
+++ b/pkg/graph/setup.go
@@ -75,7 +75,7 @@ func PollNewResourceTypes(cfg *restclient.Config, pqr *projectquotacontroller.Pr
 					}
 
 					gvk := schema.FromAPIVersionAndKind(rsList.GroupVersion, rs.Kind)
-					if gkSet.Has(gvk.GroupKind()) {
+					if groupSet.Has(gvk.Group) || gkSet.Has(gvk.GroupKind()) {
 						continue
 					}
 

--- a/pkg/graph/vars.go
+++ b/pkg/graph/vars.go
@@ -19,6 +19,7 @@ package graph
 import (
 	"sync"
 
+	"gomodules.xyz/sets"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kmapi "kmodules.xyz/client-go/api/v1"
 	"kmodules.xyz/resource-metadata/hub"
@@ -38,6 +39,18 @@ var Schema = getGraphQLSchema()
 var (
 	resourceChannel = make(chan kmapi.ResourceID, 100)
 	resourceTracker = map[schema.GroupVersionKind]kmapi.ResourceID{}
+)
+
+// groupSet lists API groups served by kube-ui-server's own aggregated API.
+// Watching these during startup would fail because the aggregated API isn't ready yet.
+var groupSet = sets.NewString(
+	"meta.k8s.appscode.com",
+	"identity.k8s.appscode.com",
+	"core.k8s.appscode.com",
+	"policy.k8s.appscode.com",
+	"cost.k8s.appscode.com",
+	"offline.licenses.appscode.com",
+	"reports.scanner.appscode.com",
 )
 
 var gkSet = ksets.NewGroupKind(


### PR DESCRIPTION
## Problem

`kube-ui-server` crashes at startup with:

```
Error in kube-ui-server Main: [the server is currently unable to handle the request
(get clusteridentities.identity.k8s.appscode.com), failed waiting for all runnables
to end within grace period of 30s: context deadline exceeded]
```

`PollNewResourceTypes()` discovers all cluster resources via `ServerPreferredResources()`
and feeds them into `SetupGraphReconciler()`. Resources from groups served by
kube-ui-server's own aggregated API are virtual (not etcd-backed). When the graph
reconciler tries to create informers for them during startup, the aggregated API isn't
ready yet — causing a fatal chicken-and-egg failure.

## Fix

Add a `groupSet` of API groups owned by kube-ui-server and skip them in the resource
poller loop, the same way individual GroupKinds are already skipped via `gkSet`.

Groups excluded:
- `identity.k8s.appscode.com`
- `meta.k8s.appscode.com`
- `core.k8s.appscode.com`
- `policy.k8s.appscode.com`
- `cost.k8s.appscode.com`
- `offline.licenses.appscode.com`
- `reports.scanner.appscode.com`

All of these are served via the aggregated API with custom (non-etcd) storage — there
are no real objects to build graph edges for, so excluding them loses nothing.