### PR TITLE
projectquota: return errors from StartWatcher instead of klog.Fatalln

### DIFF
--- a/pkg/controllers/projectquota/projectquota_controller.go
+++ b/pkg/controllers/projectquota/projectquota_controller.go
@@ -18,6 +18,7 @@ package projectquota
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -373,17 +374,17 @@ func (r *ProjectQuotaReconciler) SetupWithManager(mgr ctrl.Manager) (*ProjectQuo
 	return r, nil
 }
 
-func (r *ProjectQuotaReconciler) StartWatcher(rid kmapi.ResourceID) {
+func (r *ProjectQuotaReconciler) StartWatcher(rid kmapi.ResourceID) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if r.ctrl == nil {
-		klog.Fatalln("ProjectQuota reconciler is not setup yet!")
+		return errors.New("ProjectQuota reconciler is not setup yet")
 	}
 
 	gvk := rid.GroupVersionKind()
 	if gvk.Kind == "" {
-		klog.Fatalln("can't start ProjectQuota reconciler for unknown Kind!")
+		return fmt.Errorf("can't start ProjectQuota reconciler for unknown Kind of resource %s", rid.GroupResource())
 	}
 
 	if api.IsRegistered(gvk) && !r.regTypes[gvk] {
@@ -396,10 +397,11 @@ func (r *ProjectQuotaReconciler) StartWatcher(rid kmapi.ResourceID) {
 				handler.EnqueueRequestsFromMapFunc(ProjectQuotaForObjects(r.Client))),
 		)
 		if err != nil {
-			klog.Fatalln(err)
+			return fmt.Errorf("failed to start ProjectQuota watcher for %s: %w", gvk, err)
 		}
 		r.regTypes[gvk] = true
 	}
+	return nil
 }
 
 // Obj -> ProjectQuota

--- a/pkg/graph/setup.go
+++ b/pkg/graph/setup.go
@@ -103,7 +103,9 @@ func PollNewResourceTypes(cfg *restclient.Config, pqr *projectquotacontroller.Pr
 						resourceTracker[gvk] = rid
 						resourceChannel <- rid
 						if pqr != nil {
-							pqr.StartWatcher(rid)
+							if err := pqr.StartWatcher(rid); err != nil {
+								klog.ErrorS(err, "failed to start ProjectQuota watcher", "gvk", gvk)
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Problem

`ProjectQuotaReconciler.StartWatcher` called `klog.Fatalln` in three places — a nil reconciler, an unknown resource `Kind`, and a failed `Watch`:

```go
if r.ctrl == nil {
    klog.Fatalln("ProjectQuota reconciler is not setup yet!")
}
...
klog.Fatalln(err)
```

`StartWatcher` is invoked at runtime from the resource-discovery poller (`graph.PollNewResourceTypes`). A `klog.Fatalln` there calls `os.Exit`, so any one of these conditions on any single discovered resource type **takes down the entire `kube-ui-server` process** instead of failing just that watch.

## Fix

- `StartWatcher` now returns an `error` for each of the three conditions (with the offending resource/GVK included in the message).
- The poller logs the error via `klog.ErrorS` and continues, consistent with the rest of the resilient discovery loop (cf. #422 "Isolate per-connection failures").

No behavior in this path should be able to crash the aggregated apiserver.

## Testing

- `go build ./...` passes.
- `go vet` and `gofmt` clean on the changed files.
- `grep klog.Fatal` over `pkg/` returns nothing.