### PR TITLE
Skip OpenAPI model-building for editor EditorModels

### DIFF
--- a/pkg/cmds/server/start.go
+++ b/pkg/cmds/server/start.go
@@ -51,6 +51,7 @@ import (
 	"kmodules.xyz/client-go/tools/clientcmd"
 	promclient "kmodules.xyz/monitoring-agent-api/client"
 	rscoreapi "kmodules.xyz/resource-metadata/apis/core/v1alpha1"
+	editorapi "kmodules.xyz/resource-metadata/apis/editor/v1alpha1"
 	identityapi "kmodules.xyz/resource-metadata/apis/identity/v1alpha1"
 	rsapi "kmodules.xyz/resource-metadata/apis/meta/v1alpha1"
 	uiapi "kmodules.xyz/resource-metadata/apis/ui/v1alpha1"
@@ -160,6 +161,8 @@ func (o *UIServerOptions) Config() (*apiserver.Config, error) {
 		fmt.Sprintf("/apis/%s/%s", rsapi.SchemeGroupVersion, rsapi.ResourceResourceQueries),
 		fmt.Sprintf("/apis/%s/%s", rsapi.SchemeGroupVersion, rsapi.ResourceResourceTableDefinitions),
 		fmt.Sprintf("/apis/%s/%s", rsapi.SchemeGroupVersion, uiapi.ResourceResourceEditors),
+
+		fmt.Sprintf("/apis/%s/%s", editorapi.SchemeGroupVersion, editorapi.ResourceEditorModels),
 
 		fmt.Sprintf("/apis/%s/%s", rscoreapi.SchemeGroupVersion, rscoreapi.ResourceProjects),
 


### PR DESCRIPTION
`kube-ui-server` crashlooped at startup: `unable to get openapi models: cannot find model definition for ...EditorModel` — the newly-added `editormodels` storage was never added to `ignorePrefixes`, so the apiserver tried to build OpenAPI models for it.
`EditorModel`'s schema transitively references types (e.g. `releases/v1alpha1.Metadata`) whose definitions aren't available, so model-building fatal-exits.
Fix: add the `editormodels` path to `ignorePrefixes` like every other synthesized aggregated resource. Verified on a live cluster — pod `1/1 Running`, 0 restarts.