### PR TITLE
Strip reserved authentication.kubernetes.io extras before impersonation

### DIFF
--- a/pkg/registry/editor/editormodel/storage.go
+++ b/pkg/registry/editor/editormodel/storage.go
@@ -85,9 +85,27 @@ func (r *Storage) callerClient(ctx context.Context) (client.Client, error) {
 		UserName: user.GetName(),
 		UID:      user.GetUID(),
 		Groups:   user.GetGroups(),
-		Extra:    user.GetExtra(),
+		Extra:    impersonableExtra(user.GetExtra()),
 	}
 	return client.New(cfg, client.Options{Scheme: r.scheme, Mapper: r.mapper})
+}
+
+// impersonableExtra drops the reserved authentication.kubernetes.io/* extras
+// (e.g. credential-id added for X509/SA auth on k8s >=1.30). These are injected
+// by the apiserver and impersonating them needs a dedicated userextras RBAC verb
+// that kube-ui-server does not hold; they carry no authorization identity.
+func impersonableExtra(in map[string][]string) map[string][]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for k, v := range in {
+		if strings.HasPrefix(k, "authentication.kubernetes.io/") {
+			continue
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // Create reconstructs the editor model for an existing installation from the


### PR DESCRIPTION
## Problem

`EditorModel` reads fail with:

```
userextras.authentication.k8s.io "X509SHA256=..." is forbidden: User "system:serviceaccount:kubeops:kube-ui-server" cannot impersonate resource "userextras/authentication.kubernetes.io/credential-id" in API group "authentication.k8s.io" at the cluster scope
```

`callerClient` copies `user.GetExtra()` verbatim into the impersonation config. On k8s >=1.30, the apiserver injects reserved extras (e.g. `authentication.kubernetes.io/credential-id` for X509 / SA-token auth). Impersonating those requires a dedicated `userextras/...` impersonate RBAC verb that `kube-ui-server` does not hold, so the request is rejected.

## Fix

Drop `authentication.kubernetes.io/`-prefixed keys before building the impersonation config. These are server-injected and carry no authorization identity (RBAC binds on user/group), so stripping them does not change the impersonated client's effective permissions. `ace.appscode.com/org-id` and other extras are preserved.

## Note

`kmodules.xyz/client-go/client/delegated.go::Impersonate` (used by `pkg/graph`) has the same pattern and will need the same fix upstream + re-vendor.