### PR TITLE
Modernize golangci-lint config and switch formatter to gofumpt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/apis/cost/v1alpha1/register.go
+++ b/apis/cost/v1alpha1/register.go
@@ -46,7 +46,8 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&CostReport{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/offline/v1alpha1/register.go
+++ b/apis/offline/v1alpha1/register.go
@@ -46,7 +46,8 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&AddOfflineLicense{},
 		&OfflineLicense{},
 		&OfflineLicenseList{},

--- a/apis/policy/v1alpha1/register.go
+++ b/apis/policy/v1alpha1/register.go
@@ -46,7 +46,8 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&PolicyReport{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -159,7 +159,8 @@ func init() {
 
 	// TODO: keep the generic API server from wanting this
 	unversioned := schema.GroupVersion{Group: "", Version: "v1"}
-	Scheme.AddUnversionedTypes(unversioned,
+	Scheme.AddUnversionedTypes(
+		unversioned,
 		&metav1.Status{},
 		&metav1.APIVersions{},
 		&metav1.APIGroupList{},

--- a/pkg/cmds/server/start.go
+++ b/pkg/cmds/server/start.go
@@ -100,8 +100,9 @@ func (o UIServerOptions) AddFlags(fs *pflag.FlagSet) {
 
 // Validate validates UIServerOptions
 func (o UIServerOptions) Validate(args []string) error {
-	var errors []error
-	errors = append(errors, o.RecommendedOptions.Validate()...)
+	recommendedErrors := o.RecommendedOptions.Validate()
+	errors := make([]error, 0, len(recommendedErrors)+1)
+	errors = append(errors, recommendedErrors...)
 	errors = append(errors, o.PrometheusOptions.Validate())
 	return utilerrors.NewAggregate(errors)
 }
@@ -184,7 +185,8 @@ func (o *UIServerOptions) Config() (*apiserver.Config, error) {
 			rscoreapi.GetOpenAPIDefinitions,
 			catalogapi.GetOpenAPIDefinitions,
 		),
-		openapi.NewDefinitionNamer(apiserver.Scheme))
+		openapi.NewDefinitionNamer(apiserver.Scheme),
+	)
 	serverConfig.OpenAPIConfig.Info.Title = "kube-uiapi-server"
 	serverConfig.OpenAPIConfig.Info.Version = v.Version.Version
 	serverConfig.OpenAPIConfig.IgnorePrefixes = ignorePrefixes
@@ -194,7 +196,8 @@ func (o *UIServerOptions) Config() (*apiserver.Config, error) {
 			identityapi.GetOpenAPIDefinitions,
 			rscoreapi.GetOpenAPIDefinitions,
 		),
-		openapi.NewDefinitionNamer(apiserver.Scheme))
+		openapi.NewDefinitionNamer(apiserver.Scheme),
+	)
 	serverConfig.OpenAPIV3Config.Info.Title = "kube-uiapi-server"
 	serverConfig.OpenAPIV3Config.Info.Version = v.Version.Version
 	serverConfig.OpenAPIV3Config.IgnorePrefixes = ignorePrefixes

--- a/pkg/controllers/feature/feature_controller_test.go
+++ b/pkg/controllers/feature/feature_controller_test.go
@@ -402,7 +402,8 @@ func TestFeatureSetStatus(t *testing.T) {
 					Group:    uiapi.SchemeGroupVersion.Group,
 					Resource: uiapi.ResourceFeatureSets,
 				},
-				""),
+				"",
+			),
 		},
 		"Should not be enabled when no features are enabled": {
 			requireFeatures: []string{"foo", "bar"},

--- a/pkg/controllers/projectquota/projectquota_controller.go
+++ b/pkg/controllers/projectquota/projectquota_controller.go
@@ -393,7 +393,8 @@ func (r *ProjectQuotaReconciler) StartWatcher(rid kmapi.ResourceID) {
 			source.Kind[client.Object](
 				r.cache,
 				&obj,
-				handler.EnqueueRequestsFromMapFunc(ProjectQuotaForObjects(r.Client))),
+				handler.EnqueueRequestsFromMapFunc(ProjectQuotaForObjects(r.Client)),
+			),
 		)
 		if err != nil {
 			klog.Fatalln(err)

--- a/pkg/graph/setup.go
+++ b/pkg/graph/setup.go
@@ -197,7 +197,7 @@ func execRawGraphQLQuery(query string, vars map[string]any) ([]kmapi.ObjectRefer
 	}
 	result := graphql.Do(params)
 	if result.HasErrors() {
-		var errs []error
+		errs := make([]error, 0, len(result.Errors))
 		for _, e := range result.Errors {
 			errs = append(errs, e)
 		}

--- a/pkg/graph/vars.go
+++ b/pkg/graph/vars.go
@@ -89,4 +89,5 @@ var gkSet = ksets.NewGroupKind(
 	schema.GroupKind{
 		Group: "",
 		Kind:  "Event",
-	})
+	},
+)

--- a/pkg/registry/core/project/storage.go
+++ b/pkg/registry/core/project/storage.go
@@ -294,7 +294,8 @@ func ListRancherProjects(kc client.Client) ([]rscoreapi.Project, error) {
 					prj.Spec.Monitoring.PrometheusURL,
 					"/services/http:rancher-monitoring-prometheus:9090/proxy",
 					"/services/http:rancher-monitoring-grafana:80/proxy/?orgId=1",
-					1)
+					1,
+				)
 			} else {
 				prj.Spec.Monitoring.AlertmanagerURL,
 					prj.Spec.Monitoring.GrafanaURL,

--- a/pkg/registry/meta/chartpresetquery/storage.go
+++ b/pkg/registry/meta/chartpresetquery/storage.go
@@ -90,7 +90,8 @@ func (r *Storage) Create(ctx context.Context, obj runtime.Object, _ rest.Validat
 			preset.Source.Generation <= 0 {
 			break
 		}
-		oids = append(oids, fmt.Sprintf("G=%s,K=%s,I=%s,V=%d",
+		oids = append(oids, fmt.Sprintf(
+			"G=%s,K=%s,I=%s,V=%d",
 			preset.Source.Resource.Group,
 			preset.Source.Resource.Kind,
 			preset.Source.UID,


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt (mirrors kmodules/resource-metadata#657).

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev:1.25`), where `gofmt` is already a symlink shim to **gofumpt v0.7.0** — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go` (the double backslash matched a literal backslash rather than a dot).
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+, and go.mod pins go1.25).

`golangci-lint config verify` passes and `golangci-lint run` reports 0 issues.

### Code fixes for the newly enabled linters
- `pkg/cmds/server/start.go`: preallocate the validation `errors` slice (`prealloc`), capturing `RecommendedOptions.Validate()` once instead of calling it twice.
- `pkg/graph/setup.go`: preallocate the `errs` slice with `len(result.Errors)` capacity (`prealloc`).

### Resulting formatting
gofumpt reformat of several files (multi-line call-argument wrapping in `apis/**/register.go`, `pkg/apiserver`, `pkg/graph`, `pkg/registry/**`, and a controller test).

## Test plan
- [x] `golangci-lint config verify` — valid
- [x] `golangci-lint run` — 0 issues
- [x] `go build ./pkg/cmds/server/... ./pkg/graph/...`