### PR TITLE
Prepare for release v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	kmodules.xyz/go-containerregistry v0.0.15
 	kmodules.xyz/monitoring-agent-api v0.34.3
 	kmodules.xyz/offshoot-api v0.34.0
-	kmodules.xyz/resource-metadata v0.48.1-0.20260821132820-ad726603c537
+	kmodules.xyz/resource-metadata v0.49.0
 	kmodules.xyz/resource-metrics v0.34.4-0.20260626131047-afdc9726717d
 	kmodules.xyz/resource-metrics/utils v0.34.1-0.20260622121456-42ed2b0a80a4
 	kmodules.xyz/sets v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -1187,8 +1187,8 @@ kmodules.xyz/monitoring-agent-api v0.34.3 h1:8dCTSatkKbi9CTAQ3+u7OmoyUghLvKTqqcl
 kmodules.xyz/monitoring-agent-api v0.34.3/go.mod h1:0WtVdliczkCmjA/QyB2ZriVwABSA8Fhzt01yMEukFLY=
 kmodules.xyz/offshoot-api v0.34.0 h1:HnOOp8FrCjTWjtNApRDo6Ahe79tOlLrJmyye4xxO4Kk=
 kmodules.xyz/offshoot-api v0.34.0/go.mod h1:F+B59yYw4CZJ4uD4xu6C+mMLzIXUtuH7E+SbDICl9jE=
-kmodules.xyz/resource-metadata v0.48.1-0.20260821132820-ad726603c537 h1:KePpw4YKwixD43CXDDLYPQ0MNa+Igi1+cXpPeVBNsmY=
-kmodules.xyz/resource-metadata v0.48.1-0.20260821132820-ad726603c537/go.mod h1:6J9G/+Hs9ysFCxfSsFhK/H63nEE7wZz6smyPifxbhlc=
+kmodules.xyz/resource-metadata v0.49.0 h1:CD2GdXQnscnwXdUdRBzrnlXX9t6+0b+DvvKtO99fr7Q=
+kmodules.xyz/resource-metadata v0.49.0/go.mod h1:6J9G/+Hs9ysFCxfSsFhK/H63nEE7wZz6smyPifxbhlc=
 kmodules.xyz/resource-metrics v0.34.4-0.20260626131047-afdc9726717d h1:vgDVnRBzVuhbhlHYi8VWL/mJ8LHNk+z5ipVjIpTA2N4=
 kmodules.xyz/resource-metrics v0.34.4-0.20260626131047-afdc9726717d/go.mod h1:R34IKtp5+NqcQz7AQJheBJK6Iem0LqrCbm/55Mn+ECQ=
 kmodules.xyz/resource-metrics/utils v0.34.1-0.20260622121456-42ed2b0a80a4 h1:AhuMryuO4hKbnqH7QyVciCar8mQ2WYPqP0f1WVqzALQ=

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
@@ -34,5 +34,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
@@ -34,5 +34,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addondeploymentconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addondeploymentconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addontemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addontemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/clustermanagementaddons.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/clustermanagementaddons.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/managedclusteraddons.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/managedclusteraddons.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesetbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesetbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.kubestash.com/v1alpha1/addons.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.kubestash.com/v1alpha1/addons.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.kubestash.com/v1alpha1/functions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.kubestash.com/v1alpha1/functions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositeresourcedefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositeresourcedefinitions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositionrevisions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositionrevisions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1alpha1/environmentconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1alpha1/environmentconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
@@ -21,7 +21,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps.k8s.appscode.com/v1/petsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps.k8s.appscode.com/v1/petsets.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps.k8s.appscode.com/v1/placementpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps.k8s.appscode.com/v1/placementpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/daemonsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/daemonsets.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/deployments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/deployments.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/replicasets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/replicasets.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/statefulsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/statefulsets.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/clickhousearchivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/clickhousearchivers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mariadbarchivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mariadbarchivers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mongodbarchivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mongodbarchivers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mssqlserverarchivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mssqlserverarchivers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mysqlarchivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mysqlarchivers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/postgresarchivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/postgresarchivers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/accounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/accounts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/users.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/users.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.open-cluster-management.io/v1beta1/managedserviceaccounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.open-cluster-management.io/v1beta1/managedserviceaccounts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.azure.kubedb.com/v1alpha1/roleassignments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.azure.kubedb.com/v1alpha1/roleassignments.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterrolebindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterroles.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclustersetrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclustersetrolebindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/cassandraautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/cassandraautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/clickhouseautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/clickhouseautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/documentdbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/documentdbautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/druidautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/druidautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/hanadbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/hanadbautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/hazelcastautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/hazelcastautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/igniteautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/igniteautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/kafkaautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/kafkaautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/milvusautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/milvusautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mssqlserverautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mssqlserverautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/neo4jautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/neo4jautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/oracleautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/oracleautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgpoolautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgpoolautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/qdrantautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/qdrantautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/rabbitmqautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/rabbitmqautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redissentinelautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redissentinelautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/singlestoreautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/singlestoreautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/solrautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/solrautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/weaviateautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/weaviateautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/zookeeperautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/zookeeperautoscalers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1alpha1/storeconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1alpha1/storeconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigusages.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigusages.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/providerregistrations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/providerregistrations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/resourcegroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/resourcegroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/storeconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/storeconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/subscriptions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/subscriptions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigusages.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigusages.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch.k8s.appscode.com/v1alpha1/pendingtasks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch.k8s.appscode.com/v1alpha1/pendingtasks.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch.k8s.appscode.com/v1alpha1/taskqueues.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch.k8s.appscode.com/v1alpha1/taskqueues.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/cronjobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/cronjobs.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/jobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/jobs.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigtemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigtemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/rediscaches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/rediscaches.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterpriseclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterpriseclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterprisedatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterprisedatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisfirewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisfirewallrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redislinkedservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redislinkedservers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/cassandrabindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/cassandrabindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/clickhousebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/clickhousebindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/druidbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/druidbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/elasticsearchbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/elasticsearchbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/hazelcastbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/hazelcastbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/kafkabindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/kafkabindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mariadbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mariadbbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/memcachedbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/memcachedbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mongodbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mongodbbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mssqlserverbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mssqlserverbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mysqlbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mysqlbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/oraclebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/oraclebindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/perconaxtradbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/perconaxtradbbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgbouncerbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgbouncerbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgpoolbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgpoolbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/postgresbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/postgresbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/proxysqlbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/proxysqlbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/rabbitmqbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/rabbitmqbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/redisbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/redisbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/singlestorebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/singlestorebindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/solrbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/solrbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/zookeeperbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/zookeeperbindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/aerospikeversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/aerospikeversions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/cassandraversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/cassandraversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/clickhouseversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/clickhouseversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/db2versions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/db2versions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/documentdbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/documentdbversions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/druidversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/druidversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/hanadbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/hanadbversions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/hazelcastversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/hazelcastversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/igniteversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/igniteversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaconnectorversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaconnectorversions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/milvusversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/milvusversions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mssqlserverversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mssqlserverversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/neo4jversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/neo4jversions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/oracleversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/oracleversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgpoolversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgpoolversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/qdrantversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/qdrantversions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/rabbitmqversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/rabbitmqversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/schemaregistryversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/schemaregistryversions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/singlestoreversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/singlestoreversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/solrversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/solrversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/weaviateversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/weaviateversions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/zookeeperversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/zookeeperversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/elasticsearchbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/elasticsearchbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/kafkabindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/kafkabindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mariadbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mariadbbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/memcachedbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/memcachedbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mongodbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mongodbbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mysqlbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mysqlbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/perconaxtradbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/perconaxtradbbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/pgbouncerbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/pgbouncerbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/postgresbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/postgresbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/proxysqlbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/proxysqlbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/redisbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/redisbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
@@ -34,5 +34,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
@@ -34,5 +34,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
@@ -34,5 +34,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
@@ -34,5 +34,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/chartpresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/chartpresets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/clusterchartpresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/clusterchartpresets.yaml
@@ -21,7 +21,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: chartsxhelmdev-clusterchartpreset-editor-options
@@ -29,4 +29,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1/managedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1/managedclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/addonplacementscores.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/addonplacementscores.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/clusterclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/clusterclaims.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placementdecisions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placementdecisions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placements.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placements.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersetbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersetbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusterclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusterclasses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinedeployments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinedeployments.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinehealthchecks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinehealthchecks.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinepools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machines.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinesets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinesets.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/firewalls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/firewalls.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networkpeerings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networkpeerings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networks.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gatekeeper.sh/v1alpha1/configs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gatekeeper.sh/v1alpha1/configs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gateway.open-cluster-management.io/v1alpha1/clustergatewayconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gateway.open-cluster-management.io/v1alpha1/clustergatewayconfigurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.virtual-secrets.dev/v1alpha1/secretmetadatas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.virtual-secrets.dev/v1alpha1/secretmetadatas.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.virtual-secrets.dev/v1alpha1/secretstores.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.virtual-secrets.dev/v1alpha1/secretstores.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/awsmanagedcontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/awsmanagedcontrolplanes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/rosacontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/rosacontrolplanes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresources.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresources.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresourceservices.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresourceservices.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/podviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/podviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/projects.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/projects.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/resourcesummaries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/resourcesummaries.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupbatches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupbatches.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupblueprints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupblueprints.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupconfigurations.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: corekubestashcom-backupconfiguration-editor-options
@@ -34,4 +34,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupsessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupsessions.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: corekubestashcom-backupsession-editor-options
@@ -34,4 +34,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverificationsession.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverificationsession.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverifier.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverifier.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/hooktemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/hooktemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/restoresessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/restoresessions.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: corekubestashcom-restoresession-editor-options
@@ -34,4 +34,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/bindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/bindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/componentstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/componentstatuses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/configmaps.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/configmaps.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/endpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/endpoints.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/events.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/limitranges.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/limitranges.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/namespaces.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/namespaces.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/nodes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/nodes.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumes.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/pods.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/pods.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podstatusresults.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podstatusresults.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/rangeallocations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/rangeallocations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/replicationcontrollers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/replicationcontrollers.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequotas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequotas.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/secrets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/secrets.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/serviceaccounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/serviceaccounts.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/services.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/services.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/accounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/accounts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandraclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandraclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandradatacenters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandradatacenters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandrakeyspaces.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandrakeyspaces.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandratables.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandratables.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlindatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlindatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlingraphs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlingraphs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongocollections.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongocollections.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongodatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongodatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlcontainers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlcontainers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldedicatedgateways.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldedicatedgateways.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlfunctions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlfunctions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroleassignments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroleassignments.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroledefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroledefinitions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlstoredprocedures.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlstoredprocedures.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqltriggers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqltriggers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/tables.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/tables.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/configurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/configurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/databases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/databases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/firewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/firewallrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/servers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/servers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/configurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/configurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/databases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/databases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/firewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/firewallrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibledatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibledatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/servers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/servers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/configurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/configurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/databases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/databases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/firewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/firewallrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverdatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverdatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/serverkeys.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/serverkeys.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/servers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/servers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterinstances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterinstances.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/globalclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/globalclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/drivers.x-helm.dev/v1alpha1/appreleases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/drivers.x-helm.dev/v1alpha1/appreleases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/contributorinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/contributorinsights.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/globaltables.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/globaltables.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/kinesisstreamingdestinations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/kinesisstreamingdestinations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tableitems.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tableitems.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tablereplicas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tablereplicas.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tables.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tables.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tags.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tags.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/routes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/routes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygrouprules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygrouprules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/subnets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/subnets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcendpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcendpoints.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcpeeringconnections.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcpeeringconnections.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/parametergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/parametergroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/replicationgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/replicationgroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/usergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/usergroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/users.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/users.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domains.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domains.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainsamloptions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainsamloptions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.kubedb.com/v1alpha1/elasticsearchdashboards.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.kubedb.com/v1alpha1/elasticsearchdashboards.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mariadbroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mariadbroles.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/pkiroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/pkiroles.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/redisroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/redisroles.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1/events.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/expansion.gatekeeper.sh/v1alpha1/expansiontemplate.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/expansion.gatekeeper.sh/v1alpha1/expansiontemplate.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/deployments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/deployments.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/scales.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/scales.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/external-dns.appscode.com/v1alpha1/externaldns.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/external-dns.appscode.com/v1alpha1/externaldns.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/falco.appscode.com/v1alpha1/falcoevents.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/falco.appscode.com/v1alpha1/falcoevents.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/fluxcd.open-cluster-management.io/v1alpha1/fluxcdconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/fluxcd.open-cluster-management.io/v1alpha1/fluxcdconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewayconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewayconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewaypresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewaypresets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/authenticationfilters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/authenticationfilters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backends.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backends.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backendtrafficpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backendtrafficpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/clienttrafficpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/clienttrafficpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoypatchpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoypatchpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/httproutefilters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/httproutefilters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/ratelimitfilters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/ratelimitfilters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/securitypolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/securitypolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/backendtlspolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/backendtlspolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/gatewayclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/gatewayclasses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/gateways.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/gateways.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/grpcroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/grpcroutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/httproutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/httproutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendtlspolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendtlspolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/grpcroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/grpcroutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tcproutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tcproutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tlsroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tlsroutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/udproutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/udproutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/tlsroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/tlsroutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gatewayclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gatewayclasses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gateways.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gateways.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/httproutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/httproutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/referencegrants.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/referencegrants.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xbackendtrafficpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xbackendtrafficpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xlistenersets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xlistenersets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xmeshes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xmeshes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.open-cluster-management.io/v1alpha1/clustergateways.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.open-cluster-management.io/v1alpha1/clustergateways.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/kafkaroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/kafkaroutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mongodbroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mongodbroutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mssqlserverroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mssqlserverroutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mysqlroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mysqlroutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/oracleroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/oracleroutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/postgresroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/postgresroutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/redisroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/redisroutes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1alpha1/storeconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1alpha1/storeconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigusages.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigusages.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/cassandras.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/cassandras.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/clickhouses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/clickhouses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/druids.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/druids.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/elasticsearches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/elasticsearches.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/hanadbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/hanadbs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/hazelcasts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/hazelcasts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/ignites.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/ignites.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/kafkas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/kafkas.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mariadbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mariadbs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/memcacheds.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/memcacheds.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/milvuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/milvuses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mongodbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mongodbs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mssqlservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mssqlservers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mysqls.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/neo4js.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/neo4js.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/oracles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/oracles.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/perconaxtradbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/perconaxtradbs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/pgbouncers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/pgbouncers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/pgpools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/pgpools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/postgreses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/postgreses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/proxysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/proxysqls.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/qdrants.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/qdrants.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/rabbitmqs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/rabbitmqs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/redises.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/redises.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/redissentinels.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/redissentinels.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/singlestores.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/singlestores.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/solrs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/solrs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/weaviates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/weaviates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/zookeepers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gitops.kubedb.com/v1alpha1/zookeepers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2/helmreleases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2/helmreleases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta1/helmreleases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta1/helmreleases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta2/helmreleases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta2/helmreleases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/iam.aws.kubedb.com/v1alpha1/roles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/iam.aws.kubedb.com/v1alpha1/roles.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/clusteridentitys.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/clusteridentitys.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/selfsubjectnamespaceaccessreviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/selfsubjectnamespaceaccessreviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/siteinfos.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/siteinfos.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagepolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagepolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagerepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagerepositories.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imageupdateautomations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imageupdateautomations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagepolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagepolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagerepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagerepositories.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imageupdateautomations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imageupdateautomations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclustertemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanetemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepooltemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepooltemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureserviceprincipals.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureserviceprincipals.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azuresystemassignedidentites.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azuresystemassignedidentites.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureuserassignedidentites.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureuserassignedidentites.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusteridentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusteridentities.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclustertemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepoolmachines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepoolmachines.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachines.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinetemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclustertemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanetemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepooltemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepooltemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclustertemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachines.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachinetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachinetemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedcontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedcontrolplanes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedmachinepools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustercontrolleridentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustercontrolleridentities.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterroleidentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterroleidentities.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterstaticidentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterstaticidentities.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustertemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsfargateprofiles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsfargateprofiles.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinepools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachines.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinetemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedmachinepools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosaclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosaclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosamachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosamachinepools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddressclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddressclaims.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddresses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddressclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddressclaims.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddresses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/configurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/configurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectors.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/restproxies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/restproxies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/schemaregistries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/schemaregistries.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.azure.com/v1alpha2/aksnodeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.azure.com/v1alpha2/aksnodeclasses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.k8s.aws/v1beta1/ec2nodeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.k8s.aws/v1beta1/ec2nodeclasses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.sh/v1beta1/nodeclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.sh/v1beta1/nodeclaims.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.sh/v1beta1/nodepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.sh/v1beta1/nodepools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/keys.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/keys.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/vaults.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/vaults.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kinesis.aws.kubedb.com/v1alpha1/streams.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kinesis.aws.kubedb.com/v1alpha1/streams.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kms.aws.kubedb.com/v1alpha1/keys.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kms.aws.kubedb.com/v1alpha1/keys.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicebindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexportrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexportrequests.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexports.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexports.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicenamespaces.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicenamespaces.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/clusterbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/clusterbindings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/elasticsearches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/elasticsearches.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -215,7 +215,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -230,7 +230,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -247,7 +247,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -263,7 +263,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-elasticsearch-editor-options
@@ -271,7 +271,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/kafkas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/kafkas.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -102,7 +102,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -198,7 +198,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -214,7 +214,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-kafka-editor-options
@@ -222,7 +222,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mariadbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mariadbs.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -245,7 +245,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -261,7 +261,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-mariadb-editor-options
@@ -269,7 +269,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/memcacheds.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/memcacheds.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -82,7 +82,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -97,7 +97,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -114,7 +114,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -131,7 +131,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -146,7 +146,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -162,7 +162,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: kubedbcom-memcached-editor-options
@@ -170,7 +170,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mongodbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mongodbs.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -245,7 +245,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -261,7 +261,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-mongodb-editor-options
@@ -269,7 +269,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mysqls.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -245,7 +245,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -261,7 +261,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-mysql-editor-options
@@ -269,7 +269,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/perconaxtradbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/perconaxtradbs.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -72,7 +72,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -102,7 +102,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -151,7 +151,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -182,7 +182,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-perconaxtradb-editor-options
@@ -190,7 +190,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/pgbouncers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/pgbouncers.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -65,7 +65,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -80,7 +80,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -97,7 +97,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -114,7 +114,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -130,7 +130,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: kubedbcom-pgbouncer-editor-options
@@ -138,7 +138,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/postgreses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/postgreses.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -245,7 +245,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -261,7 +261,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-postgres-editor-options
@@ -269,7 +269,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/proxysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/proxysqls.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -80,7 +80,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -95,7 +95,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -112,7 +112,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -129,7 +129,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -144,7 +144,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -160,7 +160,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: kubedbcom-proxysql-editor-options
@@ -168,7 +168,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/redises.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/redises.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -245,7 +245,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -261,7 +261,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-redis-editor-options
@@ -269,7 +269,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/redissentinels.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/redissentinels.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -80,7 +80,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -95,7 +95,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -112,7 +112,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -129,7 +129,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -144,7 +144,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -160,7 +160,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
   variants:
   - name: default

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/aerospikes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/aerospikes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/cassandras.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/cassandras.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -245,7 +245,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -261,7 +261,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-cassandra-editor-options
@@ -269,7 +269,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/clickhouses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/clickhouses.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -245,7 +245,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -261,7 +261,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-clickhouse-editor-options
@@ -269,7 +269,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/db2s.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/db2s.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-db2-editor-options
@@ -34,7 +34,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/documentdbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/documentdbs.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -102,7 +102,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -197,7 +197,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-documentdb-editor-options
@@ -205,7 +205,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/druids.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/druids.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -245,7 +245,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -261,7 +261,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-druid-editor-options
@@ -269,7 +269,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -60,7 +60,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -102,7 +102,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -132,7 +132,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -151,7 +151,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -182,7 +182,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-elasticsearch-editor-options
@@ -190,7 +190,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/hanadbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/hanadbs.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -65,7 +65,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -82,7 +82,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -99,7 +99,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -114,7 +114,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -130,7 +130,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-hanadb-editor-options
@@ -138,7 +138,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/hazelcasts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/hazelcasts.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -102,7 +102,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -198,7 +198,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -214,7 +214,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-hazelcast-editor-options
@@ -222,7 +222,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/ignites.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/ignites.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -102,7 +102,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -197,7 +197,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-ignite-editor-options
@@ -205,7 +205,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/kafkas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/kafkas.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -44,7 +44,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-kafka-editor-options
@@ -52,7 +52,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -60,7 +60,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -197,7 +197,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-mariadb-editor-options
@@ -205,7 +205,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -67,7 +67,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -82,7 +82,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -99,7 +99,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -114,7 +114,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -130,7 +130,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: kubedbcom-memcached-editor-options
@@ -138,7 +138,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/milvuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/milvuses.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -102,7 +102,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -197,7 +197,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-milvus-editor-options
@@ -205,7 +205,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -60,7 +60,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -180,7 +180,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -211,7 +211,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -227,7 +227,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-mongodb-editor-options
@@ -235,7 +235,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mssqlservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mssqlservers.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -245,7 +245,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -261,7 +261,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-mssqlserver-editor-options
@@ -269,7 +269,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -60,7 +60,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -197,7 +197,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-mysql-editor-options
@@ -205,7 +205,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/neo4js.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/neo4js.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -244,7 +244,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-neo4j-editor-options
@@ -252,7 +252,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/oracles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/oracles.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -85,7 +85,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -102,7 +102,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -151,7 +151,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -167,7 +167,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-oracle-editor-options
@@ -175,7 +175,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-perconaxtradb-editor-options
@@ -34,7 +34,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: kubedbcom-pgbouncer-editor-options
@@ -34,7 +34,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgpools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgpools.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -80,7 +80,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -95,7 +95,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -112,7 +112,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -129,7 +129,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -144,7 +144,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -160,7 +160,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-pgpool-editor-options
@@ -168,7 +168,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -60,7 +60,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -197,7 +197,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-postgres-editor-options
@@ -205,7 +205,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -80,7 +80,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -95,7 +95,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -112,7 +112,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -127,7 +127,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -143,7 +143,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: kubedbcom-proxysql-editor-options
@@ -151,7 +151,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/qdrants.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/qdrants.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -102,7 +102,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -197,7 +197,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-qdrant-editor-options
@@ -205,7 +205,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/rabbitmqs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/rabbitmqs.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -102,7 +102,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -198,7 +198,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -214,7 +214,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-rabbitmq-editor-options
@@ -222,7 +222,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -60,7 +60,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -166,7 +166,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -197,7 +197,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-redis-editor-options
@@ -205,7 +205,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
   variants:
   - name: default

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/singlestores.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/singlestores.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -245,7 +245,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -261,7 +261,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-singlestore-editor-options
@@ -269,7 +269,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/solrs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/solrs.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -196,7 +196,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -228,7 +228,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -245,7 +245,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: streamline-ultimate:server-share
@@ -261,7 +261,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-solr-editor-options
@@ -269,7 +269,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/weaviates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/weaviates.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -102,7 +102,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -165,7 +165,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-weaviate-editor-options
@@ -173,7 +173,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/zookeepers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/zookeepers.yaml
@@ -28,7 +28,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: material-symbols-light:backup-outline
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: carbon:ibm-cloud-backup-and-recovery
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: mdi:backup-restore
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: qlementine-icons:version-control-16
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:redo
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:settings-05
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icon: hugeicons:horizontal-resize
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -181,7 +181,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -198,7 +198,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-create
         icon: hugeicons:security-check
@@ -213,7 +213,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-wizards-oci
-          version: v0.36.0
+          version: v0.37.0
         enforceQuota: false
         flow: standalone-edit
         icon: hugeicons:presentation-line-chart-01
@@ -229,7 +229,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: true
     options:
       name: kubedbcom-zookeeper-editor-options
@@ -237,7 +237,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubevault.com/v1alpha2/vaultservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubevault.com/v1alpha2/vaultservers.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: kubevaultcom-vaultserver-editor-options
@@ -34,7 +34,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1/kustomizations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1/kustomizations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1beta2/kustomizations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1beta2/kustomizations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/management.k8s.appscode.com/v1alpha1/projectquotas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/management.k8s.appscode.com/v1alpha1/projectquotas.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/match.gatekeeper.sh/match/matchcrd.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/match.gatekeeper.sh/match/matchcrd.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/acls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/acls.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/parametergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/parametergroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/snapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/snapshots.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/gatewayinfoes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/gatewayinfoes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menuoutlines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menuoutlines.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menus.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menus.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceblockdefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceblockdefinitions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcecalculators.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcecalculators.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceeditors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceeditors.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcelayouts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcelayouts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcemanifests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcemanifests.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlines.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcetabledefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcetabledefinitions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/prometheusagents.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/prometheusagents.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/scrapeconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/scrapeconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assign.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assign.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assignmetadata.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assignmetadata.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/modifyset.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/modifyset.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1alpha1/assignimage.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1alpha1/assignimage.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszones.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszones.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszonevirtualnetworklinks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszonevirtualnetworklinks.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/routetables.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/routetables.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/securitygroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/securitygroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetnetworksecuritygroupassociations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetnetworksecuritygroupassociations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetroutetableassociations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetroutetableassociations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworkpeerings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworkpeerings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworks.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.appscode.com/v1alpha1/nodetopologies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.appscode.com/v1alpha1/nodetopologies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1/receivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1/receivers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/alerts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/alerts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/providers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/providers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/receivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/receivers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/alerts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/alerts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/providers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/providers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/offline.licenses.appscode.com/v1alpha1/offlinelicenses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/offline.licenses.appscode.com/v1alpha1/offlinelicenses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboards.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboards.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboardtemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboardtemplates.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadatasources.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadatasources.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/operator.k8s.appscode.com/v1alpha1/shardconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/operator.k8s.appscode.com/v1alpha1/shardconfigurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/operator.open-cluster-management.io/v1/clustermanagers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/operator.open-cluster-management.io/v1/clustermanagers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/operator.open-cluster-management.io/v1/klusterlets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/operator.open-cluster-management.io/v1/klusterlets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/cassandraopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/cassandraopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/clickhouseopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/clickhouseopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/documentdbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/documentdbopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/druidopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/druidopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/hanadbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/hanadbopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/hazelcastopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/hazelcastopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/igniteopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/igniteopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/kafkaopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/kafkaopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/milvusopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/milvusopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mssqlserveropsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mssqlserveropsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/neo4jopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/neo4jopsrequests.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/oracleopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/oracleopsrequests.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgpoolopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgpoolopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/qdrantopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/qdrantopsrequests.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/rabbitmqopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/rabbitmqopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/singlestoreopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/singlestoreopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/solropsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/solropsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/weaviateopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/weaviateopsrequests.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/zookeeperopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/zookeeperopsrequests.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubevault.com/v1alpha1/vaultopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubevault.com/v1alpha1/vaultopsrequests.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/configurationrevisions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/configurationrevisions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/configurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/configurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/providerrevisions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/providerrevisions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/providers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/providers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1alpha1/controllerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1alpha1/controllerconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1beta1/locks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1beta1/locks.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/evictions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/evictions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/publishers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/publishers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/subscribers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/subscribers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/plans.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/plans.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/products.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/products.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyconfigurations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyserviceresolvers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyserviceresolvers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusteractivitystreams.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusteractivitystreams.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterendpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterendpoints.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterinstances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterinstances.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterroleassociations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterroleassociations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -21,7 +21,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
   variants:
   - name: MariaDB

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbinstanceautomatedbackupsreplications.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbinstanceautomatedbackupsreplications.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbsnapshotcopies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbsnapshotcopies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/globalclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/globalclusters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instanceroleassociations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instanceroleassociations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instances.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/optiongroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/optiongroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/parametergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/parametergroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxydefaulttargetgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxydefaulttargetgroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxyendpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxyendpoints.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxytargets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxytargets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/snapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/snapshots.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/redis.gcp.kubedb.com/v1alpha1/instances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/redis.gcp.kubedb.com/v1alpha1/instances.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/bundles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/bundles.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/orders.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/orders.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/runtime.cluster.x-k8s.io/v1alpha1/extensionconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/runtime.cluster.x-k8s.io/v1alpha1/extensionconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mariadbdatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mariadbdatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mongodbdatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mongodbdatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mysqldatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mysqldatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/postgresdatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/postgresdatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasspodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasspodstatuses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets.crossplane.io/v1alpha1/storeconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets.crossplane.io/v1alpha1/storeconfigs.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secretsmanager.aws.kubedb.com/v1alpha1/secrets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secretsmanager.aws.kubedb.com/v1alpha1/secrets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sns.aws.kubedb.com/v1alpha1/topics.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sns.aws.kubedb.com/v1alpha1/topics.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/gitrepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/gitrepositories.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmcharts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmcharts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmrepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmrepositories.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/buckets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/buckets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/gitrepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/gitrepositories.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmcharts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmcharts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmrepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmrepositories.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/ocirepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/ocirepositories.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databaseiammembers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databaseiammembers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instanceiammembers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instanceiammembers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instances.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabasevulnerabilityassessmentrulebaselines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabasevulnerabilityassessmentrulebaselines.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlelasticpools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlelasticpools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfailovergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfailovergroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfirewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfirewallrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobagents.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobagents.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobcredentials.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobcredentials.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanageddatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanageddatabases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstanceactivedirectoryadministrators.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstanceactivedirectoryadministrators.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancefailovergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancefailovergroups.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstances.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancevulnerabilityassessments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancevulnerabilityassessments.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqloutboundfirewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqloutboundfirewallrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserverdnsaliases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserverdnsaliases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservermicrosoftsupportauditingpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservermicrosoftsupportauditingpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserversecurityalertpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserversecurityalertpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservertransparentdataencryptions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservertransparentdataencryptions.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservervulnerabilityassessments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservervulnerabilityassessments.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlvirtualnetworkrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlvirtualnetworkrules.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databaseinstances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databaseinstances.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databases.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sourcerepresentationinstances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sourcerepresentationinstances.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sslcerts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sslcerts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/users.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/users.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: stashappscodecom-repository-editor-options
@@ -34,4 +34,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: stashappscodecom-restoresession-editor-options
@@ -34,4 +34,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constraintpodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constraintpodstatuses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constrainttemplatepodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constrainttemplatepodstatuses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/expansiontemplatepodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/expansiontemplatepodstatuses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/mutatorpodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/mutatorpodstatuses.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/accounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/accounts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/containers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/containers.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/backupstorages.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/backupstorages.yaml
@@ -21,7 +21,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: storagekubestashcom-backupstorage-editor-options
@@ -29,4 +29,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/repositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/repositories.yaml
@@ -26,7 +26,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false
     options:
       name: storagekubestashcom-repository-editor-options
@@ -34,4 +34,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/retentionpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/retentionpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/snapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/snapshots.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/approvalpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/approvalpolicies.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/clustermaintenancewindows.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/clustermaintenancewindows.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/maintenancewindows.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/maintenancewindows.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/recommendations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/recommendations.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/featuresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/featuresets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourcedashboards.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourcedashboards.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceeditors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceeditors.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/databaseconnections.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/databaseconnections.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/databaseinfoes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/databaseinfoes.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchinsights.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchnodesstats.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchnodesstats.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchschemaoverviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbinsights.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbqueries.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbschemaoverviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbinsights.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbqueries.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbschemaoverviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlinsights.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlqueries.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlschemaoverviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerinsights.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpooloverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpooloverviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpools.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerserveroverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerserveroverviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncersettings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncersettings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresinsights.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresqueries.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresschemaoverviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgressettings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgressettings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlinsights.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlqueries.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlsettings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlsettings.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisinsights.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisqueries.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisschemaoverviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.stash.appscode.com/v1alpha1/backupoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.stash.appscode.com/v1alpha1/backupoverviews.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/virtual-secrets.dev/v1alpha1/secretmounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/virtual-secrets.dev/v1alpha1/secretmounts.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/virtual-secrets.dev/v1alpha1/secrets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/virtual-secrets.dev/v1alpha1/secrets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
@@ -26,5 +26,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1/appliedmanifestworks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1/appliedmanifestworks.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1/manifestworks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1/manifestworks.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1alpha1/manifestworkreplicasets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1alpha1/manifestworkreplicasets.yaml
@@ -21,5 +21,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-wizards-oci
-      version: v0.36.0
+      version: v0.37.0
     enforceQuota: false

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2617,7 +2617,7 @@ kmodules.xyz/monitoring-agent-api/client
 ## explicit; go 1.24.0
 kmodules.xyz/offshoot-api/api/v1
 kmodules.xyz/offshoot-api/api/v2
-# kmodules.xyz/resource-metadata v0.48.1-0.20260821132820-ad726603c537
+# kmodules.xyz/resource-metadata v0.49.0
 ## explicit; go 1.25.0
 kmodules.xyz/resource-metadata/apis/core/install
 kmodules.xyz/resource-metadata/apis/core/v1alpha1


### PR DESCRIPTION
ProductLine: ACE
Release: v2026.9.11
Release-tracker: https://github.com/appscode-cloud/CHANGELOG/pull/78
Signed-off-by: 1gtm <1gtm@appscode.com>